### PR TITLE
docs(connect-example): fix protocol version, scopes, error codes, intent shapes (#609)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,14 +25,14 @@ sphere-sdk-connect-example/
 │   │       │   ├── CoinBadge.tsx    # Token icon (img or colored letter) + symbol
 │   │       │   ├── CoinSelect.tsx   # Dropdown token selector (fetches assets from wallet)
 │   │       │   └── StatusBadge.tsx  # Colored status badges (confirmed/pending/failed)
-│   │       ├── queries/             # 7 query panels (read-only operations)
+│   │       ├── queries/             # 6 query panels (read-only operations)
 │   │       │   ├── IdentityPanel.tsx     # sphere_getIdentity
 │   │       │   ├── AssetsPanel.tsx       # sphere_getAssets (table with icons, fiat, 24h)
 │   │       │   ├── BalancePanel.tsx      # sphere_getBalance + sphere_getFiatBalance
 │   │       │   ├── TokensPanel.tsx       # sphere_getTokens (with status badges)
 │   │       │   ├── HistoryPanel.tsx      # sphere_getHistory (with type badges)
 │   │       │   └── ResolvePanel.tsx      # sphere_resolve (identifier input)
-│   │       ├── intents/             # 7 intent panels (require wallet approval)
+│   │       ├── intents/             # 6 intent panels (require wallet approval)
 │   │       │   ├── SendPanel.tsx         # send (recipient, amount, coin selector, memo)
 │   │       │   ├── MintPanel.tsx         # mint (coinId, amount)
 │   │       │   ├── DMPanel.tsx           # dm (recipient, message)
@@ -40,7 +40,7 @@ sphere-sdk-connect-example/
 │   │       │   ├── ReceivePanel.tsx      # receive (button only, no params)
 │   │       │   └── SignMessagePanel.tsx  # sign_message (message textarea)
 │   │       └── events/
-│   │           └── EventLogPanel.tsx # All 9 events, color-coded, filterable
+│   │           └── EventLogPanel.tsx # Color-coded, filterable event log
 │   ├── index.html
 │   ├── package.json
 │   ├── tsconfig.json
@@ -86,9 +86,9 @@ CLI commands:
 
 ## Dependencies
 
-Both subprojects use a **local** sphere-sdk link:
+Both subprojects pin a published sphere-sdk version:
 ```json
-"@unicitylabs/sphere-sdk": "file:../../sphere-sdk"
+"@unicitylabs/sphere-sdk": "0.10.2"
 ```
 
 - **Browser:** React 19, Vite 7, Tailwind CSS 4
@@ -159,10 +159,10 @@ The browser `tsconfig.json` requires explicit path mappings for connect submodul
 | Intent Action | Description | Required Permission |
 |--------------|-------------|---------------------|
 | `send` | L3 token transfer | `transfer:request` |
-| `mint` | Self-mint a fungible token | `transfer:request` |
+| `mint` | Self-mint a fungible token | `mint:request` |
 | `dm` | Direct message | `dm:request` |
 | `payment_request` | Payment request | `payment:request` |
-| `receive` | Receive incoming tokens | `transfer:request` |
+| `receive` | Receive incoming tokens | `identity:read` |
 | `sign_message` | Message signing | `sign:request` |
 
 ### Connection Flow
@@ -178,7 +178,7 @@ The browser `tsconfig.json` requires explicit path mappings for connect submodul
 ### Browser Connection Modes
 
 **Popup mode** (default in this example):
-- Opens wallet at `WALLET_URL + '/#/connect?origin=...'`
+- Opens wallet at `WALLET_URL + '/connect?origin=...'`
 - Waits for `HOST_READY_TYPE` message before establishing transport
 - Popup close is treated as disconnection
 
@@ -190,7 +190,7 @@ The browser `tsconfig.json` requires explicit path mappings for connect submodul
 
 ```typescript
 SPHERE_CONNECT_NAMESPACE = 'sphere-connect'
-SPHERE_CONNECT_VERSION = '1.0'
+SPHERE_CONNECT_VERSION = '2.0'
 HOST_READY_TYPE = 'sphere-connect:host-ready'
 HOST_READY_TIMEOUT = 30_000  // ms
 ```
@@ -205,6 +205,8 @@ HOST_READY_TIMEOUT = 30_000  // ms
 | 4004 | `SESSION_EXPIRED` | Session TTL exceeded |
 | 4005 | `ORIGIN_BLOCKED` | Origin not allowed |
 | 4006 | `RATE_LIMITED` | Too many requests |
+| 4007 | `UNSUPPORTED_PROTOCOL_VERSION` | Connect protocol MAJOR mismatch |
+| 4008 | `INCOMPATIBLE_NETWORK` | dApp targets a different network than the wallet |
 | 4100 | `INSUFFICIENT_BALANCE` | Not enough tokens |
 | 4101 | `INVALID_RECIPIENT` | Bad recipient address |
 | 4102 | `TRANSFER_FAILED` | Transfer error |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npm run client     # Terminal 2: CLI client
 
 ## Browser Example Features
 
-All 7 queries, 6 intents, and 9 events are demonstrated:
+All queries, intents, and events are demonstrated:
 
 **Queries** (read-only):
 `sphere_getIdentity` · `sphere_getBalance` · `sphere_getAssets` · `sphere_getFiatBalance` · `sphere_getTokens` · `sphere_getHistory` · `sphere_resolve`
@@ -50,7 +50,7 @@ All 7 queries, 6 intents, and 9 events are demonstrated:
 `send` · `mint` · `dm` · `payment_request` · `receive` · `sign_message`
 
 **Events** (real-time push):
-`transfer:incoming` · `transfer:confirmed` · `transfer:failed` · `balance:updated` · `identity:updated` · `session:expired` · and more
+auto-pushed `wallet:locked` · `identity:changed` · subscribable `transfer:incoming` · `transfer:confirmed` · `transfer:failed` · and more
 
 ## 3-Priority Transport Selection
 
@@ -83,12 +83,10 @@ try {
 
 ## Dependencies
 
-Both subprojects use a local sphere-sdk reference:
+Both subprojects pin a published sphere-sdk version:
 ```json
-"@unicitylabs/sphere-sdk": "file:../../sphere-sdk"
+"@unicitylabs/sphere-sdk": "0.10.2"
 ```
-
-Rebuild SDK before testing: `cd ../../sphere-sdk && npm run build`
 
 ## Documentation
 

--- a/browser/CONNECT.md
+++ b/browser/CONNECT.md
@@ -104,7 +104,7 @@ if (!wallet.isConnected) {
 
 // Connected
 const balance = await wallet.query('sphere_getBalance');
-await wallet.intent('send', { recipient: '@alice', amount: 100 });
+await wallet.intent('send', { to: '@alice', amount: '10', coinId: '<lowercase 64-hex coin id>' });
 ```
 
 ### State shape
@@ -135,7 +135,7 @@ const fiat    = await wallet.query('sphere_getFiatBalance');
 
 // Assets & tokens
 const assets = await wallet.query('sphere_getAssets');
-const tokens = await wallet.query('sphere_getTokens', { coinId: 'USDC' });
+const tokens = await wallet.query('sphere_getTokens', { coinId: '<lowercase 64-hex coin id>' });
 
 // History
 const history = await wallet.query('sphere_getHistory');
@@ -151,9 +151,9 @@ const info = await wallet.query('sphere_resolve', { identifier: '@alice' });
 ```typescript
 // Send tokens
 await wallet.intent('send', {
-  recipient: '@alice',       // nametag or DIRECT:// address
-  amount: 100,
-  coinId: 'USDC',            // optional, default: native
+  to: '@alice',                              // nametag or DIRECT:// address
+  amount: '10',                              // string amount
+  coinId: '<lowercase 64-hex coin id>',      // optional, default: native
 });
 
 // Self-mint a fungible token
@@ -161,25 +161,28 @@ await wallet.intent('mint', { coinId: '<lowercase-hex>', amount: '1000000' });
 
 // Send DM
 await wallet.intent('dm', {
-  recipient: '@alice',
-  content: 'Hello!',
+  to: '@alice',
+  message: 'Hello!',
 });
 
 // Create payment request (QR code shown to sender)
 await wallet.intent('payment_request', {
-  amount: 50,
-  coinId: 'USDC',
-  description: 'Coffee',
+  to: '@bob',
+  amount: '5',
+  coinId: '<lowercase 64-hex coin id>',
+  message: 'Coffee',
 });
 
 // Show receive address
-await wallet.intent('receive', { coinId: 'USDC' });
+await wallet.intent('receive', {});
 
 // Sign a message
 const { signature } = await wallet.intent('sign_message', {
   message: 'I agree to the terms',
 });
 ```
+
+> **Note:** Invoice / accounting intents are experimental and are **not** supported by the Sphere wallet. Do not use them.
 
 ---
 
@@ -196,7 +199,7 @@ const unsub = wallet.on('transfer:incoming', (data) => {
 return () => unsub();
 ```
 
-Available events: `transfer:incoming`, `transfer:confirmed`, `transfer:failed`, `balance:updated`, `identity:updated`, `session:expired`.
+Available events: auto-pushed `wallet:locked` and `identity:changed`, plus subscribable `transfer:incoming`, `transfer:confirmed`, `transfer:failed`. The full set is larger — see EventLogPanel for the complete list.
 
 ### Auto-pushed wallet events
 
@@ -356,8 +359,10 @@ try {
 ```bash
 cd sphere-sdk-connect-example/browser
 npm install
-npm run dev       # starts on https://localhost:5173 (if certs available)
+npm run dev       # starts on http://localhost:5174
 ```
+
+The Sphere wallet, when run locally, listens on `http://localhost:5173`.
 
 ### Environment Variables
 
@@ -365,19 +370,7 @@ Set `VITE_WALLET_URL` in `.env.development` or `.env.local` to point to your wal
 
 ```bash
 VITE_WALLET_URL=https://sphere.unicity.network   # production (default)
-VITE_WALLET_URL=https://localhost:5174            # local development
+VITE_WALLET_URL=http://localhost:5173             # local development (Sphere wallet)
 ```
 
-### HTTPS for development
-
-The Vite config automatically enables HTTPS if SSL certificates exist at `../../sphere/.certs/`. Generate self-signed certs for local HTTPS:
-
-```bash
-mkdir -p sphere/.certs
-openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
-  -keyout sphere/.certs/privkey.pem -out sphere/.certs/fullchain.pem \
-  -days 365 -nodes -subj "/CN=localhost" \
-  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
-```
-
-Both the example app and Sphere wallet will use these certs automatically.
+The example dev server runs on port **5174** (see `vite.config.ts`); the Sphere wallet runs on port **5173**. The Vite config only sets `server: { port: 5174 }` — it does not enable HTTPS or load any certificates, so the dev server is served over plain `http`.


### PR DESCRIPTION
## Summary

Track **D1** of the docs audit (#609). Corrects factual inaccuracies in the connect-example documentation so it matches the actual Sphere Connect protocol (v2) and the example's own source code. This also closes out the intent-shape errors tracked in #608.

Docs only — no code changes.

## Changes

### `CLAUDE.md`
- `SPHERE_CONNECT_VERSION` `'1.0'` -> `'2.0'`
- Intents table scopes: `mint` `transfer:request` -> `mint:request`; `receive` `transfer:request` -> `identity:read`
- Added error codes `4007 UNSUPPORTED_PROTOCOL_VERSION` and `4008 INCOMPATIBLE_NETWORK`
- Dependency instruction now reflects the pinned `"@unicitylabs/sphere-sdk": "0.10.2"` (both subprojects pin this; there is no `file:../../sphere-sdk` link)
- Popup URL: `WALLET_URL + '/#/connect?origin=...'` -> `WALLET_URL + '/connect?origin=...'`
- Project-structure tree: `7 query panels` -> `6`, `7 intent panels` -> `6`
- `EventLogPanel.tsx` description no longer claims a fixed "9 events" count

### `browser/CONNECT.md` (#608 intent shapes)
- `recipient` -> `to`; `content` -> `message`; `description` -> `message`; numeric `amount` -> string; symbol coin ids (`'USDC'`/`'UCT'`) -> lowercase 64-hex coin id placeholders
- `payment_request` gains a `to` field; `receive` takes no params
- "Available events" list replaced (the old `balance:updated` / `identity:updated` / `session:expired` do not exist) with real events: auto-pushed `wallet:locked`, `identity:changed`; subscribable `transfer:incoming`, `transfer:confirmed`, `transfer:failed`
- Removed the false claim that Vite auto-enables HTTPS from `../../sphere/.certs/` (the config only sets `server: { port: 5174 }`); clarified dev ports (example = **5174**, Sphere wallet = **5173**), served over plain http
- Added a note that invoice / accounting intents are experimental and **not** supported by the Sphere wallet

### `README.md`
- Aligned the events list, dependency pin (`0.10.2`), and feature-count phrasing with the above

## Notes
- Remaining `recipient` references are intentional: the `INVALID_RECIPIENT` error-code row, and the project-structure tree comments that describe the panels' form-input fields (the panel source genuinely uses a `recipient` React state that it maps to the wire field `to`).
- Source files (`nodejs/src/mock-wallet-server.ts`, `browser/src/lib/types.ts`, panels) were left untouched — out of scope for a docs-accuracy pass and accurate to the code.

Part of #609 (track D1).
