### PR TITLE
feat(example): dual prod/staging Pages deploy + env switch, drop extension option

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy Browser App to GitHub Pages
 on:
   push:
     branches: [main]
-    paths: [browser/**]
+    paths: [browser/**, .github/workflows/deploy.yml]
   workflow_dispatch:
 
 permissions:
@@ -32,10 +32,24 @@ jobs:
 
       - run: npm install
 
-      - name: Build
+      # Two builds into one Pages artifact (one repo = one Pages site).
+      # Same code, different wallet target baked in via VITE_WALLET_URL:
+      #   /          → production wallet (sphere.unicity.network)
+      #   /staging/  → staging wallet (sphere repo's gh-pages `main` branch deploy)
+      - name: Build (production wallet → /)
         run: npm run build
         env:
           VITE_BASE_PATH: /sphere-sdk-connect-example/
+          VITE_WALLET_URL: https://sphere.unicity.network
+
+      # Runs after the prod build so emptyOutDir only clears dist/staging,
+      # leaving the prod bundle in dist/ intact. Skips the redundant tsc -b
+      # (already type-checked by the prod build above).
+      - name: Build (staging wallet → /staging/)
+        run: npx vite build --outDir dist/staging
+        env:
+          VITE_BASE_PATH: /sphere-sdk-connect-example/staging/
+          VITE_WALLET_URL: https://unicity-sphere.github.io/sphere/main
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/browser/src/components/ConnectButton.tsx
+++ b/browser/src/components/ConnectButton.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
 import { Button } from '@unicitylabs/sphere-ui';
+import { EnvSwitch } from './EnvSwitch';
 
 interface ConnectButtonProps {
   onConnect: () => void;
@@ -19,33 +19,6 @@ function Spinner() {
   );
 }
 
-function ExtensionIcon({ detected }: { detected: boolean }) {
-  return (
-    <div className={`w-12 h-12 rounded-2xl flex items-center justify-center mb-3 ${detected ? 'bg-green-500/15' : 'bg-white/6'}`}>
-      <svg width="28" height="28" viewBox="0 0 24 24" fill="none">
-        <path
-          d="M20.5 11H19V7a2 2 0 0 0-2-2h-4V3.5A2.5 2.5 0 0 0 10.5 1 2.5 2.5 0 0 0 8 3.5V5H4a2 2 0 0 0-2 2v3.8h1.5c1.5 0 2.7 1.2 2.7 2.7S5 16.2 3.5 16.2H2V20a2 2 0 0 0 2 2h3.8v-1.5c0-1.5 1.2-2.7 2.7-2.7 1.5 0 2.7 1.2 2.7 2.7V22H17a2 2 0 0 0 2-2v-4h1.5a2.5 2.5 0 0 0 2.5-2.5 2.5 2.5 0 0 0-2.5-2.5z"
-          fill={detected ? '#4ade80' : '#6b7280'}
-        />
-      </svg>
-    </div>
-  );
-}
-
-function PopupIcon() {
-  return (
-    <div className="w-12 h-12 rounded-2xl flex items-center justify-center mb-3 bg-orange-500/10">
-      <svg width="28" height="28" viewBox="0 0 24 24" fill="none">
-        <rect x="2" y="4" width="20" height="16" rx="2" stroke="#f97316" strokeWidth="2" />
-        <path d="M2 8h20" stroke="#f97316" strokeWidth="2" />
-        <circle cx="5.5" cy="6" r="1" fill="#f97316" />
-        <circle cx="8.5" cy="6" r="1" fill="#f97316" />
-        <path d="M10 13l3-3m0 0h-2.5m2.5 0v2.5" stroke="#f97316" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-      </svg>
-    </div>
-  );
-}
-
 export function ConnectButton({
   onConnect,
   onConnectExtension,
@@ -54,108 +27,42 @@ export function ConnectButton({
   extensionInstalled,
   error,
 }: ConnectButtonProps) {
-  const [showModal, setShowModal] = useState(false);
-
-  // Suppress unused warning — onConnect is kept for P1 iframe usage upstream
+  // Extension connection is temporarily hidden — popup is the only method for now,
+  // so "Connect Wallet" opens the popup directly (no method chooser modal).
+  // These props are kept so re-enabling the extension option needs no App.tsx change.
   void onConnect;
-
-  const handleExtension = () => {
-    setShowModal(false);
-    onConnectExtension();
-  };
-
-  const handlePopup = () => {
-    setShowModal(false);
-    onConnectPopup();
-  };
+  void onConnectExtension;
+  void extensionInstalled;
 
   return (
-    <>
-      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-6">
-        <div className="text-center">
-          <h1 className="text-4xl font-bold text-white mb-2">Sphere Connect</h1>
-          <p className="text-white/45 text-lg">Browser dApp Example</p>
-        </div>
-
-        <Button
-          onClick={() => !isConnecting && setShowModal(true)}
-          disabled={isConnecting}
-          className="px-8 py-4 text-lg shadow-lg shadow-orange-500/25"
-        >
-          {isConnecting ? (
-            <span className="flex items-center gap-2">
-              <Spinner />
-              Connecting...
-            </span>
-          ) : (
-            'Connect Wallet'
-          )}
-        </Button>
-
-        {error && (
-          <div className="bg-red-500/10 border border-red-500/20 text-red-400 px-4 py-3 rounded-xl max-w-md text-center text-sm">
-            {error}
-          </div>
-        )}
+    <div className="flex flex-col items-center justify-center min-h-[60vh] gap-6">
+      <div className="text-center">
+        <h1 className="text-4xl font-bold text-white mb-2">Sphere Connect</h1>
+        <p className="text-white/45 text-lg">Browser dApp Example</p>
       </div>
 
-      {/* Connection method modal */}
-      {showModal && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
-          onClick={() => setShowModal(false)}
-        >
-          <div
-            className="admin-card p-6 w-full max-w-sm mx-4"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <h2 className="text-xl font-bold text-white text-center mb-1">Choose connection</h2>
-            <p className="text-sm text-white/45 text-center mb-6">
-              How would you like to connect your Sphere wallet?
-            </p>
+      <EnvSwitch />
 
-            <div className="flex gap-3">
-              {/* Extension option */}
-              <button
-                onClick={handleExtension}
-                disabled={!extensionInstalled}
-                className={`flex-1 flex flex-col items-center p-4 rounded-2xl border-2 transition-all
-                  ${extensionInstalled
-                    ? 'border-green-500/30 hover:border-green-400 hover:bg-green-500/10 cursor-pointer'
-                    : 'border-white/8 bg-white/3 cursor-not-allowed opacity-50'
-                  }`}
-              >
-                <ExtensionIcon detected={extensionInstalled} />
-                <span className={`text-sm font-semibold ${extensionInstalled ? 'text-white' : 'text-white/45'}`}>
-                  Extension
-                </span>
-                <span className="text-xs text-white/45 mt-0.5 text-center leading-tight">
-                  {extensionInstalled ? 'Sphere extension detected' : 'Not installed'}
-                </span>
-              </button>
+      <Button
+        onClick={() => !isConnecting && onConnectPopup()}
+        disabled={isConnecting}
+        className="px-8 py-4 text-lg shadow-lg shadow-orange-500/25"
+      >
+        {isConnecting ? (
+          <span className="flex items-center gap-2">
+            <Spinner />
+            Connecting...
+          </span>
+        ) : (
+          'Connect Wallet'
+        )}
+      </Button>
 
-              {/* Popup option */}
-              <button
-                onClick={handlePopup}
-                className="flex-1 flex flex-col items-center p-4 rounded-2xl border-2 border-orange-500/30 hover:border-orange-400 hover:bg-orange-500/10 transition-all cursor-pointer"
-              >
-                <PopupIcon />
-                <span className="text-sm font-semibold text-white">Popup</span>
-                <span className="text-xs text-white/45 mt-0.5 text-center leading-tight">
-                  Opens sphere.unicity.network
-                </span>
-              </button>
-            </div>
-
-            <button
-              onClick={() => setShowModal(false)}
-              className="mt-4 w-full text-sm text-white/45 hover:text-white/70 transition-colors py-1"
-            >
-              Cancel
-            </button>
-          </div>
+      {error && (
+        <div className="bg-red-500/10 border border-red-500/20 text-red-400 px-4 py-3 rounded-xl max-w-md text-center text-sm">
+          {error}
         </div>
       )}
-    </>
+    </div>
   );
 }

