### PR TITLE
fix(example): fully-dark dropdowns via CustomSelect

### DIFF
--- a/browser/src/components/events/EventLogPanel.tsx
+++ b/browser/src/components/events/EventLogPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { Button, Select } from '@unicitylabs/sphere-ui';
+import { Button, CustomSelect } from '@unicitylabs/sphere-ui';
 
 interface LogEntry {
   id: number;
@@ -134,13 +134,15 @@ export function EventLogPanel({ on }: Props) {
       <p className="text-xs text-white/45 mb-4">Real-time wallet events ({ALL_EVENTS.length} subscribed)</p>
 
       <div className="flex items-center gap-2 mb-3">
-        <Select value={filter} onChange={(e) => setFilter(e.target.value)}
-          className="flex-1">
-          <option value="all">All events</option>
-          {ALL_EVENTS.map((ev) => (
-            <option key={ev} value={ev}>{ev}</option>
-          ))}
-        </Select>
+        <CustomSelect
+          value={filter}
+          onChange={setFilter}
+          className="flex-1"
+          options={[
+            { value: 'all', label: 'All events' },
+            ...ALL_EVENTS.map((ev) => ({ value: ev, label: ev })),
+          ]}
+        />
         {entries.length > 0 && (
           <Button onClick={() => setEntries([])} variant="secondary">
             Clear

--- a/browser/src/components/queries/HistoryPanel.tsx
+++ b/browser/src/components/queries/HistoryPanel.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, type ReactNode } from 'react';
 import { RPC_METHODS } from '@unicitylabs/sphere-sdk/connect';
-import { Button, Select } from '@unicitylabs/sphere-ui';
+import { Button, CustomSelect } from '@unicitylabs/sphere-ui';
 import { ResultDisplay } from '../ui/ResultDisplay';
 import { StatusBadge } from '../ui/StatusBadge';
 import { CoinBadge } from '../ui/CoinBadge';
@@ -199,14 +199,13 @@ function Pagination({
     <div className="flex flex-wrap items-center justify-between gap-2 mt-3 text-xs text-white/45">
       <div className="flex items-center gap-2">
         <span>Rows per page:</span>
-        <Select
-          value={pageSize}
-          onChange={(e) => onPageSizeChange(Number(e.target.value))}
-        >
-          {PAGE_SIZE_OPTIONS.map((s) => (
-            <option key={s} value={s}>{s}</option>
-          ))}
-        </Select>
+        <CustomSelect
+          value={String(pageSize)}
+          onChange={(v) => onPageSizeChange(Number(v))}
+          size="sm"
+          className="w-20"
+          options={PAGE_SIZE_OPTIONS.map((s) => ({ value: String(s), label: String(s) }))}
+        />
       </div>
 
       <div className="flex items-center gap-3">


### PR DESCRIPTION
The dark restyle (#10) swapped raw `<select>` elements to sphere-ui's `Select`, which is a **native** `<select>` — its control is dark, but the opened option list is rendered by the OS/browser and shows up white (Chrome/Windows ignores option styling). 

This swaps the two dropdowns where the open list matters to sphere-ui's **`CustomSelect`** (a portal-based, fully-styleable dark dropdown):
- **EventLogPanel** — the event-type filter.
- **HistoryPanel** — the rows-per-page selector.

`CoinSelect` is the example's own custom dropdown and was already dark, so it's unchanged.

Build clean (`tsc -b && vite build`).
