### PR TITLE
chore(example): remove L1 from nodejs CLI + docs, bump nodejs to 0.10.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,8 @@ sphere-sdk-connect-example/
 │   │   ├── hooks/
 │   │   │   └── useWalletConnect.ts   # Core hook: popup/iframe connect logic
 │   │   ├── lib/
-│   │   │   ├── types.ts             # Local TS interfaces (Asset, Token, L1Balance, etc.)
-│   │   │   └── format.ts           # Amount formatting (decimals, fiat, L1, truncate, relativeTime)
+│   │   │   ├── types.ts             # Local TS interfaces (Asset, Token, etc.)
+│   │   │   └── format.ts           # Amount formatting (decimals, fiat, truncate, relativeTime)
 │   │   └── components/
 │   │       ├── ConnectButton.tsx     # "Connect Wallet" button with loading state
 │   │       ├── layout/
@@ -25,18 +25,16 @@ sphere-sdk-connect-example/
 │   │       │   ├── CoinBadge.tsx    # Token icon (img or colored letter) + symbol
 │   │       │   ├── CoinSelect.tsx   # Dropdown token selector (fetches assets from wallet)
 │   │       │   └── StatusBadge.tsx  # Colored status badges (confirmed/pending/failed)
-│   │       ├── queries/             # 8 query panels (read-only operations)
+│   │       ├── queries/             # 7 query panels (read-only operations)
 │   │       │   ├── IdentityPanel.tsx     # sphere_getIdentity
 │   │       │   ├── AssetsPanel.tsx       # sphere_getAssets (table with icons, fiat, 24h)
 │   │       │   ├── BalancePanel.tsx      # sphere_getBalance + sphere_getFiatBalance
 │   │       │   ├── TokensPanel.tsx       # sphere_getTokens (with status badges)
 │   │       │   ├── HistoryPanel.tsx      # sphere_getHistory (with type badges)
-│   │       │   ├── L1BalancePanel.tsx    # sphere_l1GetBalance (vested/unvested breakdown)
-│   │       │   ├── L1HistoryPanel.tsx    # sphere_l1GetHistory (with limit param)
 │   │       │   └── ResolvePanel.tsx      # sphere_resolve (identifier input)
 │   │       ├── intents/             # 7 intent panels (require wallet approval)
 │   │       │   ├── SendPanel.tsx         # send (recipient, amount, coin selector, memo)
-│   │       │   ├── L1SendPanel.tsx       # l1_send (shows L1 balance, recipient, amount)
+│   │       │   ├── MintPanel.tsx         # mint (coinId, amount)
 │   │       │   ├── DMPanel.tsx           # dm (recipient, message)
 │   │       │   ├── PaymentRequestPanel.tsx # payment_request (recipient, amount, coin, message)
 │   │       │   ├── ReceivePanel.tsx      # receive (button only, no params)