--- a/browser/src/components/EnvSwitch.tsx
+++ b/browser/src/components/EnvSwitch.tsx
@@ -1,0 +1,39 @@
+/**
+ * Cross-link between the two GitHub Pages deploys of this demo.
+ *
+ * Both are the same code built twice (see .github/workflows/deploy.yml):
+ *   - production build → site root, talks to https://sphere.unicity.network
+ *   - staging build    → /staging/,  talks to https://unicity-sphere.github.io/sphere/main
+ *
+ * The current environment is derived purely from the baked-in base path
+ * (`import.meta.env.BASE_URL`), and the button always points at the *other*
+ * deploy. Deriving the sibling path from the base means a repo rename needs
+ * no change here. On the dev server (base `/`) it shows "Production → Staging"
+ * pointing at `/staging/` — there is no real pair locally, but keeping it
+ * visible lets the placement be verified in `npm run dev`.
+ */
+export function EnvSwitch() {
+  const base = import.meta.env.BASE_URL;
+  const normalized = base.endsWith('/') ? base : base + '/';
+  const isStaging = normalized.endsWith('/staging/');
+
+  const targetHref = isStaging
+    ? normalized.slice(0, -'staging/'.length) // strip the staging segment → prod root
+    : normalized + 'staging/'; //               append the staging segment → staging
+
+  const currentLabel = isStaging ? 'Staging' : 'Production';
+  const targetLabel = isStaging ? 'Production' : 'Staging';
+
+  return (
+    <a
+      href={targetHref}
+      title={`You are on ${currentLabel}. Switch to ${targetLabel}.`}
+      className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-white/70 transition-colors hover:border-white/20 hover:bg-white/10 hover:text-white"
+    >
+      <span className={`h-1.5 w-1.5 rounded-full ${isStaging ? 'bg-amber-400' : 'bg-green-500'}`} />
+      <span className="text-white/45">{currentLabel}</span>
+      <span aria-hidden="true">→</span>
+      <span>{targetLabel}</span>
+    </a>
+  );
+}

