### PR TITLE
feat(example): dark restyle on sphere-ui

### DIFF
--- a/browser/index.html
+++ b/browser/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/browser/package-lock.json
+++ b/browser/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tailwindcss/vite": "^4.1.16",
         "@unicitylabs/sphere-sdk": "0.10.2",
+        "@unicitylabs/sphere-ui": "^0.1.23",
         "react": "^19.1.1",
         "react-dom": "^19.2.4"
       },
@@ -310,6 +311,63 @@
       "integrity": "sha512-KIjt+6IfysQ4GCv66xihEitBjvhU/bixbbbFxdJ1sqCp4uJ0wuZiYBPhksZoy4lfaF0k9cwNzY5upEW/VWdw3w==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@dnsquery/dns-packet": {
       "version": "6.1.1",
@@ -1583,6 +1641,69 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
+      "integrity": "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.0.tgz",
+      "integrity": "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tanstack/query-core": "5.101.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1760,6 +1881,30 @@
         }
       }
     },
+    "node_modules/@unicitylabs/sphere-ui": {
+      "version": "0.1.23",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-ui/-/sphere-ui-0.1.23.tgz",
+      "integrity": "sha512-BsyhrYQ2XKFsuxW4/X72hJqV/F5k/ZG5rhWPWZ9md+/mbA73wF8HVICLNQ5xK52+VQGt/OeHOxOow6L4YLoYcw==",
+      "dependencies": {
+        "framer-motion": "^11.18.2",
+        "lucide-react": ">=0.400.0",
+        "react-dropzone": "^14.4.1"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.0.0",
+        "@dnd-kit/sortable": "^8.0.0 || ^10.0.0",
+        "@tanstack/react-query": "^5.0.0",
+        "@tanstack/react-table": "^8.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "recharts": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "recharts": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@unicitylabs/state-transition-sdk": {
       "version": "2.0.0-rc.68bc1e5",
       "resolved": "https://registry.npmjs.org/@unicitylabs/state-transition-sdk/-/state-transition-sdk-2.0.0-rc.68bc1e5.tgz",
@@ -1801,6 +1946,15 @@
       "integrity": "sha512-lVgvB2NyPLqbXXhVmXcYFTC1x5K7CiVdPgdY7LGgFQWC8506oN01sPN3i9cl9ynuwF4iJ0TS9exnR7cZ9FuX4w==",
       "license": "Apache-2.0 OR MIT",
       "optional": true
+    },
+    "node_modules/attr-accept": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -2126,6 +2280,45 @@
         }
       }
     },
+    "node_modules/file-selector": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
+      "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2313,7 +2506,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
@@ -2597,6 +2789,18 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2605,6 +2809,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.21.0.tgz",
+      "integrity": "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {
@@ -2633,6 +2846,21 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "license": "MIT"
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
       "license": "MIT"
     },
     "node_modules/ms": {
@@ -2673,6 +2901,15 @@
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/p-queue": {
       "version": "9.3.0",
@@ -2757,6 +2994,17 @@
       "license": "Apache-2.0 OR MIT",
       "optional": true
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/protons-runtime": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-7.0.0.tgz",
@@ -2789,6 +3037,29 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-dropzone": {
+      "version": "14.4.1",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.4.1.tgz",
+      "integrity": "sha512-QDuV76v3uKbHiH34SpwifZ+gOLi1+RdsCO1kl5vxMT4wW8R82+sthjvBw4th3NHF/XX6FBsqDYZVNN+pnhaw0g==",
+      "license": "MIT",
+      "dependencies": {
+        "attr-accept": "^2.2.4",
+        "file-selector": "^2.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8 || 18.0.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -2926,6 +3197,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "5.6.3",

--- a/browser/package-lock.json
+++ b/browser/package-lock.json
@@ -11,6 +11,7 @@
         "@tailwindcss/vite": "^4.1.16",
         "@unicitylabs/sphere-sdk": "0.10.2",
         "@unicitylabs/sphere-ui": "^0.1.23",
+        "lucide-react": "^0.400.0",
         "react": "^19.1.1",
         "react-dom": "^19.2.4"
       },
@@ -2812,9 +2813,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.21.0.tgz",
-      "integrity": "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ==",
+      "version": "0.400.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.400.0.tgz",
+      "integrity": "sha512-rpp7pFHh3Xd93KHixNgB0SqThMHpYNzsGUu69UaQbSZ75Q/J3m5t6EhKyMT3m4w2WOxmJ2mY0tD3vebnXqQryQ==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/browser/package.json
+++ b/browser/package.json
@@ -12,6 +12,7 @@
     "@tailwindcss/vite": "^4.1.16",
     "@unicitylabs/sphere-sdk": "0.10.2",
     "@unicitylabs/sphere-ui": "^0.1.23",
+    "lucide-react": "^0.400.0",
     "react": "^19.1.1",
     "react-dom": "^19.2.4"
   },

--- a/browser/package.json
+++ b/browser/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.16",
     "@unicitylabs/sphere-sdk": "0.10.2",
+    "@unicitylabs/sphere-ui": "^0.1.23",
     "react": "^19.1.1",
     "react-dom": "^19.2.4"
   },