@@ -82,8 +80,8 @@ npm run client     # Connects to ws://localhost:8765
 ```
 
 CLI commands:
-- **Queries:** `identity`, `balance`, `assets`, `fiat`, `tokens`, `history`, `l1`, `l1history [limit]`, `resolve @tag`
-- **Intents:** `send @to amt [coin]`, `l1send alpha1... amount`, `dm @to message`, `pay @to amt [coin] [message]`, `receive`, `sign message text`
+- **Queries:** `identity`, `balance`, `assets`, `fiat`, `tokens`, `history`, `resolve @tag`
+- **Intents:** `send @to amt [coin]`, `mint <coinId> <amount>`, `dm @to message`, `pay @to amt [coin] [message]`, `receive`, `sign message text`
 - **Other:** `disconnect`, `help`
 
 ## Dependencies
@@ -153,8 +151,6 @@ The browser `tsconfig.json` requires explicit path mappings for connect submodul
 | `sphere_getFiatBalance` | USD value | `balance:read` |
 | `sphere_getTokens` | Token list | `tokens:read` |
 | `sphere_getHistory` | Transaction history | `history:read` |
-| `sphere_l1GetBalance` | L1 balance | `l1:read` |
-| `sphere_l1GetHistory` | L1 tx history | `l1:read` |
 | `sphere_resolve` | Resolve nametag/address | `resolve:peer` |
 | `sphere_subscribe` | Subscribe to events | `events:subscribe` |
 | `sphere_unsubscribe` | Unsubscribe | `events:subscribe` |
@@ -163,7 +159,7 @@ The browser `tsconfig.json` requires explicit path mappings for connect submodul
 | Intent Action | Description | Required Permission |
 |--------------|-------------|---------------------|
 | `send` | L3 token transfer | `transfer:request` |
-| `l1_send` | L1 transaction | `l1:transfer` |
+| `mint` | Self-mint a fungible token | `transfer:request` |
 | `dm` | Direct message | `dm:request` |
 | `payment_request` | Payment request | `payment:request` |
 | `receive` | Receive incoming tokens | `transfer:request` |
@@ -229,12 +225,10 @@ Sidebar + content area design:
 │  Balance │                                      │
 │  Tokens  │                                      │
 │  History │                                      │
-│  L1 Bal  │                                      │
-│  L1 Hist │                                      │
 │  Resolve │                                      │
 │ INTENTS  │                                      │
 │  Send    │                                      │
-│  L1 Send │                                      │
+│  Mint    │                                      │
 │  DM      │                                      │
 │  Pay Req │                                      │
 │  Receive │                                      │
@@ -251,7 +245,6 @@ Token metadata (symbol, name, decimals, iconUrl) comes from the wallet's TokenRe
 - `CoinBadge` — renders token icon (img from `iconUrl` or colored letter fallback) + symbol
 - `CoinSelect` — dropdown that fetches assets from wallet via `GET_ASSETS` query, shows icon + symbol + balance per coin
 - `formatAmount(raw, decimals)` — converts raw amounts using token's decimal places
-- `formatL1(amount)` — formats L1 ALPHA amounts (8 decimal places)
 
 ### useWalletConnect Hook (`browser/src/hooks/useWalletConnect.ts`)
 
@@ -267,8 +260,8 @@ Central state management for wallet connection:
 Testing-only server that emulates wallet behavior:
 - Creates `ConnectHost` with mock `SphereInstance`
 - Auto-approves all connection requests with full permissions
-- Auto-approves all intents with action-specific success responses
-- Returns rich mock data: identity, assets (UCT + USDU with fiat/24h change), tokens (with statuses), history, L1 balance (with vested/unvested), L1 history
+- Auto-approves all intents with action-specific success responses (send, mint, dm, payment_request, receive, sign_message)
+- Returns rich mock data: identity, assets (UCT + USDU with fiat/24h change), tokens (with statuses), history
 
 ### Event Subscriptions
 

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ npm run client     # Terminal 2: CLI client
 
 ## Browser Example Features
 
-All 8 queries, 6 intents, and 9 events are demonstrated:
+All 7 queries, 6 intents, and 9 events are demonstrated:
 
 **Queries** (read-only):
-`sphere_getIdentity` · `sphere_getBalance` · `sphere_getAssets` · `sphere_getFiatBalance` · `sphere_getTokens` · `sphere_getHistory` · `sphere_l1GetBalance` · `sphere_l1GetHistory` · `sphere_resolve`
+`sphere_getIdentity` · `sphere_getBalance` · `sphere_getAssets` · `sphere_getFiatBalance` · `sphere_getTokens` · `sphere_getHistory` · `sphere_resolve`
 
 **Intents** (require wallet approval):
-`send` · `l1_send` · `dm` · `payment_request` · `receive` · `sign_message`
+`send` · `mint` · `dm` · `payment_request` · `receive` · `sign_message`
 
 **Events** (real-time push):
 `transfer:incoming` · `transfer:confirmed` · `transfer:failed` · `balance:updated` · `identity:updated` · `session:expired` · and more

--- a/browser/CONNECT.md
+++ b/browser/CONNECT.md
@@ -132,15 +132,13 @@ const identity = await wallet.query('sphere_getIdentity');
 // Balances
 const balance = await wallet.query('sphere_getBalance');
 const fiat    = await wallet.query('sphere_getFiatBalance');
-const l1      = await wallet.query('sphere_l1GetBalance');
 
 // Assets & tokens
 const assets = await wallet.query('sphere_getAssets');
 const tokens = await wallet.query('sphere_getTokens', { coinId: 'USDC' });
 
 // History
-const history   = await wallet.query('sphere_getHistory');
-const l1History = await wallet.query('sphere_l1GetHistory', { limit: 20 });
+const history = await wallet.query('sphere_getHistory');
 
 // Resolve nametag / address
 const info = await wallet.query('sphere_resolve', { identifier: '@alice' });
@@ -153,16 +151,13 @@ const info = await wallet.query('sphere_resolve', { identifier: '@alice' });
 ```typescript
 // Send tokens
 await wallet.intent('send', {
-  recipient: '@alice',       // nametag, DIRECT:// address, or L1 address
+  recipient: '@alice',       // nametag or DIRECT:// address
   amount: 100,
   coinId: 'USDC',            // optional, default: native
 });
 