--- a/browser/src/components/layout/WalletHeader.tsx
+++ b/browser/src/components/layout/WalletHeader.tsx
@@ -1,6 +1,7 @@
 import type { PublicIdentity } from '@unicitylabs/sphere-sdk/connect';
 import { Button } from '@unicitylabs/sphere-ui';
 import { truncate } from '../../lib/format';
+import { EnvSwitch } from '../EnvSwitch';
 
 interface WalletHeaderProps {
   identity: PublicIdentity;
@@ -21,6 +22,7 @@ export function WalletHeader({ identity, onDisconnect }: WalletHeaderProps) {
         </span>
       </div>
       <div className="flex items-center gap-3">
+        <EnvSwitch />
         <span className="inline-flex items-center gap-1.5 text-xs text-green-400">
           <span className="w-2 h-2 rounded-full bg-green-500" />
           Connected


### PR DESCRIPTION
## What

Two follow-ups on the Connect browser example, on top of the merged dark restyle (#10):

- **Dual prod/staging GitHub Pages deploy.** `deploy.yml` now builds the
  browser app twice into a single Pages artifact, same code, different wallet
  baked in via `VITE_WALLET_URL`:
  - `/` → production wallet (`sphere.unicity.network`)
  - `/staging/` → staging wallet (`unicity-sphere.github.io/sphere/main`)

  The workflow also triggers on changes to itself, so this lands as a redeploy.
- **`EnvSwitch` button.** An environment-aware pill, derived from
  `import.meta.env.BASE_URL`, that links the current deploy to the other one.
  Shown on the landing screen and the connected wallet header.
- **Extension connection option hidden for now.** "Connect Wallet" opens the
  popup directly (no method-chooser modal); the extension props are kept so it
  can be re-enabled without touching `App.tsx`.

## Notes

- One repo = one Pages site, so the two environments live as two paths under
  the same site rather than two separate sites.
- Make sure repo **Settings → Pages → Source = GitHub Actions** for the
  artifact to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