--- a/browser/src/App.tsx
+++ b/browser/src/App.tsx
@@ -34,19 +34,19 @@ export default function App() {
     // Blank screen during silent auto-connect — avoids flash of Connect button
     if (wallet.isAutoConnecting) {
       return (
-        <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="min-h-screen bg-(--bg-root) flex items-center justify-center">
           <div className="flex flex-col items-center gap-3">
             <svg className="animate-spin h-8 w-8 text-orange-500" viewBox="0 0 24 24">
               <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
               <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
             </svg>
-            <p className="text-sm text-gray-500">Connecting to wallet...</p>
+            <p className="text-sm text-white/45">Connecting to wallet...</p>
           </div>
         </div>
       );
     }
     return (
-      <div className="min-h-screen bg-gray-50">
+      <div className="min-h-screen bg-(--bg-root)">
         <ConnectButton
           onConnect={wallet.connect}
           onConnectExtension={wallet.connectViaExtension}

--- a/browser/src/components/ConnectButton.tsx
+++ b/browser/src/components/ConnectButton.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Button } from '@unicitylabs/sphere-ui';
 
 interface ConnectButtonProps {
   onConnect: () => void;
@@ -20,11 +21,11 @@ function Spinner() {
 
 function ExtensionIcon({ detected }: { detected: boolean }) {
   return (
-    <div className={`w-12 h-12 rounded-2xl flex items-center justify-center mb-3 ${detected ? 'bg-green-100' : 'bg-gray-100'}`}>
+    <div className={`w-12 h-12 rounded-2xl flex items-center justify-center mb-3 ${detected ? 'bg-green-500/15' : 'bg-white/6'}`}>
       <svg width="28" height="28" viewBox="0 0 24 24" fill="none">
         <path
           d="M20.5 11H19V7a2 2 0 0 0-2-2h-4V3.5A2.5 2.5 0 0 0 10.5 1 2.5 2.5 0 0 0 8 3.5V5H4a2 2 0 0 0-2 2v3.8h1.5c1.5 0 2.7 1.2 2.7 2.7S5 16.2 3.5 16.2H2V20a2 2 0 0 0 2 2h3.8v-1.5c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7V22H17a2 2 0 0 0 2-2v-4h1.5a2.5 2.5 0 0 0 2.5-2.5 2.5 2.5 0 0 0-2.5-2.5z"
-          fill={detected ? '#16a34a' : '#9ca3af'}
+          fill={detected ? '#4ade80' : '#6b7280'}
         />
       </svg>
     </div>
@@ -33,7 +34,7 @@ function ExtensionIcon({ detected }: { detected: boolean }) {
 
 function PopupIcon() {
   return (
-    <div className="w-12 h-12 rounded-2xl flex items-center justify-center mb-3 bg-orange-100">
+    <div className="w-12 h-12 rounded-2xl flex items-center justify-center mb-3 bg-orange-500/10">
       <svg width="28" height="28" viewBox="0 0 24 24" fill="none">
         <rect x="2" y="4" width="20" height="16" rx="2" stroke="#f97316" strokeWidth="2" />
         <path d="M2 8h20" stroke="#f97316" strokeWidth="2" />
@@ -72,14 +73,14 @@ export function ConnectButton({
     <>
       <div className="flex flex-col items-center justify-center min-h-[60vh] gap-6">
         <div className="text-center">
-          <h1 className="text-4xl font-bold text-gray-900 mb-2">Sphere Connect</h1>
-          <p className="text-gray-500 text-lg">Browser dApp Example</p>
+          <h1 className="text-4xl font-bold text-white mb-2">Sphere Connect</h1>
+          <p className="text-white/45 text-lg">Browser dApp Example</p>
         </div>
 
-        <button
+        <Button
           onClick={() => !isConnecting && setShowModal(true)}
           disabled={isConnecting}
-          className="px-8 py-4 bg-orange-500 hover:bg-orange-600 disabled:bg-orange-300 text-white font-semibold rounded-2xl text-lg transition-colors shadow-lg shadow-orange-500/25 cursor-pointer disabled:cursor-not-allowed"
+          className="px-8 py-4 text-lg shadow-lg shadow-orange-500/25"
         >
           {isConnecting ? (
             <span className="flex items-center gap-2">
@@ -89,10 +90,10 @@ export function ConnectButton({
           ) : (
             'Connect Wallet'
           )}
-        </button>
+        </Button>
 
         {error && (
-          <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-xl max-w-md text-center text-sm">
+          <div className="bg-red-500/10 border border-red-500/20 text-red-400 px-4 py-3 rounded-xl max-w-md text-center text-sm">
             {error}
           </div>
         )}
@@ -101,15 +102,15 @@ export function ConnectButton({
       {/* Connection method modal */}
       {showModal && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
           onClick={() => setShowModal(false)}
         >
           <div
-            className="bg-white rounded-3xl shadow-2xl p-6 w-full max-w-sm mx-4"
+            className="admin-card p-6 w-full max-w-sm mx-4"
             onClick={(e) => e.stopPropagation()}
           >
-            <h2 className="text-xl font-bold text-gray-900 text-center mb-1">Choose connection</h2>
-            <p className="text-sm text-gray-500 text-center mb-6">
+            <h2 className="text-xl font-bold text-white text-center mb-1">Choose connection</h2>
+            <p className="text-sm text-white/45 text-center mb-6">
               How would you like to connect your Sphere wallet?
             </p>
 
@@ -120,15 +121,15 @@ export function ConnectButton({
                 disabled={!extensionInstalled}
                 className={`flex-1 flex flex-col items-center p-4 rounded-2xl border-2 transition-all
                   ${extensionInstalled
-                    ? 'border-green-200 hover:border-green-400 hover:bg-green-50 cursor-pointer'
-                    : 'border-gray-100 bg-gray-50 cursor-not-allowed opacity-50'
+                    ? 'border-green-500/30 hover:border-green-400 hover:bg-green-500/10 cursor-pointer'
+                    : 'border-white/8 bg-white/3 cursor-not-allowed opacity-50'
                   }`}
               >
                 <ExtensionIcon detected={extensionInstalled} />
-                <span className={`text-sm font-semibold ${extensionInstalled ? 'text-gray-900' : 'text-gray-400'}`}>
+                <span className={`text-sm font-semibold ${extensionInstalled ? 'text-white' : 'text-white/45'}`}>
                   Extension
                 </span>
-                <span className="text-xs text-gray-400 mt-0.5 text-center leading-tight">
+                <span className="text-xs text-white/45 mt-0.5 text-center leading-tight">
                   {extensionInstalled ? 'Sphere extension detected' : 'Not installed'}
                 </span>
               </button>
@@ -136,11 +137,11 @@ export function ConnectButton({
               {/* Popup option */}
               <button
                 onClick={handlePopup}
-                className="flex-1 flex flex-col items-center p-4 rounded-2xl border-2 border-orange-200 hover:border-orange-400 hover:bg-orange-50 transition-all cursor-pointer"
+                className="flex-1 flex flex-col items-center p-4 rounded-2xl border-2 border-orange-500/30 hover:border-orange-400 hover:bg-orange-500/10 transition-all cursor-pointer"
               >
                 <PopupIcon />
-                <span className="text-sm font-semibold text-gray-900">Popup</span>
-                <span className="text-xs text-gray-400 mt-0.5 text-center leading-tight">
+                <span className="text-sm font-semibold text-white">Popup</span>
+                <span className="text-xs text-white/45 mt-0.5 text-center leading-tight">
                   Opens sphere.unicity.network
                 </span>
               </button>
@@ -148,7 +149,7 @@ export function ConnectButton({
 
             <button
               onClick={() => setShowModal(false)}
-              className="mt-4 w-full text-sm text-gray-400 hover:text-gray-600 transition-colors py-1"
+              className="mt-4 w-full text-sm text-white/45 hover:text-white/70 transition-colors py-1"
             >
               Cancel
             </button>

--- a/browser/src/components/chat/ChatPanel.tsx
+++ b/browser/src/components/chat/ChatPanel.tsx
@@ -191,7 +191,7 @@ export function ChatPanel({ query, intent, on, walletPubkey }: Props) {
 
           {/* New chat input */}
           <div className="p-2 border-b border-white/8">
-            <Input
+            <input
               type="text"
               value={newChatRecipient}
               onChange={(e) => setNewChatRecipient(e.target.value)}
@@ -202,7 +202,7 @@ export function ChatPanel({ query, intent, on, walletPubkey }: Props) {
                 }
               }}
               placeholder="New chat (@nametag)"
-              className="w-full text-xs"
+              className="w-full px-2 py-1.5 text-xs rounded-lg bg-white/3 border border-white/8 text-white placeholder-white/30 focus:outline-none focus:border-orange-500"
             />
           </div>
 
@@ -334,6 +334,7 @@ export function ChatPanel({ query, intent, on, walletPubkey }: Props) {
               <Button
                 onClick={sendMessage}
                 disabled={sending || !input.trim()}
+                className="shrink-0"
               >
                 {sending ? '...' : 'Send'}
               </Button>

--- a/browser/src/components/chat/ChatPanel.tsx
+++ b/browser/src/components/chat/ChatPanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { RPC_METHODS, INTENT_ACTIONS } from '@unicitylabs/sphere-sdk/connect';
+import { Button, Input } from '@unicitylabs/sphere-ui';
 import { chatTime, truncate } from '../../lib/format';
 import type { ConversationSummary, ConversationPage, DirectMessage } from '../../lib/types';
 
@@ -180,17 +181,17 @@ export function ChatPanel({ query, intent, on, walletPubkey }: Props) {
       : null;
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden" style={{ height: '600px' }}>
+    <div className="admin-card overflow-hidden" style={{ height: '600px' }}>
       <div className="flex h-full">
         {/* Conversation list */}
-        <div className="w-56 shrink-0 border-r border-gray-200 flex flex-col">
-          <div className="p-3 border-b border-gray-100">
-            <h2 className="text-sm font-semibold text-gray-900">Chats</h2>
+        <div className="w-56 shrink-0 border-r border-white/8 flex flex-col">
+          <div className="p-3 border-b border-white/8">
+            <h2 className="text-sm font-semibold text-white">Chats</h2>
           </div>
 
           {/* New chat input */}
-          <div className="p-2 border-b border-gray-100">
-            <input
+          <div className="p-2 border-b border-white/8">
+            <Input
               type="text"
               value={newChatRecipient}
               onChange={(e) => setNewChatRecipient(e.target.value)}
@@ -201,27 +202,27 @@ export function ChatPanel({ query, intent, on, walletPubkey }: Props) {
                 }
               }}
               placeholder="New chat (@nametag)"
-              className="w-full px-2 py-1.5 text-xs border border-gray-200 rounded-lg focus:outline-none focus:ring-1 focus:ring-orange-500/30 focus:border-orange-500"
+              className="w-full text-xs"
             />
           </div>
 
           {/* Conversation list */}
           <div className="flex-1 overflow-y-auto">
             {conversations.length === 0 && (
-              <div className="p-4 text-xs text-gray-400 text-center">No conversations yet</div>
+              <div className="p-4 text-xs text-white/45 text-center">No conversations yet</div>
             )}
             {conversations.map((convo) => (
               <button
                 key={convo.peerPubkey}
                 onClick={() => selectPeer(convo.peerPubkey)}
-                className={`w-full text-left px-3 py-2.5 border-b border-gray-50 cursor-pointer transition-colors ${
+                className={`w-full text-left px-3 py-2.5 border-b border-white/8 cursor-pointer transition-colors ${
                   selectedPeer === convo.peerPubkey
-                    ? 'bg-orange-50'
-                    : 'hover:bg-gray-50'
+                    ? 'bg-orange-500/10'
+                    : 'hover:bg-white/3'
                 }`}
               >
                 <div className="flex items-center justify-between mb-0.5">
-                  <span className="text-sm font-medium text-gray-900 truncate">
+                  <span className="text-sm font-medium text-white truncate">
                     {(convo.peerNametag || getNametag(convo.peerPubkey)) ? `@${convo.peerNametag || getNametag(convo.peerPubkey)}` : truncate(convo.peerPubkey)}
                   </span>
                   {convo.unreadCount > 0 && (
@@ -231,10 +232,10 @@ export function ChatPanel({ query, intent, on, walletPubkey }: Props) {
                   )}
                 </div>
                 <div className="flex items-center justify-between">
-                  <span className="text-xs text-gray-500 truncate max-w-[120px]">
+                  <span className="text-xs text-white/45 truncate max-w-[120px]">
                     {convo.lastMessage.content}
                   </span>
-                  <span className="text-[10px] text-gray-400 shrink-0 ml-1">
+                  <span className="text-[10px] text-white/45 shrink-0 ml-1">
                     {chatTime(convo.lastMessage.timestamp)}
                   </span>
                 </div>
@@ -246,15 +247,15 @@ export function ChatPanel({ query, intent, on, walletPubkey }: Props) {
         {/* Message thread */}
         <div className="flex-1 flex flex-col min-w-0">
           {/* Thread header */}
-          <div className="px-4 py-3 border-b border-gray-200 bg-gray-50">
+          <div className="px-4 py-3 border-b border-white/8 bg-white/3">
             {peerDisplay ? (
-              <span className="text-sm font-semibold text-gray-900">{peerDisplay}</span>
+              <span className="text-sm font-semibold text-white">{peerDisplay}</span>
             ) : newChatRecipient ? (
-              <span className="text-sm font-semibold text-gray-900">
+              <span className="text-sm font-semibold text-white">
                 New chat with {newChatRecipient.startsWith('@') ? newChatRecipient : '@' + newChatRecipient}
               </span>
             ) : (
-              <span className="text-sm text-gray-400">Select a conversation or start a new chat</span>
+              <span className="text-sm text-white/45">Select a conversation or start a new chat</span>
             )}
           </div>
 
@@ -263,18 +264,18 @@ export function ChatPanel({ query, intent, on, walletPubkey }: Props) {
             {hasMore && (
               <button
                 onClick={loadOlder}
-                className="w-full text-xs text-orange-500 hover:text-orange-600 py-1 cursor-pointer"
+                className="w-full text-xs text-orange-500 hover:text-orange-400 py-1 cursor-pointer"
               >
                 Load older messages
               </button>
             )}
 
             {loading && messages.length === 0 && (
-              <div className="text-xs text-gray-400 text-center py-8">Loading messages...</div>
+              <div className="text-xs text-white/45 text-center py-8">Loading messages...</div>
             )}
 
             {!selectedPeer && !newChatRecipient && messages.length === 0 && !loading && (
-              <div className="text-xs text-gray-400 text-center py-8">
+              <div className="text-xs text-white/45 text-center py-8">
                 Select a conversation from the list or type a @nametag to start a new chat
               </div>
             )}
@@ -287,16 +288,16 @@ export function ChatPanel({ query, intent, on, walletPubkey }: Props) {
                     className={`max-w-[75%] rounded-2xl px-3.5 py-2 ${
                       isOwn
                         ? 'bg-orange-500 text-white rounded-br-md'
-                        : 'bg-gray-100 text-gray-900 rounded-bl-md'
+                        : 'bg-white/6 text-white rounded-bl-md'
                     }`}
                   >
                     {!isOwn && msg.senderNametag && (
-                      <div className="text-[10px] font-medium text-orange-600 mb-0.5">
+                      <div className="text-[10px] font-medium text-orange-400 mb-0.5">
                         @{msg.senderNametag}
                       </div>
                     )}
                     <div className="text-sm break-words">{msg.content}</div>
-                    <div className={`text-[10px] mt-0.5 ${isOwn ? 'text-orange-200' : 'text-gray-400'}`}>
+                    <div className={`text-[10px] mt-0.5 ${isOwn ? 'text-orange-200' : 'text-white/45'}`}>
                       {chatTime(msg.timestamp)}
                     </div>
                   </div>
@@ -308,15 +309,15 @@ export function ChatPanel({ query, intent, on, walletPubkey }: Props) {
 
           {/* Error */}
           {error && (
-            <div className="px-4 py-1.5 text-xs text-red-500 bg-red-50 border-t border-red-100">
+            <div className="px-4 py-1.5 text-xs text-red-500 bg-red-500/10 border-t border-red-500/20">
               {error}
             </div>
           )}
 
           {/* Input */}
           {(selectedPeer || newChatRecipient) && (
-            <div className="px-3 py-2.5 border-t border-gray-200 flex gap-2">
-              <input
+            <div className="px-3 py-2.5 border-t border-white/8 flex gap-2">
+              <Input
                 type="text"
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
@@ -328,15 +329,14 @@ export function ChatPanel({ query, intent, on, walletPubkey }: Props) {
                 }}
                 placeholder="Type a message..."
                 disabled={sending}
-                className="flex-1 px-3 py-2 text-sm border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500 disabled:bg-gray-50"
+                className="flex-1"
               />
-              <button
+              <Button
                 onClick={sendMessage}
                 disabled={sending || !input.trim()}
-                className="px-4 py-2 bg-orange-500 hover:bg-orange-600 disabled:bg-gray-200 disabled:text-gray-400 text-white text-sm font-medium rounded-xl transition-colors cursor-pointer disabled:cursor-not-allowed shrink-0"
               >
                 {sending ? '...' : 'Send'}
-              </button>
+              </Button>
             </div>
           )}
         </div>

--- a/browser/src/components/events/EventLogPanel.tsx
+++ b/browser/src/components/events/EventLogPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { Button, Select } from '@unicitylabs/sphere-ui';
 
 interface LogEntry {
   id: number;
@@ -56,45 +57,45 @@ const ALL_EVENTS = [
 
 const EVENT_COLORS: Record<string, string> = {
   // Transfers
-  'transfer:incoming': 'bg-green-100 text-green-700',
-  'transfer:confirmed': 'bg-green-100 text-green-700',
-  'transfer:failed': 'bg-red-100 text-red-700',
+  'transfer:incoming': 'bg-green-500/15 text-green-400',
+  'transfer:confirmed': 'bg-green-500/15 text-green-400',
+  'transfer:failed': 'bg-red-500/15 text-red-400',
   // Payment requests
-  'payment_request:incoming': 'bg-orange-100 text-orange-700',
-  'payment_request:accepted': 'bg-green-100 text-green-700',
-  'payment_request:rejected': 'bg-red-100 text-red-700',
-  'payment_request:paid': 'bg-green-100 text-green-700',
-  'payment_request:response': 'bg-orange-100 text-orange-700',
+  'payment_request:incoming': 'bg-orange-500/10 text-orange-400',
+  'payment_request:accepted': 'bg-green-500/15 text-green-400',
+  'payment_request:rejected': 'bg-red-500/15 text-red-400',
+  'payment_request:paid': 'bg-green-500/15 text-green-400',
+  'payment_request:response': 'bg-orange-500/10 text-orange-400',
   // Messages
-  'message:dm': 'bg-indigo-100 text-indigo-700',
-  'message:read': 'bg-indigo-100 text-indigo-700',
-  'message:typing': 'bg-indigo-100 text-indigo-700',
-  'composing:started': 'bg-indigo-100 text-indigo-700',
-  'message:broadcast': 'bg-indigo-100 text-indigo-700',
+  'message:dm': 'bg-indigo-500/15 text-indigo-400',
+  'message:read': 'bg-indigo-500/15 text-indigo-400',
+  'message:typing': 'bg-indigo-500/15 text-indigo-400',
+  'composing:started': 'bg-indigo-500/15 text-indigo-400',
+  'message:broadcast': 'bg-indigo-500/15 text-indigo-400',
   // Sync
-  'sync:started': 'bg-gray-100 text-gray-600',
-  'sync:completed': 'bg-gray-100 text-gray-600',
-  'sync:provider': 'bg-gray-100 text-gray-600',
-  'sync:error': 'bg-red-100 text-red-700',
-  'sync:remote-update': 'bg-gray-100 text-gray-600',
+  'sync:started': 'bg-white/3 text-white/55',
+  'sync:completed': 'bg-white/3 text-white/55',
+  'sync:provider': 'bg-white/3 text-white/55',
+  'sync:error': 'bg-red-500/15 text-red-400',
+  'sync:remote-update': 'bg-white/3 text-white/55',
   // Connection & wallet state
-  'connection:changed': 'bg-yellow-100 text-yellow-700',
-  'wallet:locked': 'bg-red-100 text-red-700',
+  'connection:changed': 'bg-yellow-500/15 text-amber-400',
+  'wallet:locked': 'bg-red-500/15 text-red-400',
   // Identity & addresses
-  'identity:changed': 'bg-blue-100 text-blue-700',
-  'nametag:registered': 'bg-purple-100 text-purple-700',
-  'nametag:recovered': 'bg-purple-100 text-purple-700',
-  'address:activated': 'bg-blue-100 text-blue-700',
-  'address:hidden': 'bg-blue-100 text-blue-700',
-  'address:unhidden': 'bg-blue-100 text-blue-700',
+  'identity:changed': 'bg-blue-500/15 text-blue-400',
+  'nametag:registered': 'bg-purple-500/15 text-purple-400',
+  'nametag:recovered': 'bg-purple-500/15 text-purple-400',
+  'address:activated': 'bg-blue-500/15 text-blue-400',
+  'address:hidden': 'bg-blue-500/15 text-blue-400',
+  'address:unhidden': 'bg-blue-500/15 text-blue-400',
   // Group chat
-  'groupchat:message': 'bg-teal-100 text-teal-700',
-  'groupchat:joined': 'bg-teal-100 text-teal-700',
-  'groupchat:left': 'bg-teal-100 text-teal-700',
-  'groupchat:kicked': 'bg-red-100 text-red-700',
-  'groupchat:group_deleted': 'bg-red-100 text-red-700',
-  'groupchat:updated': 'bg-teal-100 text-teal-700',
-  'groupchat:connection': 'bg-teal-100 text-teal-700',
+  'groupchat:message': 'bg-teal-500/15 text-teal-400',
+  'groupchat:joined': 'bg-teal-500/15 text-teal-400',
+  'groupchat:left': 'bg-teal-500/15 text-teal-400',
+  'groupchat:kicked': 'bg-red-500/15 text-red-400',
+  'groupchat:group_deleted': 'bg-red-500/15 text-red-400',
+  'groupchat:updated': 'bg-teal-500/15 text-teal-400',
+  'groupchat:connection': 'bg-teal-500/15 text-teal-400',
 };
 
 let nextId = 0;
@@ -125,46 +126,45 @@ export function EventLogPanel({ on }: Props) {
   const filtered = filter === 'all' ? entries : entries.filter((e) => e.event === filter);
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-200 shadow-sm p-5">
+    <div className="admin-card p-5">
       <div className="flex items-center justify-between mb-1">
-        <h2 className="text-lg font-semibold text-gray-900">Event Log</h2>
-        <span className="text-[10px] font-mono text-purple-500 bg-purple-50 px-2 py-0.5 rounded">events</span>
+        <h2 className="text-lg font-semibold text-white">Event Log</h2>
+        <span className="text-[10px] font-mono text-purple-400 bg-purple-500/15 px-2 py-0.5 rounded">events</span>
       </div>
-      <p className="text-xs text-gray-400 mb-4">Real-time wallet events ({ALL_EVENTS.length} subscribed)</p>
+      <p className="text-xs text-white/45 mb-4">Real-time wallet events ({ALL_EVENTS.length} subscribed)</p>
 
       <div className="flex items-center gap-2 mb-3">
-        <select value={filter} onChange={(e) => setFilter(e.target.value)}
-          className="flex-1 px-3 py-2 border border-gray-200 rounded-xl text-sm bg-white focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500">
+        <Select value={filter} onChange={(e) => setFilter(e.target.value)}
+          className="flex-1">
           <option value="all">All events</option>
           {ALL_EVENTS.map((ev) => (
             <option key={ev} value={ev}>{ev}</option>
           ))}
-        </select>
+        </Select>
         {entries.length > 0 && (
-          <button onClick={() => setEntries([])}
-            className="px-3 py-2 text-sm text-gray-400 hover:text-gray-600 cursor-pointer">
+          <Button onClick={() => setEntries([])} variant="secondary">
             Clear
-          </button>
+          </Button>
         )}
       </div>
 
       <div ref={containerRef} className="space-y-2 max-h-96 overflow-y-auto">
         {filtered.length === 0 ? (
-          <div className="text-gray-400 text-sm py-8 text-center">
+          <div className="text-white/45 text-sm py-8 text-center">
             Listening for events...
           </div>
         ) : (
           filtered.map((entry) => {
-            const badgeStyle = EVENT_COLORS[entry.event] ?? 'bg-gray-100 text-gray-600';
+            const badgeStyle = EVENT_COLORS[entry.event] ?? 'bg-white/3 text-white/55';
             return (
-              <div key={entry.id} className="p-3 bg-gray-50 rounded-xl text-xs">
+              <div key={entry.id} className="p-3 bg-white/3 rounded-xl text-xs">
                 <div className="flex items-center justify-between mb-1">
                   <span className={`inline-block px-2 py-0.5 rounded-md font-medium ${badgeStyle}`}>
                     {entry.event}
                   </span>
-                  <span className="text-gray-400">{entry.timestamp.toLocaleTimeString()}</span>
+                  <span className="text-white/45">{entry.timestamp.toLocaleTimeString()}</span>
                 </div>
-                <pre className="text-gray-600 overflow-auto max-h-32">
+                <pre className="text-white/55 overflow-auto max-h-32">
                   {JSON.stringify(entry.data, null, 2)}
                 </pre>
               </div>

--- a/browser/src/components/intents/DMPanel.tsx
+++ b/browser/src/components/intents/DMPanel.tsx
@@ -43,7 +43,7 @@ export function DMPanel({ intent }: Props) {
         <Input type="text" value={recipient} onChange={(e) => setRecipient(e.target.value)}
           placeholder="To (@nametag)" />
         <Textarea value={message} onChange={(e) => setMessage(e.target.value)}
-          placeholder="Message" rows={3} />
+          placeholder="Message" rows={3} className="resize-none" />
         <Button onClick={execute} disabled={loading || !recipient || !message} className="w-full">
           {loading ? 'Sending...' : 'Send DM'}
         </Button>

--- a/browser/src/components/intents/DMPanel.tsx
+++ b/browser/src/components/intents/DMPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { INTENT_ACTIONS } from '@unicitylabs/sphere-sdk/connect';
+import { Button, Input, Textarea } from '@unicitylabs/sphere-ui';
 import { ResultDisplay } from '../ui/ResultDisplay';
 
 interface Props {
@@ -30,25 +31,22 @@ export function DMPanel({ intent }: Props) {
   };
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-200 shadow-sm p-5">
+    <div className="admin-card p-5">
       <div className="flex items-center justify-between mb-1">
-        <h2 className="text-lg font-semibold text-gray-900">Direct Message</h2>
-        <span className="text-[10px] font-mono text-orange-500 bg-orange-50 px-2 py-0.5 rounded">intent: dm</span>
+        <h2 className="text-lg font-semibold text-white">Direct Message</h2>
+        <span className="text-[10px] font-mono text-orange-400 bg-orange-500/10 px-2 py-0.5 rounded">intent: dm</span>
       </div>
-      <p className="text-xs text-gray-400 mb-1">Send a direct message via Nostr</p>
-      <p className="text-[11px] text-yellow-600 mb-4">Requires wallet approval</p>
+      <p className="text-xs text-white/45 mb-1">Send a direct message via Nostr</p>
+      <p className="text-[11px] text-amber-400 mb-4">Requires wallet approval</p>
 
       <div className="space-y-3">
-        <input type="text" value={recipient} onChange={(e) => setRecipient(e.target.value)}
-          placeholder="To (@nametag)"
-          className="w-full px-3 py-2 border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500" />
-        <textarea value={message} onChange={(e) => setMessage(e.target.value)}
-          placeholder="Message" rows={3}
-          className="w-full px-3 py-2 border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500 resize-none" />
-        <button onClick={execute} disabled={loading || !recipient || !message}
-          className="w-full py-2.5 bg-orange-500 hover:bg-orange-600 disabled:bg-gray-200 disabled:text-gray-400 text-white font-medium rounded-xl transition-colors cursor-pointer disabled:cursor-not-allowed">
+        <Input type="text" value={recipient} onChange={(e) => setRecipient(e.target.value)}
+          placeholder="To (@nametag)" />
+        <Textarea value={message} onChange={(e) => setMessage(e.target.value)}
+          placeholder="Message" rows={3} />
+        <Button onClick={execute} disabled={loading || !recipient || !message} className="w-full">
           {loading ? 'Sending...' : 'Send DM'}
-        </button>
+        </Button>
       </div>
 
       <ResultDisplay result={raw} error={error} />

--- a/browser/src/components/intents/MintPanel.tsx
+++ b/browser/src/components/intents/MintPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { INTENT_ACTIONS } from '@unicitylabs/sphere-sdk/connect';
+import { Button, Input } from '@unicitylabs/sphere-ui';
 import { ResultDisplay } from '../ui/ResultDisplay';
 
 interface Props {
@@ -43,22 +44,22 @@ export function MintPanel({ intent }: Props) {
   };
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-200 shadow-sm p-5">
+    <div className="admin-card p-5">
       <div className="flex items-center justify-between mb-1">
-        <h2 className="text-lg font-semibold text-gray-900">Mint (L3)</h2>
-        <span className="text-[10px] font-mono text-orange-500 bg-orange-50 px-2 py-0.5 rounded">intent: mint</span>
+        <h2 className="text-lg font-semibold text-white">Mint (L3)</h2>
+        <span className="text-[10px] font-mono text-orange-400 bg-orange-500/10 px-2 py-0.5 rounded">intent: mint</span>
       </div>
-      <p className="text-xs text-gray-400 mb-1">Self-mint a fungible token to the connected wallet</p>
-      <p className="text-[11px] text-yellow-600 mb-3">Requires wallet approval · works only where the network allows self-mint (testnet2)</p>
+      <p className="text-xs text-white/45 mb-1">Self-mint a fungible token to the connected wallet</p>
+      <p className="text-[11px] text-amber-400 mb-3">Requires wallet approval · works only where the network allows self-mint (testnet2)</p>
 
       <div className="flex flex-wrap gap-2 mb-4">
-        <span className="text-[11px] text-gray-400 self-center mr-1">Presets:</span>
+        <span className="text-[11px] text-white/45 self-center mr-1">Presets:</span>
         {PRESETS.map((p) => (
           <button
             key={p.label}
             type="button"
             onClick={() => { setCoinId(p.coinId); setAmount(p.amount); }}
-            className="text-xs font-medium px-2.5 py-1 rounded-lg border border-gray-200 text-gray-600 hover:border-orange-400 hover:text-orange-600 transition-colors cursor-pointer"
+            className="text-xs font-medium px-2.5 py-1 rounded-lg border border-white/8 text-white/55 hover:border-orange-400 hover:text-orange-400 transition-colors cursor-pointer"
           >
             {p.label}
           </button>
@@ -66,16 +67,14 @@ export function MintPanel({ intent }: Props) {
       </div>
 
       <div className="space-y-3">
-        <input type="text" value={coinId} onChange={(e) => setCoinId(e.target.value)}
+        <Input type="text" value={coinId} onChange={(e) => setCoinId(e.target.value)}
           placeholder="Coin ID (lowercase hex, e.g. 1111…)"
-          className="w-full px-3 py-2 border border-gray-200 rounded-xl text-sm font-mono focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500" />
-        <input type="text" value={amount} onChange={(e) => setAmount(e.target.value)}
-          placeholder="Amount (smallest units)"
-          className="w-full px-3 py-2 border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500" />
-        <button onClick={execute} disabled={loading || !coinId || !amount}
-          className="w-full py-2.5 bg-orange-500 hover:bg-orange-600 disabled:bg-gray-200 disabled:text-gray-400 text-white font-medium rounded-xl transition-colors cursor-pointer disabled:cursor-not-allowed">
+          className="font-mono" />
+        <Input type="text" value={amount} onChange={(e) => setAmount(e.target.value)}
+          placeholder="Amount (smallest units)" />
+        <Button onClick={execute} disabled={loading || !coinId || !amount} className="w-full">
           {loading ? 'Minting...' : 'Mint'}
-        </button>
+        </Button>
       </div>
 
       <ResultDisplay result={raw} error={error} />

--- a/browser/src/components/intents/PaymentRequestPanel.tsx
+++ b/browser/src/components/intents/PaymentRequestPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { INTENT_ACTIONS } from '@unicitylabs/sphere-sdk/connect';
+import { Button, Input } from '@unicitylabs/sphere-ui';
 import { ResultDisplay } from '../ui/ResultDisplay';
 import { CoinSelect } from '../ui/CoinSelect';
 
@@ -36,31 +37,28 @@ export function PaymentRequestPanel({ intent, query }: Props) {
   };
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-200 shadow-sm p-5">
+    <div className="admin-card p-5">
       <div className="flex items-center justify-between mb-1">
-        <h2 className="text-lg font-semibold text-gray-900">Payment Request</h2>
-        <span className="text-[10px] font-mono text-orange-500 bg-orange-50 px-2 py-0.5 rounded">intent: payment_request</span>
+        <h2 className="text-lg font-semibold text-white">Payment Request</h2>
+        <span className="text-[10px] font-mono text-orange-400 bg-orange-500/10 px-2 py-0.5 rounded">intent: payment_request</span>
       </div>
-      <p className="text-xs text-gray-400 mb-1">Request payment from another user</p>
-      <p className="text-[11px] text-yellow-600 mb-4">Requires wallet approval</p>
+      <p className="text-xs text-white/45 mb-1">Request payment from another user</p>
+      <p className="text-[11px] text-amber-400 mb-4">Requires wallet approval</p>
 
       <div className="space-y-3">
-        <input type="text" value={recipient} onChange={(e) => setRecipient(e.target.value)}
-          placeholder="Recipient (@nametag)"
-          className="w-full px-3 py-2 border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500" />
+        <Input type="text" value={recipient} onChange={(e) => setRecipient(e.target.value)}
+          placeholder="Recipient (@nametag)" />
         <div className="flex gap-2">
-          <input type="text" value={amount} onChange={(e) => setAmount(e.target.value)}
+          <Input type="text" value={amount} onChange={(e) => setAmount(e.target.value)}
             placeholder="Amount"
-            className="flex-1 px-3 py-2 border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500" />
+            className="flex-1" />
           <CoinSelect value={coinId} onChange={setCoinId} query={query} />
         </div>
-        <input type="text" value={message} onChange={(e) => setMessage(e.target.value)}
-          placeholder="Message (optional)"
-          className="w-full px-3 py-2 border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500" />
-        <button onClick={execute} disabled={loading || !recipient || !amount || !coinId}
-          className="w-full py-2.5 bg-orange-500 hover:bg-orange-600 disabled:bg-gray-200 disabled:text-gray-400 text-white font-medium rounded-xl transition-colors cursor-pointer disabled:cursor-not-allowed">
+        <Input type="text" value={message} onChange={(e) => setMessage(e.target.value)}
+          placeholder="Message (optional)" />
+        <Button onClick={execute} disabled={loading || !recipient || !amount || !coinId} className="w-full">
           {loading ? 'Sending...' : 'Send Payment Request'}
-        </button>
+        </Button>
       </div>
 
       <ResultDisplay result={raw} error={error} />

--- a/browser/src/components/intents/ReceivePanel.tsx
+++ b/browser/src/components/intents/ReceivePanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { INTENT_ACTIONS } from '@unicitylabs/sphere-sdk/connect';
+import { Button } from '@unicitylabs/sphere-ui';
 import { ResultDisplay } from '../ui/ResultDisplay';
 
 interface Props {
@@ -26,20 +27,19 @@ export function ReceivePanel({ intent }: Props) {
   };
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-200 shadow-sm p-5">
+    <div className="admin-card p-5">
       <div className="flex items-center justify-between mb-1">
-        <h2 className="text-lg font-semibold text-gray-900">Receive</h2>
-        <span className="text-[10px] font-mono text-orange-500 bg-orange-50 px-2 py-0.5 rounded">intent: receive</span>
+        <h2 className="text-lg font-semibold text-white">Receive</h2>
+        <span className="text-[10px] font-mono text-orange-400 bg-orange-500/10 px-2 py-0.5 rounded">intent: receive</span>
       </div>
-      <p className="text-xs text-gray-400 mb-1">Explicit one-shot poll for pending incoming transfers via Nostr</p>
-      <p className="text-[11px] text-gray-400 mb-1">In a live wallet transfers arrive automatically — this is for CLI/batch scenarios without a persistent connection</p>
+      <p className="text-xs text-white/45 mb-1">Explicit one-shot poll for pending incoming transfers via Nostr</p>
+      <p className="text-[11px] text-white/45 mb-1">In a live wallet transfers arrive automatically — this is for CLI/batch scenarios without a persistent connection</p>
       <p className="text-[11px] text-red-500 mb-1">Not yet implemented in wallet — will show "Unknown Intent"</p>
-      <p className="text-[11px] text-yellow-600 mb-4">Requires wallet approval</p>
+      <p className="text-[11px] text-amber-400 mb-4">Requires wallet approval</p>
 
-      <button onClick={execute} disabled={loading}
-        className="w-full py-2.5 bg-orange-500 hover:bg-orange-600 disabled:bg-gray-200 disabled:text-gray-400 text-white font-medium rounded-xl transition-colors cursor-pointer disabled:cursor-not-allowed">
+      <Button onClick={execute} disabled={loading} className="w-full">
         {loading ? 'Receiving...' : 'Receive Tokens'}
-      </button>
+      </Button>
 
       <ResultDisplay result={raw} error={error} />
     </div>

--- a/browser/src/components/intents/SendPanel.tsx
+++ b/browser/src/components/intents/SendPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { INTENT_ACTIONS } from '@unicitylabs/sphere-sdk/connect';
+import { Button, Input } from '@unicitylabs/sphere-ui';
 import { ResultDisplay } from '../ui/ResultDisplay';
 import { CoinSelect } from '../ui/CoinSelect';
 
@@ -36,31 +37,28 @@ export function SendPanel({ intent, query }: Props) {
   };
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-200 shadow-sm p-5">
+    <div className="admin-card p-5">
       <div className="flex items-center justify-between mb-1">
-        <h2 className="text-lg font-semibold text-gray-900">Send (L3)</h2>
-        <span className="text-[10px] font-mono text-orange-500 bg-orange-50 px-2 py-0.5 rounded">intent: send</span>
+        <h2 className="text-lg font-semibold text-white">Send (L3)</h2>
+        <span className="text-[10px] font-mono text-orange-400 bg-orange-500/10 px-2 py-0.5 rounded">intent: send</span>
       </div>
-      <p className="text-xs text-gray-400 mb-1">Transfer L3 tokens to a recipient</p>
-      <p className="text-[11px] text-yellow-600 mb-4">Requires wallet approval</p>
+      <p className="text-xs text-white/45 mb-1">Transfer L3 tokens to a recipient</p>
+      <p className="text-[11px] text-amber-400 mb-4">Requires wallet approval</p>
 
       <div className="space-y-3">
-        <input type="text" value={recipient} onChange={(e) => setRecipient(e.target.value)}
-          placeholder="Recipient (@nametag, DIRECT://..., pubkey)"
-          className="w-full px-3 py-2 border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500" />
+        <Input type="text" value={recipient} onChange={(e) => setRecipient(e.target.value)}
+          placeholder="Recipient (@nametag, DIRECT://..., pubkey)" />
         <div className="flex gap-2">
-          <input type="text" value={amount} onChange={(e) => setAmount(e.target.value)}
+          <Input type="text" value={amount} onChange={(e) => setAmount(e.target.value)}
             placeholder="Amount"
-            className="flex-1 px-3 py-2 border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500" />
+            className="flex-1" />
           <CoinSelect value={coinId} onChange={setCoinId} query={query} />
         </div>
-        <input type="text" value={memo} onChange={(e) => setMemo(e.target.value)}
-          placeholder="Memo (optional)"
-          className="w-full px-3 py-2 border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500" />
-        <button onClick={execute} disabled={loading || !recipient || !amount || !coinId}
-          className="w-full py-2.5 bg-orange-500 hover:bg-orange-600 disabled:bg-gray-200 disabled:text-gray-400 text-white font-medium rounded-xl transition-colors cursor-pointer disabled:cursor-not-allowed">
+        <Input type="text" value={memo} onChange={(e) => setMemo(e.target.value)}
+          placeholder="Memo (optional)" />
+        <Button onClick={execute} disabled={loading || !recipient || !amount || !coinId} className="w-full">
           {loading ? 'Sending...' : 'Send'}
-        </button>
+        </Button>
       </div>
 
       <ResultDisplay result={raw} error={error} />

--- a/browser/src/components/intents/SignMessagePanel.tsx
+++ b/browser/src/components/intents/SignMessagePanel.tsx
@@ -39,7 +39,7 @@ export function SignMessagePanel({ intent }: Props) {
 
       <div className="space-y-3">
         <Textarea value={message} onChange={(e) => setMessage(e.target.value)}
-          placeholder="Message to sign" rows={4} />
+          placeholder="Message to sign" rows={4} className="resize-none" />
         <Button onClick={execute} disabled={loading || !message} className="w-full">
           {loading ? 'Signing...' : 'Sign Message'}
         </Button>

--- a/browser/src/components/intents/SignMessagePanel.tsx
+++ b/browser/src/components/intents/SignMessagePanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { INTENT_ACTIONS } from '@unicitylabs/sphere-sdk/connect';
+import { Button, Textarea } from '@unicitylabs/sphere-ui';
 import { ResultDisplay } from '../ui/ResultDisplay';
 
 interface Props {
@@ -28,22 +29,20 @@ export function SignMessagePanel({ intent }: Props) {
   };
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-200 shadow-sm p-5">
+    <div className="admin-card p-5">
       <div className="flex items-center justify-between mb-1">
-        <h2 className="text-lg font-semibold text-gray-900">Sign Message</h2>
-        <span className="text-[10px] font-mono text-orange-500 bg-orange-50 px-2 py-0.5 rounded">intent: sign_message</span>
+        <h2 className="text-lg font-semibold text-white">Sign Message</h2>
+        <span className="text-[10px] font-mono text-orange-400 bg-orange-500/10 px-2 py-0.5 rounded">intent: sign_message</span>
       </div>
-      <p className="text-xs text-gray-400 mb-1">Sign an arbitrary message with wallet key (e.g. for authentication or proof of ownership)</p>
-      <p className="text-[11px] text-yellow-600 mb-4">Requires wallet approval</p>
+      <p className="text-xs text-white/45 mb-1">Sign an arbitrary message with wallet key (e.g. for authentication or proof of ownership)</p>
+      <p className="text-[11px] text-amber-400 mb-4">Requires wallet approval</p>
 
       <div className="space-y-3">
-        <textarea value={message} onChange={(e) => setMessage(e.target.value)}
-          placeholder="Message to sign" rows={4}
-          className="w-full px-3 py-2 border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500 resize-none" />
-        <button onClick={execute} disabled={loading || !message}
-          className="w-full py-2.5 bg-orange-500 hover:bg-orange-600 disabled:bg-gray-200 disabled:text-gray-400 text-white font-medium rounded-xl transition-colors cursor-pointer disabled:cursor-not-allowed">
+        <Textarea value={message} onChange={(e) => setMessage(e.target.value)}
+          placeholder="Message to sign" rows={4} />
+        <Button onClick={execute} disabled={loading || !message} className="w-full">
           {loading ? 'Signing...' : 'Sign Message'}
-        </button>
+        </Button>
       </div>
 
       <ResultDisplay result={raw} error={error} />

--- a/browser/src/components/layout/PageShell.tsx
+++ b/browser/src/components/layout/PageShell.tsx
@@ -47,8 +47,8 @@ function NavGroup({ title, color, items, active, onSelect }: {
           onClick={() => onSelect(item.key)}
           className={`w-full text-left px-3 py-1.5 text-sm cursor-pointer transition-colors ${
             active === item.key
-              ? 'bg-orange-50 text-orange-700 border-l-2 border-orange-500 font-medium'
-              : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900 border-l-2 border-transparent'
+              ? 'bg-orange-500/10 text-orange-400 border-l-2 border-orange-500 font-medium'
+              : 'text-white/55 hover:bg-white/6 hover:text-white border-l-2 border-transparent'
           }`}
         >
           {item.label}
@@ -60,11 +60,11 @@ function NavGroup({ title, color, items, active, onSelect }: {
 
 export function PageShell({ identity, onDisconnect, section, onSectionChange, children }: PageShellProps) {
   return (
-    <div className="flex flex-col h-screen bg-gray-50">
+    <div className="flex flex-col h-screen bg-(--bg-root)">
       <WalletHeader identity={identity} onDisconnect={onDisconnect} />
 
       {/* Mobile horizontal nav */}
-      <div className="lg:hidden border-b border-gray-200 bg-white overflow-x-auto">
+      <div className="lg:hidden border-b border-white/8 bg-(--bg-surface) overflow-x-auto">
         <div className="flex gap-1 px-3 py-2 min-w-max">
           {[...QUERIES, ...INTENTS, ...CHAT, ...EVENTS].map((item) => (
             <button
@@ -73,7 +73,7 @@ export function PageShell({ identity, onDisconnect, section, onSectionChange, ch
               className={`px-3 py-1.5 text-xs rounded-lg whitespace-nowrap cursor-pointer transition-colors ${
                 section === item.key
                   ? 'bg-orange-500 text-white font-medium'
-                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                  : 'bg-white/6 text-white/55 hover:bg-white/10'
               }`}
             >
               {item.label}
@@ -84,7 +84,7 @@ export function PageShell({ identity, onDisconnect, section, onSectionChange, ch
 
       <div className="flex flex-1 overflow-hidden">
         {/* Desktop sidebar */}
-        <aside className="hidden lg:block w-48 shrink-0 bg-white border-r border-gray-200 overflow-y-auto py-4">
+        <aside className="hidden lg:block w-48 shrink-0 bg-(--bg-surface) border-r border-white/8 overflow-y-auto py-4">
           <NavGroup title="Queries" color="text-blue-500" items={QUERIES} active={section} onSelect={onSectionChange} />
           <NavGroup title="Intents" color="text-orange-500" items={INTENTS} active={section} onSelect={onSectionChange} />
           <NavGroup title="Chat" color="text-green-500" items={CHAT} active={section} onSelect={onSectionChange} />

--- a/browser/src/components/layout/WalletHeader.tsx
+++ b/browser/src/components/layout/WalletHeader.tsx
@@ -1,4 +1,5 @@
 import type { PublicIdentity } from '@unicitylabs/sphere-sdk/connect';
+import { Button } from '@unicitylabs/sphere-ui';
 import { truncate } from '../../lib/format';
 
 interface WalletHeaderProps {
@@ -8,28 +9,25 @@ interface WalletHeaderProps {
 
 export function WalletHeader({ identity, onDisconnect }: WalletHeaderProps) {
   return (
-    <header className="bg-white border-b border-gray-200 px-4 py-3 flex items-center justify-between">
+    <header className="bg-(--bg-surface) border-b border-white/8 px-4 py-3 flex items-center justify-between">
       <div className="flex items-center gap-3">
-        <h1 className="text-lg font-bold text-gray-900">Sphere Connect</h1>
-        <span className="hidden sm:inline-block h-5 w-px bg-gray-200" />
+        <h1 className="text-lg font-bold text-white">Sphere Connect</h1>
+        <span className="hidden sm:inline-block h-5 w-px bg-white/8" />
         {identity.nametag && (
-          <span className="hidden sm:inline text-sm font-mono text-orange-600">@{identity.nametag}</span>
+          <span className="hidden sm:inline text-sm font-mono text-orange-400">@{identity.nametag}</span>
         )}
-        <span className="hidden md:inline text-xs font-mono text-gray-400">
+        <span className="hidden md:inline text-xs font-mono text-white/55">
           {truncate(identity.directAddress ?? identity.chainPubkey)}
         </span>
       </div>
       <div className="flex items-center gap-3">
-        <span className="inline-flex items-center gap-1.5 text-xs text-green-600">
+        <span className="inline-flex items-center gap-1.5 text-xs text-green-400">
           <span className="w-2 h-2 rounded-full bg-green-500" />
           Connected
         </span>
-        <button
-          onClick={onDisconnect}
-          className="text-sm text-red-500 hover:text-red-700 font-medium cursor-pointer"
-        >
+        <Button variant="secondary" onClick={onDisconnect}>
           Disconnect
-        </button>
+        </Button>
       </div>
     </header>
   );

--- a/browser/src/components/queries/AssetsPanel.tsx
+++ b/browser/src/components/queries/AssetsPanel.tsx
@@ -36,7 +36,7 @@ export function AssetsPanel({ query }: Props) {
     <div className="admin-card p-5">
       <div className="flex items-center justify-between mb-1">
         <h2 className="text-lg font-semibold text-white">Assets</h2>
-        <span className="text-[10px] font-mono text-blue-500 bg-blue-50 px-2 py-0.5 rounded">sphere_getAssets</span>
+        <span className="text-[10px] font-mono text-blue-400 bg-blue-500/15 px-2 py-0.5 rounded">sphere_getAssets</span>
       </div>
       <p className="text-xs text-white/45 mb-4">Full asset details with fiat values and 24h change</p>
 
@@ -46,7 +46,7 @@ export function AssetsPanel({ query }: Props) {
           placeholder="Filter by coinId (optional)"
           className="flex-1"
         />
-        <Button onClick={execute} disabled={loading} variant="secondary">
+        <Button onClick={execute} disabled={loading}>
           {loading ? '...' : 'Fetch'}
         </Button>
       </div>

--- a/browser/src/components/queries/AssetsPanel.tsx
+++ b/browser/src/components/queries/AssetsPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { RPC_METHODS } from '@unicitylabs/sphere-sdk/connect';
+import { Button, Input } from '@unicitylabs/sphere-ui';
 import { ResultDisplay } from '../ui/ResultDisplay';
 import { CoinBadge } from '../ui/CoinBadge';
 import { formatAmount, formatFiat, formatChange } from '../../lib/format';
@@ -32,23 +33,22 @@ export function AssetsPanel({ query }: Props) {
   };
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-200 shadow-sm p-5">
+    <div className="admin-card p-5">
       <div className="flex items-center justify-between mb-1">
-        <h2 className="text-lg font-semibold text-gray-900">Assets</h2>
+        <h2 className="text-lg font-semibold text-white">Assets</h2>
         <span className="text-[10px] font-mono text-blue-500 bg-blue-50 px-2 py-0.5 rounded">sphere_getAssets</span>
       </div>
-      <p className="text-xs text-gray-400 mb-4">Full asset details with fiat values and 24h change</p>
+      <p className="text-xs text-white/45 mb-4">Full asset details with fiat values and 24h change</p>
 
       <div className="flex gap-2 mb-3">
-        <input
+        <Input
           type="text" value={coinFilter} onChange={(e) => setCoinFilter(e.target.value)}
           placeholder="Filter by coinId (optional)"
-          className="flex-1 px-3 py-2 border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500"
+          className="flex-1"
         />
-        <button onClick={execute} disabled={loading}
-          className="px-5 py-2 bg-orange-500 hover:bg-orange-600 disabled:bg-gray-200 disabled:text-gray-400 text-white font-medium rounded-xl transition-colors cursor-pointer disabled:cursor-not-allowed text-sm">
+        <Button onClick={execute} disabled={loading} variant="secondary">
           {loading ? '...' : 'Fetch'}
-        </button>
+        </Button>
       </div>
 
       {assets.length > 0 && !error && (
@@ -56,20 +56,20 @@ export function AssetsPanel({ query }: Props) {
           {assets.map((a) => {
             const change = formatChange(a.change24h);
             return (
-              <div key={a.coinId} className="p-3 bg-gray-50 rounded-xl">
+              <div key={a.coinId} className="p-3 bg-white/3 rounded-xl">
                 <div className="flex items-center justify-between mb-1">
                   <CoinBadge symbol={a.symbol} iconUrl={a.iconUrl} />
                   <div className="text-right">
-                    <div className="font-mono text-sm text-gray-900">{formatAmount(a.totalAmount, a.decimals)}</div>
-                    <div className="text-xs text-gray-400">{formatFiat(a.fiatValueUsd)}</div>
+                    <div className="font-mono text-sm text-white">{formatAmount(a.totalAmount, a.decimals)}</div>
+                    <div className="text-xs text-white/45">{formatFiat(a.fiatValueUsd)}</div>
                   </div>
                 </div>
-                <div className="flex items-center justify-between text-xs text-gray-500 mt-1">
+                <div className="flex items-center justify-between text-xs text-white/45 mt-1">
                   <span>{a.tokenCount} token{a.tokenCount !== 1 ? 's' : ''} ({a.confirmedTokenCount} confirmed)</span>
                   <span className={change.color}>{change.text}</span>
                 </div>
                 {(a.unconfirmedAmount && a.unconfirmedAmount !== '0') && (
-                  <div className="text-xs text-yellow-600 mt-1">
+                  <div className="text-xs text-amber-400 mt-1">
                     Unconfirmed: {formatAmount(a.unconfirmedAmount, a.decimals)}
                   </div>
                 )}

--- a/browser/src/components/queries/BalancePanel.tsx
+++ b/browser/src/components/queries/BalancePanel.tsx
@@ -45,8 +45,8 @@ export function BalancePanel({ query }: Props) {
       <div className="flex items-center justify-between mb-1">
         <h2 className="text-lg font-semibold text-white">Balance</h2>
         <div className="flex gap-1">
-          <span className="text-[10px] font-mono text-blue-500 bg-blue-50 px-2 py-0.5 rounded">getBalance</span>
-          <span className="text-[10px] font-mono text-blue-500 bg-blue-50 px-2 py-0.5 rounded">getFiatBalance</span>
+          <span className="text-[10px] font-mono text-blue-400 bg-blue-500/15 px-2 py-0.5 rounded">getBalance</span>
+          <span className="text-[10px] font-mono text-blue-400 bg-blue-500/15 px-2 py-0.5 rounded">getFiatBalance</span>
         </div>
       </div>
       <p className="text-xs text-white/45 mb-4">Coin balances + total fiat value</p>

--- a/browser/src/components/queries/BalancePanel.tsx
+++ b/browser/src/components/queries/BalancePanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { RPC_METHODS } from '@unicitylabs/sphere-sdk/connect';
+import { Button } from '@unicitylabs/sphere-ui';
 import { ResultDisplay } from '../ui/ResultDisplay';
 import { CoinBadge } from '../ui/CoinBadge';
 import { formatFiat } from '../../lib/format';
@@ -40,34 +41,33 @@ export function BalancePanel({ query }: Props) {
   };
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-200 shadow-sm p-5">
+    <div className="admin-card p-5">
       <div className="flex items-center justify-between mb-1">
-        <h2 className="text-lg font-semibold text-gray-900">Balance</h2>
+        <h2 className="text-lg font-semibold text-white">Balance</h2>
         <div className="flex gap-1">
           <span className="text-[10px] font-mono text-blue-500 bg-blue-50 px-2 py-0.5 rounded">getBalance</span>
           <span className="text-[10px] font-mono text-blue-500 bg-blue-50 px-2 py-0.5 rounded">getFiatBalance</span>
         </div>
       </div>
-      <p className="text-xs text-gray-400 mb-4">Coin balances + total fiat value</p>
+      <p className="text-xs text-white/45 mb-4">Coin balances + total fiat value</p>
 
-      <button onClick={execute} disabled={loading}
-        className="w-full py-2.5 bg-orange-500 hover:bg-orange-600 disabled:bg-gray-200 disabled:text-gray-400 text-white font-medium rounded-xl transition-colors cursor-pointer disabled:cursor-not-allowed">
+      <Button onClick={execute} disabled={loading} className="w-full">
         {loading ? 'Loading...' : 'Fetch Balance'}
-      </button>
+      </Button>
 
       {(balances.length > 0 || fiat !== null) && !error && (
         <div className="mt-4">
           {fiat !== null && (
-            <div className="text-center py-3 mb-3 bg-orange-50 rounded-xl">
-              <div className="text-2xl font-bold text-gray-900">{formatFiat(fiat)}</div>
-              <div className="text-xs text-gray-400">Total Portfolio Value</div>
+            <div className="text-center py-3 mb-3 bg-orange-500/10 rounded-xl">
+              <div className="text-2xl font-bold text-white">{formatFiat(fiat)}</div>
+              <div className="text-xs text-white/45">Total Portfolio Value</div>
             </div>
           )}
           <div className="space-y-2">
             {balances.map((b) => (
-              <div key={b.coinId} className="flex items-center justify-between py-2 px-3 bg-gray-50 rounded-xl">
+              <div key={b.coinId} className="flex items-center justify-between py-2 px-3 bg-white/3 rounded-xl">
                 <CoinBadge symbol={b.symbol ?? b.coinId} size="sm" />
-                <span className="font-mono text-sm text-gray-900">{b.totalAmount}</span>
+                <span className="font-mono text-sm text-white">{b.totalAmount}</span>
               </div>
             ))}
           </div>

--- a/browser/src/components/queries/HistoryPanel.tsx
+++ b/browser/src/components/queries/HistoryPanel.tsx
@@ -77,7 +77,7 @@ export function HistoryPanel({ query }: Props) {
     <div className="admin-card p-5">
       <div className="flex items-center justify-between mb-1">
         <h2 className="text-lg font-semibold text-white">History</h2>
-        <span className="text-[10px] font-mono text-blue-500 bg-blue-50 px-2 py-0.5 rounded">sphere_getHistory</span>
+        <span className="text-[10px] font-mono text-blue-400 bg-blue-500/15 px-2 py-0.5 rounded">sphere_getHistory</span>
       </div>
       <p className="text-xs text-white/45 mb-4">Transaction history with paginated table view</p>
 
@@ -177,7 +177,7 @@ function renderCounterparty(e: HistoryEntry): ReactNode {
   if (e.type === 'SENT' && e.recipientNametag) return <span>to @{e.recipientNametag}</span>;
   if (e.type === 'RECEIVED' && e.senderNametag) return <span>from @{e.senderNametag}</span>;
   if (e.senderPubkey) return <span className="font-mono text-xs">{truncate(e.senderPubkey, 6, 4)}</span>;
-  return <span className="text-white/8">—</span>;
+  return <span className="text-white/30">—</span>;
 }
 
 // ── Pagination ───────────────────────────────────────────────────────────────

--- a/browser/src/components/queries/HistoryPanel.tsx
+++ b/browser/src/components/queries/HistoryPanel.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, type ReactNode } from 'react';
 import { RPC_METHODS } from '@unicitylabs/sphere-sdk/connect';
+import { Button, Select } from '@unicitylabs/sphere-ui';
 import { ResultDisplay } from '../ui/ResultDisplay';
 import { StatusBadge } from '../ui/StatusBadge';
 import { CoinBadge } from '../ui/CoinBadge';
@@ -73,17 +74,16 @@ export function HistoryPanel({ query }: Props) {
   const pageEntries = entries.slice(safePage * pageSize, safePage * pageSize + pageSize);
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-200 shadow-sm p-5">
+    <div className="admin-card p-5">
       <div className="flex items-center justify-between mb-1">
-        <h2 className="text-lg font-semibold text-gray-900">History</h2>
+        <h2 className="text-lg font-semibold text-white">History</h2>
         <span className="text-[10px] font-mono text-blue-500 bg-blue-50 px-2 py-0.5 rounded">sphere_getHistory</span>
       </div>
-      <p className="text-xs text-gray-400 mb-4">Transaction history with paginated table view</p>
+      <p className="text-xs text-white/45 mb-4">Transaction history with paginated table view</p>
 
-      <button onClick={execute} disabled={loading}
-        className="w-full py-2.5 bg-orange-500 hover:bg-orange-600 disabled:bg-gray-200 disabled:text-gray-400 text-white font-medium rounded-xl transition-colors cursor-pointer disabled:cursor-not-allowed">
+      <Button onClick={execute} disabled={loading} className="w-full">
         {loading ? 'Loading...' : 'Fetch History'}
-      </button>
+      </Button>
 
       {entries.length > 0 && !error && (
         <>
@@ -110,10 +110,10 @@ export function HistoryPanel({ query }: Props) {
 function SummaryCards({ stats }: { stats: { total: number; sent: number; received: number; other: number } }) {
   return (
     <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mt-4">
-      <StatCard label="Total" value={stats.total} accent="bg-gray-50 text-gray-900" />
-      <StatCard label="Sent" value={stats.sent} accent="bg-orange-50 text-orange-700" />
-      <StatCard label="Received" value={stats.received} accent="bg-green-50 text-green-700" />
-      <StatCard label="Other" value={stats.other} accent="bg-gray-50 text-gray-500" />
+      <StatCard label="Total" value={stats.total} accent="bg-white/3 text-white" />
+      <StatCard label="Sent" value={stats.sent} accent="bg-orange-500/10 text-orange-400" />
+      <StatCard label="Received" value={stats.received} accent="bg-green-500/15 text-green-400" />
+      <StatCard label="Other" value={stats.other} accent="bg-white/3 text-white/45" />
     </div>
   );
 }
@@ -131,9 +131,9 @@ function StatCard({ label, value, accent }: { label: string; value: number; acce
 
 function HistoryTable({ entries, coinMap }: { entries: HistoryEntry[]; coinMap: Record<string, CoinMeta> }) {
   return (
-    <div className="mt-4 overflow-x-auto rounded-xl border border-gray-100">
+    <div className="mt-4 overflow-x-auto rounded-xl border border-white/8">
       <table className="w-full text-sm">
-        <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+        <thead className="bg-white/3 text-xs uppercase tracking-wide text-white/45">
           <tr>
             <th className="text-left px-3 py-2 font-medium">Type</th>
             <th className="text-right px-3 py-2 font-medium">Amount</th>
@@ -142,26 +142,26 @@ function HistoryTable({ entries, coinMap }: { entries: HistoryEntry[]; coinMap: 
             <th className="text-right px-3 py-2 font-medium">Time</th>
           </tr>
         </thead>
-        <tbody className="divide-y divide-gray-100">
+        <tbody className="divide-y divide-white/8">
           {entries.map((e, i) => {
             const meta = coinMap[e.coinId];
             const decimals = meta?.decimals ?? 0;
             const symbol = meta?.symbol ?? e.symbol ?? e.coinId;
             const iconUrl = meta?.iconUrl;
             const sign = e.type === 'SENT' ? '-' : e.type === 'RECEIVED' ? '+' : '';
-            const amountColor = e.type === 'SENT' ? 'text-orange-700' : e.type === 'RECEIVED' ? 'text-green-700' : 'text-gray-700';
+            const amountColor = e.type === 'SENT' ? 'text-orange-400' : e.type === 'RECEIVED' ? 'text-green-400' : 'text-white/70';
 
             return (
-              <tr key={e.id ?? i} className="hover:bg-gray-50">
+              <tr key={e.id ?? i} className="hover:bg-white/3">
                 <td className="px-3 py-2"><StatusBadge status={e.type} /></td>
                 <td className={`px-3 py-2 text-right font-mono ${amountColor}`}>
                   {sign}{formatAmount(e.amount, decimals)}
                 </td>
                 <td className="px-3 py-2"><CoinBadge symbol={symbol} iconUrl={iconUrl} size="sm" /></td>
-                <td className="px-3 py-2 text-gray-600">
+                <td className="px-3 py-2 text-white/55">
                   {renderCounterparty(e)}
                 </td>
-                <td className="px-3 py-2 text-right text-xs text-gray-400 whitespace-nowrap">
+                <td className="px-3 py-2 text-right text-xs text-white/45 whitespace-nowrap">
                   {relativeTime(e.timestamp)}
                 </td>
               </tr>
@@ -177,7 +177,7 @@ function renderCounterparty(e: HistoryEntry): ReactNode {
   if (e.type === 'SENT' && e.recipientNametag) return <span>to @{e.recipientNametag}</span>;
   if (e.type === 'RECEIVED' && e.senderNametag) return <span>from @{e.senderNametag}</span>;
   if (e.senderPubkey) return <span className="font-mono text-xs">{truncate(e.senderPubkey, 6, 4)}</span>;
-  return <span className="text-gray-300">—</span>;
+  return <span className="text-white/8">—</span>;
 }
 
 // ── Pagination ───────────────────────────────────────────────────────────────
@@ -196,18 +196,17 @@ function Pagination({
   const end = Math.min((page + 1) * pageSize, totalCount);
 
   return (
-    <div className="flex flex-wrap items-center justify-between gap-2 mt-3 text-xs text-gray-500">
+    <div className="flex flex-wrap items-center justify-between gap-2 mt-3 text-xs text-white/45">
       <div className="flex items-center gap-2">
         <span>Rows per page:</span>
-        <select
+        <Select
           value={pageSize}
           onChange={(e) => onPageSizeChange(Number(e.target.value))}
-          className="border border-gray-200 rounded-md px-2 py-1 bg-white focus:outline-none focus:ring-2 focus:ring-orange-500/30"
         >
           {PAGE_SIZE_OPTIONS.map((s) => (
             <option key={s} value={s}>{s}</option>
           ))}
-        </select>
+        </Select>
       </div>
 
       <div className="flex items-center gap-3">
@@ -216,7 +215,7 @@ function Pagination({
           <button
             onClick={() => onPageChange(page - 1)}
             disabled={page <= 0}
-            className="px-2 py-1 rounded-md border border-gray-200 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+            className="px-2 py-1 rounded-md border border-white/8 hover:bg-white/3 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
           >
             ← Prev
           </button>
@@ -224,7 +223,7 @@ function Pagination({
           <button
             onClick={() => onPageChange(page + 1)}
             disabled={page >= totalPages - 1}
-            className="px-2 py-1 rounded-md border border-gray-200 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+            className="px-2 py-1 rounded-md border border-white/8 hover:bg-white/3 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
           >
             Next →
           </button>

--- a/browser/src/components/queries/IdentityPanel.tsx
+++ b/browser/src/components/queries/IdentityPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { RPC_METHODS } from '@unicitylabs/sphere-sdk/connect';
+import { Button } from '@unicitylabs/sphere-ui';
 import { ResultDisplay } from '../ui/ResultDisplay';
 
 interface Props {
@@ -33,34 +34,33 @@ export function IdentityPanel({ query }: Props) {
   };
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-200 shadow-sm p-5">
+    <div className="admin-card p-5">
       <div className="flex items-center justify-between mb-1">
-        <h2 className="text-lg font-semibold text-gray-900">Identity</h2>
+        <h2 className="text-lg font-semibold text-white">Identity</h2>
         <span className="text-[10px] font-mono text-blue-500 bg-blue-50 px-2 py-0.5 rounded">sphere_getIdentity</span>
       </div>
-      <p className="text-xs text-gray-400 mb-4">Read wallet identity (pubkey, addresses, nametag)</p>
+      <p className="text-xs text-white/45 mb-4">Read wallet identity (pubkey, addresses, nametag)</p>
 
-      <button onClick={execute} disabled={loading}
-        className="w-full py-2.5 bg-orange-500 hover:bg-orange-600 disabled:bg-gray-200 disabled:text-gray-400 text-white font-medium rounded-xl transition-colors cursor-pointer disabled:cursor-not-allowed">
+      <Button onClick={execute} disabled={loading} className="w-full">
         {loading ? 'Loading...' : 'Get Identity'}
-      </button>
+      </Button>
 
       {data && !error && (
         <div className="mt-4 space-y-3">
           {data.nametag && (
             <div className="flex items-center gap-2">
-              <span className="text-xs text-gray-400 w-24 shrink-0">Nametag</span>
-              <span className="font-mono text-sm text-orange-600">@{data.nametag}</span>
+              <span className="text-xs text-white/45 w-24 shrink-0">Nametag</span>
+              <span className="font-mono text-sm text-orange-400">@{data.nametag}</span>
             </div>
           )}
           <div className="flex items-start gap-2">
-            <span className="text-xs text-gray-400 w-24 shrink-0">Chain Pubkey</span>
-            <span className="font-mono text-xs text-gray-700 break-all">{data.chainPubkey}</span>
+            <span className="text-xs text-white/45 w-24 shrink-0">Chain Pubkey</span>
+            <span className="font-mono text-xs text-white/70 break-all">{data.chainPubkey}</span>
           </div>
           {data.directAddress && (
             <div className="flex items-start gap-2">
-              <span className="text-xs text-gray-400 w-24 shrink-0">Direct Addr</span>
-              <span className="font-mono text-xs text-gray-700 break-all">{data.directAddress}</span>
+              <span className="text-xs text-white/45 w-24 shrink-0">Direct Addr</span>
+              <span className="font-mono text-xs text-white/70 break-all">{data.directAddress}</span>
             </div>
           )}
         </div>

--- a/browser/src/components/queries/IdentityPanel.tsx
+++ b/browser/src/components/queries/IdentityPanel.tsx
@@ -37,7 +37,7 @@ export function IdentityPanel({ query }: Props) {
     <div className="admin-card p-5">
       <div className="flex items-center justify-between mb-1">
         <h2 className="text-lg font-semibold text-white">Identity</h2>
-        <span className="text-[10px] font-mono text-blue-500 bg-blue-50 px-2 py-0.5 rounded">sphere_getIdentity</span>
+        <span className="text-[10px] font-mono text-blue-400 bg-blue-500/15 px-2 py-0.5 rounded">sphere_getIdentity</span>
       </div>
       <p className="text-xs text-white/45 mb-4">Read wallet identity (pubkey, addresses, nametag)</p>
 

--- a/browser/src/components/queries/ResolvePanel.tsx
+++ b/browser/src/components/queries/ResolvePanel.tsx
@@ -36,7 +36,7 @@ export function ResolvePanel({ query }: Props) {
     <div className="admin-card p-5">
       <div className="flex items-center justify-between mb-1">
         <h2 className="text-lg font-semibold text-white">Resolve</h2>
-        <span className="text-[10px] font-mono text-blue-500 bg-blue-50 px-2 py-0.5 rounded">sphere_resolve</span>
+        <span className="text-[10px] font-mono text-blue-400 bg-blue-500/15 px-2 py-0.5 rounded">sphere_resolve</span>
       </div>
       <p className="text-xs text-white/45 mb-4">Resolve @nametag, address, or pubkey to peer info</p>
 
@@ -45,7 +45,7 @@ export function ResolvePanel({ query }: Props) {
           placeholder="@nametag, DIRECT://..., pubkey"
           className="flex-1"
           onKeyDown={(e) => e.key === 'Enter' && execute()} />
-        <Button onClick={execute} disabled={loading || !identifier} variant="secondary">
+        <Button onClick={execute} disabled={loading || !identifier}>
           {loading ? '...' : 'Resolve'}
         </Button>
       </div>

--- a/browser/src/components/queries/ResolvePanel.tsx
+++ b/browser/src/components/queries/ResolvePanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { RPC_METHODS } from '@unicitylabs/sphere-sdk/connect';
+import { Button, Input } from '@unicitylabs/sphere-ui';
 import { ResultDisplay } from '../ui/ResultDisplay';
 import type { PeerInfo } from '../../lib/types';
 
@@ -32,37 +33,36 @@ export function ResolvePanel({ query }: Props) {
   };
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-200 shadow-sm p-5">
+    <div className="admin-card p-5">
       <div className="flex items-center justify-between mb-1">
-        <h2 className="text-lg font-semibold text-gray-900">Resolve</h2>
+        <h2 className="text-lg font-semibold text-white">Resolve</h2>
         <span className="text-[10px] font-mono text-blue-500 bg-blue-50 px-2 py-0.5 rounded">sphere_resolve</span>
       </div>
-      <p className="text-xs text-gray-400 mb-4">Resolve @nametag, address, or pubkey to peer info</p>
+      <p className="text-xs text-white/45 mb-4">Resolve @nametag, address, or pubkey to peer info</p>
 
       <div className="flex gap-2 mb-3">
-        <input type="text" value={identifier} onChange={(e) => setIdentifier(e.target.value)}
+        <Input type="text" value={identifier} onChange={(e) => setIdentifier(e.target.value)}
           placeholder="@nametag, DIRECT://..., pubkey"
-          className="flex-1 px-3 py-2 border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500"
+          className="flex-1"
           onKeyDown={(e) => e.key === 'Enter' && execute()} />
-        <button onClick={execute} disabled={loading || !identifier}
-          className="px-5 py-2 bg-orange-500 hover:bg-orange-600 disabled:bg-gray-200 disabled:text-gray-400 text-white font-medium rounded-xl transition-colors cursor-pointer disabled:cursor-not-allowed text-sm">
+        <Button onClick={execute} disabled={loading || !identifier} variant="secondary">
           {loading ? '...' : 'Resolve'}
-        </button>
+        </Button>
       </div>
 
       {peer && !error && (
         <div className="mt-4 space-y-2 text-sm">
           {peer.nametag && (
-            <div className="flex gap-2"><span className="text-gray-400 w-28 shrink-0">Nametag</span><span className="font-mono text-orange-600">@{peer.nametag}</span></div>
+            <div className="flex gap-2"><span className="text-white/45 w-28 shrink-0">Nametag</span><span className="font-mono text-orange-400">@{peer.nametag}</span></div>
           )}
           {peer.chainPubkey && (
-            <div className="flex gap-2"><span className="text-gray-400 w-28 shrink-0">Chain Pubkey</span><span className="font-mono text-xs text-gray-700 break-all">{peer.chainPubkey}</span></div>
+            <div className="flex gap-2"><span className="text-white/45 w-28 shrink-0">Chain Pubkey</span><span className="font-mono text-xs text-white/70 break-all">{peer.chainPubkey}</span></div>
           )}
           {peer.directAddress && (
-            <div className="flex gap-2"><span className="text-gray-400 w-28 shrink-0">Direct Addr</span><span className="font-mono text-xs text-gray-700 break-all">{peer.directAddress}</span></div>
+            <div className="flex gap-2"><span className="text-white/45 w-28 shrink-0">Direct Addr</span><span className="font-mono text-xs text-white/70 break-all">{peer.directAddress}</span></div>
           )}
           {peer.transportPubkey && (
-            <div className="flex gap-2"><span className="text-gray-400 w-28 shrink-0">Transport Key</span><span className="font-mono text-xs text-gray-700 break-all">{peer.transportPubkey}</span></div>
+            <div className="flex gap-2"><span className="text-white/45 w-28 shrink-0">Transport Key</span><span className="font-mono text-xs text-white/70 break-all">{peer.transportPubkey}</span></div>
           )}
         </div>
       )}

--- a/browser/src/components/queries/TokensPanel.tsx
+++ b/browser/src/components/queries/TokensPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { RPC_METHODS } from '@unicitylabs/sphere-sdk/connect';
+import { Button, Input } from '@unicitylabs/sphere-ui';
 import { ResultDisplay } from '../ui/ResultDisplay';
 import { CoinBadge } from '../ui/CoinBadge';
 import { StatusBadge } from '../ui/StatusBadge';
@@ -33,37 +34,36 @@ export function TokensPanel({ query }: Props) {
   };
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-200 shadow-sm p-5">
+    <div className="admin-card p-5">
       <div className="flex items-center justify-between mb-1">
-        <h2 className="text-lg font-semibold text-gray-900">Tokens</h2>
+        <h2 className="text-lg font-semibold text-white">Tokens</h2>
         <span className="text-[10px] font-mono text-blue-500 bg-blue-50 px-2 py-0.5 rounded">sphere_getTokens</span>
       </div>
-      <p className="text-xs text-gray-400 mb-4">Individual token list with status</p>
+      <p className="text-xs text-white/45 mb-4">Individual token list with status</p>
 
       <div className="flex gap-2 mb-3">
-        <input type="text" value={coinFilter} onChange={(e) => setCoinFilter(e.target.value)}
+        <Input type="text" value={coinFilter} onChange={(e) => setCoinFilter(e.target.value)}
           placeholder="Filter by coinId (optional)"
-          className="flex-1 px-3 py-2 border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500" />
-        <button onClick={execute} disabled={loading}
-          className="px-5 py-2 bg-orange-500 hover:bg-orange-600 disabled:bg-gray-200 disabled:text-gray-400 text-white font-medium rounded-xl transition-colors cursor-pointer disabled:cursor-not-allowed text-sm">
+          className="flex-1" />
+        <Button onClick={execute} disabled={loading} variant="secondary">
           {loading ? '...' : 'Fetch'}
-        </button>
+        </Button>
       </div>
 
       {tokens.length > 0 && !error && (
         <div className="mt-4 space-y-2">
           {tokens.map((t) => (
-            <div key={t.id} className="p-3 bg-gray-50 rounded-xl flex items-center justify-between">
+            <div key={t.id} className="p-3 bg-white/3 rounded-xl flex items-center justify-between">
               <div className="flex items-center gap-3">
                 <CoinBadge symbol={t.symbol} iconUrl={t.iconUrl} size="sm" />
                 <div>
-                  <div className="font-mono text-sm text-gray-900">{formatAmount(t.amount, t.decimals)}</div>
-                  <div className="text-[11px] text-gray-400 font-mono">{truncate(t.id, 10, 6)}</div>
+                  <div className="font-mono text-sm text-white">{formatAmount(t.amount, t.decimals)}</div>
+                  <div className="text-[11px] text-white/45 font-mono">{truncate(t.id, 10, 6)}</div>
                 </div>
               </div>
               <div className="text-right">
                 <StatusBadge status={t.status} />
-                <div className="text-[11px] text-gray-400 mt-1">{relativeTime(t.updatedAt)}</div>
+                <div className="text-[11px] text-white/45 mt-1">{relativeTime(t.updatedAt)}</div>
               </div>
             </div>
           ))}

--- a/browser/src/components/queries/TokensPanel.tsx
+++ b/browser/src/components/queries/TokensPanel.tsx
@@ -37,7 +37,7 @@ export function TokensPanel({ query }: Props) {
     <div className="admin-card p-5">
       <div className="flex items-center justify-between mb-1">
         <h2 className="text-lg font-semibold text-white">Tokens</h2>
-        <span className="text-[10px] font-mono text-blue-500 bg-blue-50 px-2 py-0.5 rounded">sphere_getTokens</span>
+        <span className="text-[10px] font-mono text-blue-400 bg-blue-500/15 px-2 py-0.5 rounded">sphere_getTokens</span>
       </div>
       <p className="text-xs text-white/45 mb-4">Individual token list with status</p>
 
@@ -45,7 +45,7 @@ export function TokensPanel({ query }: Props) {
         <Input type="text" value={coinFilter} onChange={(e) => setCoinFilter(e.target.value)}
           placeholder="Filter by coinId (optional)"
           className="flex-1" />
-        <Button onClick={execute} disabled={loading} variant="secondary">
+        <Button onClick={execute} disabled={loading}>
           {loading ? '...' : 'Fetch'}
         </Button>
       </div>

--- a/browser/src/components/ui/CoinBadge.tsx
+++ b/browser/src/components/ui/CoinBadge.tsx
@@ -1,10 +1,10 @@
 const COLORS = [
-  'bg-orange-100 text-orange-700',
-  'bg-blue-100 text-blue-700',
-  'bg-green-100 text-green-700',
-  'bg-purple-100 text-purple-700',
-  'bg-pink-100 text-pink-700',
-  'bg-teal-100 text-teal-700',
+  'bg-orange-500/15 text-orange-400',
+  'bg-blue-500/15 text-blue-400',
+  'bg-green-500/15 text-green-400',
+  'bg-purple-500/15 text-purple-400',
+  'bg-pink-500/15 text-pink-400',
+  'bg-teal-500/15 text-teal-400',
 ];
 
 function colorFor(symbol: string): string {
@@ -31,7 +31,7 @@ export function CoinBadge({ symbol, iconUrl, size = 'md' }: CoinBadgeProps) {
           {symbol.charAt(0)}
         </span>
       )}
-      <span className="font-semibold text-gray-800">{symbol}</span>
+      <span className="font-semibold text-white">{symbol}</span>
     </span>
   );
 }

--- a/browser/src/components/ui/CoinSelect.tsx
+++ b/browser/src/components/ui/CoinSelect.tsx
@@ -47,7 +47,7 @@ export function CoinSelect({ value, onChange, query }: CoinSelectProps) {
 
   if (!loaded) {
     return (
-      <div className="w-36 px-3 py-2 border border-gray-200 rounded-xl text-sm text-gray-400 bg-gray-50">
+      <div className="w-36 px-3 py-2 border border-white/8 rounded-xl text-sm text-white/45 bg-white/3">
         Loading...
       </div>
     );
@@ -57,46 +57,46 @@ export function CoinSelect({ value, onChange, query }: CoinSelectProps) {
     return (
       <input type="text" value={value} onChange={(e) => onChange(e.target.value)}
         placeholder="Coin ID"
-        className="w-36 px-3 py-2 border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500" />
+        className="w-36 px-3 py-2 border border-white/8 rounded-xl text-sm text-white bg-white/3 focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500" />
     );
   }
 
   return (
     <div ref={ref} className="relative w-44">
       <button type="button" onClick={() => setOpen(!open)}
-        className="w-full flex items-center gap-2 px-3 py-2 border border-gray-200 rounded-xl text-sm bg-white hover:bg-gray-50 cursor-pointer focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500 transition-colors">
+        className="w-full flex items-center gap-2 px-3 py-2 border border-white/8 rounded-xl text-sm bg-white/3 hover:bg-white/6 cursor-pointer focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500 transition-colors">
         {selected ? (
           <>
             <CoinIcon symbol={selected.symbol} iconUrl={selected.iconUrl} />
-            <span className="font-semibold text-gray-800">{selected.symbol}</span>
-            <span className="text-gray-400 text-xs ml-auto truncate">
+            <span className="font-semibold text-white">{selected.symbol}</span>
+            <span className="text-white/45 text-xs ml-auto truncate">
               {formatAmount(selected.totalAmount, selected.decimals)}
             </span>
           </>
         ) : (
-          <span className="text-gray-400">Select coin</span>
+          <span className="text-white/45">Select coin</span>
         )}
-        <svg className={`w-3.5 h-3.5 text-gray-400 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
+        <svg className={`w-3.5 h-3.5 text-white/45 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
           fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
           <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
         </svg>
       </button>
 
       {open && (
-        <div className="absolute z-50 mt-1 w-full bg-white border border-gray-200 rounded-xl shadow-lg overflow-hidden">
+        <div className="absolute z-50 mt-1 w-full bg-(--bg-elevated) border border-white/8 rounded-xl shadow-lg overflow-hidden">
           {coins.map((coin) => (
             <button key={coin.coinId} type="button"
               onClick={() => { onChange(coin.coinId); setOpen(false); }}
               className={`w-full flex items-center gap-2 px-3 py-2.5 text-sm cursor-pointer transition-colors ${
-                coin.coinId === value ? 'bg-orange-50' : 'hover:bg-gray-50'
+                coin.coinId === value ? 'bg-orange-500/15' : 'hover:bg-white/6'
               }`}>
               <CoinIcon symbol={coin.symbol} iconUrl={coin.iconUrl} />
               <div className="flex-1 text-left">
-                <div className="font-semibold text-gray-800">{coin.symbol}</div>
-                <div className="text-[11px] text-gray-400">{coin.name}</div>
+                <div className="font-semibold text-white">{coin.symbol}</div>
+                <div className="text-[11px] text-white/45">{coin.name}</div>
               </div>
               <div className="text-right">
-                <div className="text-xs font-mono text-gray-600">{formatAmount(coin.totalAmount, coin.decimals)}</div>
+                <div className="text-xs font-mono text-white/55">{formatAmount(coin.totalAmount, coin.decimals)}</div>
               </div>
             </button>
           ))}
@@ -107,10 +107,10 @@ export function CoinSelect({ value, onChange, query }: CoinSelectProps) {
 }
 
 const COLORS = [
-  'bg-orange-100 text-orange-700',
-  'bg-blue-100 text-blue-700',
-  'bg-green-100 text-green-700',
-  'bg-purple-100 text-purple-700',
+  'bg-orange-500/15 text-orange-400',
+  'bg-blue-500/15 text-blue-400',
+  'bg-green-500/15 text-green-400',
+  'bg-purple-500/15 text-purple-400',
 ];
 
 function CoinIcon({ symbol, iconUrl }: { symbol: string; iconUrl?: string | null }) {

--- a/browser/src/components/ui/ResultDisplay.tsx
+++ b/browser/src/components/ui/ResultDisplay.tsx
@@ -20,7 +20,7 @@ export function ResultDisplay({ result, error }: ResultDisplayProps) {
 
   if (error) {
     return (
-      <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-xl text-sm text-red-700">
+      <div className="mt-4 p-3 rounded-xl text-sm bg-red-500/10 border border-red-500/20 text-red-400">
         {error}
       </div>
     );
@@ -29,15 +29,15 @@ export function ResultDisplay({ result, error }: ResultDisplayProps) {
   return (
     <div className="mt-4">
       <div className="flex items-center justify-between mb-1">
-        <span className="text-xs font-medium text-gray-500">Result</span>
+        <span className="text-xs font-medium text-white/45">Result</span>
         <button
           onClick={handleCopy}
-          className="text-xs text-gray-400 hover:text-gray-600 cursor-pointer"
+          className="text-xs text-white/45 hover:text-white cursor-pointer transition-colors"
         >
           {copied ? 'Copied!' : 'Copy JSON'}
         </button>
       </div>
-      <pre className="p-3 bg-gray-50 border border-gray-200 rounded-xl text-xs text-gray-700 overflow-auto max-h-64">
+      <pre className="p-3 rounded-xl text-xs overflow-auto max-h-64 font-mono bg-white/3 border border-white/8 text-white/70">
         {json}
       </pre>
     </div>

--- a/browser/src/components/ui/StatusBadge.tsx
+++ b/browser/src/components/ui/StatusBadge.tsx
@@ -1,19 +1,19 @@
-const STYLES: Record<string, string> = {
-  confirmed: 'bg-green-100 text-green-700',
-  received: 'bg-green-100 text-green-700',
-  RECEIVED: 'bg-green-100 text-green-700',
-  completed: 'bg-green-100 text-green-700',
-  receive: 'bg-green-100 text-green-700',
-  pending: 'bg-yellow-100 text-yellow-700',
-  submitted: 'bg-yellow-100 text-yellow-700',
-  transferring: 'bg-blue-100 text-blue-700',
-  delivered: 'bg-blue-100 text-blue-700',
-  SENT: 'bg-red-100 text-red-700',
-  send: 'bg-red-100 text-red-700',
-  spent: 'bg-gray-100 text-gray-500',
-  invalid: 'bg-red-100 text-red-700',
-  failed: 'bg-red-100 text-red-700',
-  MINT: 'bg-purple-100 text-purple-700',
+const STATUS_BADGE: Record<string, string> = {
+  confirmed:    'badge-green',
+  received:     'badge-green',
+  RECEIVED:     'badge-green',
+  completed:    'badge-green',
+  receive:      'badge-green',
+  pending:      'badge-yellow',
+  submitted:    'badge-yellow',
+  transferring: 'badge-blue',
+  delivered:    'badge-blue',
+  SENT:         'badge-red',
+  send:         'badge-red',
+  spent:        'badge-gray',
+  invalid:      'badge-red',
+  failed:       'badge-red',
+  MINT:         'badge-purple',
 };
 
 interface StatusBadgeProps {
@@ -21,10 +21,5 @@ interface StatusBadgeProps {
 }
 
 export function StatusBadge({ status }: StatusBadgeProps) {
-  const style = STYLES[status] ?? 'bg-gray-100 text-gray-600';
-  return (
-    <span className={`inline-block px-2 py-0.5 rounded-md text-[11px] font-medium ${style}`}>
-      {status}
-    </span>
-  );
+  return <span className={`badge ${STATUS_BADGE[status] ?? 'badge-gray'}`}>{status}</span>;
 }

--- a/browser/src/index.css
+++ b/browser/src/index.css
@@ -1,1 +1,14 @@
 @import "tailwindcss";
+
+/* Scan sphere-ui's built classes (dark:, hover:, badge-*, admin-*, btn-*) */
+@source "../node_modules/@unicitylabs/sphere-ui/dist";
+
+/* sphere-ui uses the `dark` class to gate its dark: utility variants */
+@custom-variant dark (&:where(.dark, .dark *));
+
+/* Dark page background using sphere-ui's brand token */
+html, body, #root {
+  min-height: 100%;
+  background: var(--bg-root);
+  color: var(--text-primary);
+}

--- a/browser/src/main.tsx
+++ b/browser/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import '@unicitylabs/sphere-ui/styles';
 import './index.css';
 import App from './App';
 


### PR DESCRIPTION
Restyles the browser Connect example to the Unicity brand using `@unicitylabs/sphere-ui`'s dark theme. Behavior, Connect flows, and panel structure are unchanged — purely visual + component swaps. Doubles as a live showcase of the design system for dApp developers.

**What changed (5 commits):**
- **Integration** — add `@unicitylabs/sphere-ui@^0.1.23`, import its styles, `@source` its dist in `index.css` + `dark` variant, render the app under a `dark` root with the brand dark background.
- **ui/ primitives → dark** — `ResultDisplay` (dark surface), `StatusBadge` (reuse sphere-ui `.badge-*` mapped to token tx statuses), `CoinBadge` / `CoinSelect` recolored.
- **Layout → dark** — grouped sidebar (Queries/Intents/Chat/Events kept) + `WalletHeader`; disconnect uses sphere-ui `Button`.
- **Panels** — swap raw `<button>`/`<input>`/`<textarea>`/`<select>` → sphere-ui `Button`/`Input`/`Textarea`/`Select`; white cards → `admin-card`; recolor across all query/intent/chat/events panels + `ConnectButton`.
- **Review fixes** — dark RPC-method chips, em-dash contrast, `resize-none` preserved on textareas, chat sidebar input sizing, consistent button variants.

**Notes:**
- Pins `lucide-react@^0.400.0` (matches sphere-dev-portal) — sphere-ui@0.1.23 references a `Twitter` icon removed in newer lucide-react.
- `ResultDisplay` and `StatusBadge` stay custom (restyled) rather than swapped: sphere-ui `JsonPanel` is an editable form panel (not a read-only viewer), and sphere-ui `StatusBadge` only maps quest/project statuses, not token tx statuses.

Build clean (`tsc -b && vite build`); no light-theme utilities remain in `src/components`.