-// Send to L1
-await wallet.intent('l1_send', {
-  recipient: '0x...',
-  amount: 0.001,
-});
+// Self-mint a fungible token
+await wallet.intent('mint', { coinId: '<lowercase-hex>', amount: '1000000' });
 
 // Send DM
 await wallet.intent('dm', {

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "sphere-connect-nodejs-example",
       "version": "0.0.0",
       "dependencies": {
-        "@unicitylabs/sphere-sdk": "0.10.1",
+        "@unicitylabs/sphere-sdk": "0.10.2",
         "ws": "^8.18.0"
       },
       "devDependencies": {
@@ -765,9 +765,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.10.1.tgz",
-      "integrity": "sha512-Kq3xSPkZ8wW32ikaB0CMV5ae34SAv1bseZDF8pNgNEBFb42Oc8SzjUjpSFSxA+XxQXnlePy9BYyeoieB8yBNhw==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.10.2.tgz",
+      "integrity": "sha512-W0Shfa5EBA/jggZeh5j0WpQnvKy9hO/BE7tUZax5iQyRDKI7LAEvOapxkPj4wLYjqE/DaWdfz7dAp55P9jbuvQ==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -8,7 +8,7 @@
     "client": "npx tsx src/index.ts"
   },
   "dependencies": {
-    "@unicitylabs/sphere-sdk": "0.10.1",
+    "@unicitylabs/sphere-sdk": "0.10.2",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/nodejs/src/index.ts
+++ b/nodejs/src/index.ts
@@ -98,18 +98,6 @@ async function main() {
             console.log('Identity:', JSON.stringify(identity, null, 2));
             break;
           }
-          case 'l1': {
-            const l1 = await client.query(RPC_METHODS.L1_GET_BALANCE);
-            console.log('L1 Balance:', JSON.stringify(l1, null, 2));
-            break;
-          }
-          case 'l1history': {
-            const limit = parts[1] ? parseInt(parts[1]) : undefined;
-            const params = limit ? { limit } : undefined;
-            const l1h = await client.query(RPC_METHODS.L1_GET_HISTORY, params);
-            console.log('L1 History:', JSON.stringify(l1h, null, 2));
-            break;
-          }
           case 'resolve': {
             const identifier = parts[1];
             if (!identifier) {
@@ -138,18 +126,18 @@ async function main() {
             console.log('Send result:', JSON.stringify(sendResult, null, 2));
             break;
           }
-          case 'l1send': {
-            const l1to = parts[1];
-            const l1amount = parts[2];
-            if (!l1to || !l1amount) {
-              console.log('Usage: l1send alpha1... amount');
+          case 'mint': {
+            const mintCoinId = parts[1];
+            const mintAmount = parts[2];
+            if (!mintCoinId || !mintAmount) {
+              console.log('Usage: mint <coinId> <amount>');
               break;
             }
-            const l1Result = await client.intent(INTENT_ACTIONS.L1_SEND, {
-              to: l1to,
-              amount: l1amount,
+            const mintResult = await client.intent(INTENT_ACTIONS.MINT, {
+              coinId: mintCoinId,
+              amount: mintAmount,
             });
-            console.log('L1 Send result:', JSON.stringify(l1Result, null, 2));
+            console.log('Mint result:', JSON.stringify(mintResult, null, 2));
             break;
           }
           case 'dm': {
@@ -257,17 +245,15 @@ Commands:
     fiat               - Get total fiat balance
     tokens             - Get individual token list
     history            - Get transaction history
-    l1                 - Get L1 ALPHA balance
-    l1history [limit]  - Get L1 transaction history
     resolve @tag       - Resolve nametag/address to peer info
 
   INTENTS (require wallet approval)
-    send @to amt [coin]          - Send L3 tokens
-    l1send alpha1... amount      - Send L1 ALPHA
-    dm @to message               - Send direct message
-    pay @to amt [coin] [message] - Send payment request
-    receive                      - Receive incoming tokens
-    sign message text            - Sign a message
+    send @to amt [coin]              - Send L3 tokens
+    mint <coinId> <amount>           - Self-mint a fungible token (coinId = lowercase hex)
+    dm @to message                   - Send direct message
+    pay @to amt [coin] [message]     - Send payment request
+    receive                          - Receive incoming tokens
+    sign message text                - Sign a message
 
   CHAT (require dm:read permission)
     conversations                - List DM conversations

--- a/nodejs/src/mock-wallet-server.ts
+++ b/nodejs/src/mock-wallet-server.ts
@@ -15,7 +15,6 @@ const mockSphere = {
   networkId: 4,
   identity: {
     chainPubkey: '02abc123def456789012345678901234567890123456789012345678901234567890',
-    l1Address: 'alpha1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
     directAddress: 'DIRECT://abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
     nametag: 'alice',
   },
@@ -90,37 +89,10 @@ const mockSphere = {
         timestamp: now - 86400000,
       },
     ],
-    l1: {
-      getBalance: async () => ({
-        confirmed: '100000',
-        unconfirmed: '5000',
-        vested: '80000',
-        unvested: '20000',
-        total: '105000',
-      }),
-      getHistory: async (limit?: number) => {
-        const txs = [
-          {
-            txid: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
-            type: 'receive', amount: '50000', fee: '226',
-            address: 'alpha1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
-            confirmations: 144, timestamp: now - 86400000, blockHeight: 850000,
-          },
-          {
-            txid: 'f6e5d4c3b2a1f6e5d4c3b2a1f6e5d4c3b2a1f6e5d4c3b2a1f6e5d4c3b2a1f6e5',
-            type: 'send', amount: '10000', fee: '340',
-            address: 'alpha1qrp33g0q5b5698ahp5jnf5yzjkcd2fdjl3lgdy4',
-            confirmations: 6, timestamp: now - 3600000, blockHeight: 850100,
-          },
-        ];
-        return limit ? txs.slice(0, limit) : txs;
-      },
-    },
   },
   resolve: async (identifier: string) => ({
     nametag: identifier.replace('@', ''),
     chainPubkey: '03fedcba09876543210fedcba09876543210fedcba09876543210fedcba0987654321',
-    l1Address: 'alpha1qrp33g0q5b5698ahp5jnf5yzjkcd2fdjl3lgdy4',
     directAddress: 'DIRECT://fedcba09876543210fedcba09876543210fedcba09876543210fedcba0987654321',
     transportPubkey: 'aa00bb11cc22dd33ee44ff5566778899aabbccddeeff00112233445566778899',
   }),
@@ -241,8 +213,14 @@ async function main() {
               tokenTransfers: [{ sourceTokenId: 'tok-abc123def456', method: 'direct' }],
             },
           };
-        case 'l1_send':
-          return { result: { txid: `l1tx-${Date.now()}`, success: true, fee: '340' } };
+        case 'mint':
+          return {
+            result: {
+              tokenId: 'aa'.repeat(32),
+              coinId: params.coinId,
+              amount: params.amount,
+            },
+          };
         case 'dm':
           return { result: { sent: true, messageId: `msg-${Date.now()}`, timestamp: Date.now() } };
         case 'payment_request':


### PR DESCRIPTION
Finishes the L1 removal in the example (the `browser/` app was done in #8).

- **nodejs/**: bump to `@unicitylabs/sphere-sdk@0.10.2`; remove the `l1` / `l1history` / `l1send` CLI commands and the L1 mock from the mock wallet server; add a `mint` command (parity with the browser MintPanel). Builds clean (`tsc`) against 0.10.2.
- **docs**: remove `sphere_l1GetBalance` / `sphere_l1GetHistory` / `l1_send` from `README.md`, `browser/CONNECT.md`, `CLAUDE.md`; add `mint`.

No L1 references remain anywhere in the repo (outside node_modules/dist).