### PR TITLE
feat(connect): send/payment_request amounts in base units

### DIFF
--- a/browser/CONNECT.md
+++ b/browser/CONNECT.md
@@ -104,7 +104,8 @@ if (!wallet.isConnected) {
 
 // Connected
 const balance = await wallet.query('sphere_getBalance');
-await wallet.intent('send', { to: '@alice', amount: '10', coinId: '<lowercase 64-hex coin id>' });
+// amount is in BASE UNITS (smallest unit) — e.g. 1 of an 18-decimals coin = '1000000000000000000'
+await wallet.intent('send', { to: '@alice', amount: '1000000000000000000', coinId: '<lowercase 64-hex coin id>' });
 ```
 
 ### State shape
@@ -149,14 +150,16 @@ const info = await wallet.query('sphere_resolve', { identifier: '@alice' });
 ## Intents (require user confirmation in wallet)
 
 ```typescript
-// Send tokens
+// Send tokens. amount is in BASE UNITS (smallest indivisible unit), as a string —
+// the same convention as `mint` and the SDK. Convert at the dApp edge, e.g.
+// the SDK's parseTokenAmount('1.5', decimals) (or ethers/viem parseUnits).
 await wallet.intent('send', {
   to: '@alice',                              // nametag or DIRECT:// address
-  amount: '10',                              // string amount
-  coinId: '<lowercase 64-hex coin id>',      // optional, default: native
+  amount: '1500000000000000000',             // base units (= 1.5 of an 18-decimals coin)
+  coinId: '<lowercase 64-hex coin id>',      // required, lowercase 64-hex
 });
 
-// Self-mint a fungible token
+// Self-mint a fungible token (amount in base units)
 await wallet.intent('mint', { coinId: '<lowercase-hex>', amount: '1000000' });
 
 // Send DM
@@ -165,10 +168,10 @@ await wallet.intent('dm', {
   message: 'Hello!',
 });
 
-// Create payment request (QR code shown to sender)
+// Create payment request (amount in base units, like `send`)
 await wallet.intent('payment_request', {
   to: '@bob',
-  amount: '5',
+  amount: '5000000000000000000',             // base units
   coinId: '<lowercase 64-hex coin id>',
   message: 'Coffee',
 });

--- a/browser/src/components/intents/PaymentRequestPanel.tsx
+++ b/browser/src/components/intents/PaymentRequestPanel.tsx
@@ -3,6 +3,7 @@ import { INTENT_ACTIONS } from '@unicitylabs/sphere-sdk/connect';
 import { Button, Input } from '@unicitylabs/sphere-ui';
 import { ResultDisplay } from '../ui/ResultDisplay';
 import { CoinSelect } from '../ui/CoinSelect';
+import { parseAmount, safeParseAmount } from '../../lib/format';
 
 interface Props {
   intent: <T>(action: string, params: Record<string, unknown>) => Promise<T>;
@@ -13,6 +14,7 @@ export function PaymentRequestPanel({ intent, query }: Props) {
   const [recipient, setRecipient] = useState('');
   const [amount, setAmount] = useState('');
   const [coinId, setCoinId] = useState('');
+  const [decimals, setDecimals] = useState(0);
   const [message, setMessage] = useState('');
   const [raw, setRaw] = useState<unknown>(null);
   const [error, setError] = useState<string | null>(null);
@@ -25,7 +27,9 @@ export function PaymentRequestPanel({ intent, query }: Props) {
     setRaw(null);
     try {
       const to = recipient.startsWith('@') ? recipient : '@' + recipient;
-      const params: Record<string, unknown> = { to, amount, coinId };
+      // Connect `payment_request` takes the amount in BASE UNITS — convert the
+      // human input here, at the dApp's edge (string-based, exact).
+      const params: Record<string, unknown> = { to, amount: parseAmount(amount, decimals), coinId };
       if (message) params.message = message;
       const result = await intent(INTENT_ACTIONS.PAYMENT_REQUEST, params);
       setRaw(result);
@@ -52,8 +56,11 @@ export function PaymentRequestPanel({ intent, query }: Props) {
           <Input type="text" value={amount} onChange={(e) => setAmount(e.target.value)}
             placeholder="Amount"
             className="flex-1" />
-          <CoinSelect value={coinId} onChange={setCoinId} query={query} />
+          <CoinSelect value={coinId} onChange={(c, d) => { setCoinId(c); setDecimals(d); }} query={query} />
         </div>
+        {amount && safeParseAmount(amount, decimals) && (
+          <p className="text-[10px] font-mono text-white/30">= {safeParseAmount(amount, decimals)} base units (sent to wallet)</p>
+        )}
         <Input type="text" value={message} onChange={(e) => setMessage(e.target.value)}
           placeholder="Message (optional)" />
         <Button onClick={execute} disabled={loading || !recipient || !amount || !coinId} className="w-full">

--- a/browser/src/components/intents/SendPanel.tsx
+++ b/browser/src/components/intents/SendPanel.tsx
@@ -3,6 +3,7 @@ import { INTENT_ACTIONS } from '@unicitylabs/sphere-sdk/connect';
 import { Button, Input } from '@unicitylabs/sphere-ui';
 import { ResultDisplay } from '../ui/ResultDisplay';
 import { CoinSelect } from '../ui/CoinSelect';
+import { parseAmount, safeParseAmount } from '../../lib/format';
 
 interface Props {
   intent: <T>(action: string, params: Record<string, unknown>) => Promise<T>;
@@ -13,6 +14,7 @@ export function SendPanel({ intent, query }: Props) {
   const [recipient, setRecipient] = useState('');
   const [amount, setAmount] = useState('');
   const [coinId, setCoinId] = useState('');
+  const [decimals, setDecimals] = useState(0);
   const [memo, setMemo] = useState('');
   const [raw, setRaw] = useState<unknown>(null);
   const [error, setError] = useState<string | null>(null);
@@ -25,7 +27,10 @@ export function SendPanel({ intent, query }: Props) {
     setRaw(null);
     try {
       const to = recipient.startsWith('@') ? recipient : '@' + recipient;
-      const params: Record<string, unknown> = { to, amount, coinId };
+      // Connect `send` takes the amount in BASE UNITS — convert the human input
+      // here, at the dApp's edge (string-based, exact). The wallet only displays
+      // it. (The SDK also exports `parseTokenAmount` for the same purpose.)
+      const params: Record<string, unknown> = { to, amount: parseAmount(amount, decimals), coinId };
       if (memo) params.memo = memo;
       const result = await intent(INTENT_ACTIONS.SEND, params);
       setRaw(result);
@@ -52,8 +57,11 @@ export function SendPanel({ intent, query }: Props) {
           <Input type="text" value={amount} onChange={(e) => setAmount(e.target.value)}
             placeholder="Amount"
             className="flex-1" />
-          <CoinSelect value={coinId} onChange={setCoinId} query={query} />
+          <CoinSelect value={coinId} onChange={(c, d) => { setCoinId(c); setDecimals(d); }} query={query} />
         </div>
+        {amount && safeParseAmount(amount, decimals) && (
+          <p className="text-[10px] font-mono text-white/30">= {safeParseAmount(amount, decimals)} base units (sent to wallet)</p>
+        )}
         <Input type="text" value={memo} onChange={(e) => setMemo(e.target.value)}
           placeholder="Memo (optional)" />
         <Button onClick={execute} disabled={loading || !recipient || !amount || !coinId} className="w-full">

--- a/browser/src/components/ui/CoinSelect.tsx
+++ b/browser/src/components/ui/CoinSelect.tsx
@@ -13,7 +13,8 @@ interface CoinOption {
 
 interface CoinSelectProps {
   value: string;
-  onChange: (coinId: string) => void;
+  /** Reports the chosen coin's id AND decimals (callers need decimals to convert human→base units). */
+  onChange: (coinId: string, decimals: number) => void;
   query: <T>(method: string, params?: Record<string, unknown>) => Promise<T>;
 }
 
@@ -28,7 +29,7 @@ export function CoinSelect({ value, onChange, query }: CoinSelectProps) {
       .then((assets) => {
         if (assets?.length) {
           setCoins(assets);
-          if (!value && assets[0]) onChange(assets[0].coinId);
+          if (!value && assets[0]) onChange(assets[0].coinId, assets[0].decimals);
         }
         setLoaded(true);
       })
@@ -55,7 +56,7 @@ export function CoinSelect({ value, onChange, query }: CoinSelectProps) {
 
   if (coins.length === 0) {
     return (
-      <input type="text" value={value} onChange={(e) => onChange(e.target.value)}
+      <input type="text" value={value} onChange={(e) => onChange(e.target.value, 0)}
         placeholder="Coin ID"
         className="w-36 px-3 py-2 border border-white/8 rounded-xl text-sm text-white bg-white/3 focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500" />
     );
@@ -86,7 +87,7 @@ export function CoinSelect({ value, onChange, query }: CoinSelectProps) {
         <div className="absolute z-50 mt-1 w-full bg-(--bg-elevated) border border-white/8 rounded-xl shadow-lg overflow-hidden">
           {coins.map((coin) => (
             <button key={coin.coinId} type="button"
-              onClick={() => { onChange(coin.coinId); setOpen(false); }}
+              onClick={() => { onChange(coin.coinId, coin.decimals); setOpen(false); }}
               className={`w-full flex items-center gap-2 px-3 py-2.5 text-sm cursor-pointer transition-colors ${
                 coin.coinId === value ? 'bg-orange-500/15' : 'hover:bg-white/6'
               }`}>

--- a/browser/src/lib/format.ts
+++ b/browser/src/lib/format.ts
@@ -7,6 +7,34 @@ export function formatAmount(raw: string, decimals: number): string {
   return fracPart ? `${intFormatted}.${fracPart}` : intFormatted;
 }
 
+/**
+ * Convert a human-readable amount to BASE UNITS (smallest indivisible unit) —
+ * the inverse of {@link formatAmount}. Connect `send` / `payment_request` (like
+ * `mint`) take the amount in base units, so the dApp converts at this UI edge.
+ * String-based (no float) so precision is exact. Throws on invalid input.
+ *
+ * Apps that already depend on the SDK can use its `parseTokenAmount` instead —
+ * this local copy keeps the example dependency-light.
+ */
+export function parseAmount(human: string, decimals: number): string {
+  const str = (human ?? '').trim();
+  if (!/^\d+(\.\d+)?$/.test(str)) throw new Error(`Invalid amount: "${human}"`);
+  const [intPart, fracPart = ''] = str.split('.');
+  if (fracPart.length > decimals) {
+    throw new Error(`Amount "${human}" has more than ${decimals} decimal place(s)`);
+  }
+  return BigInt(intPart + fracPart.padEnd(decimals, '0')).toString();
+}
+
+/** Non-throwing {@link parseAmount} for live UI hints: `null` when not valid yet. */
+export function safeParseAmount(human: string, decimals: number): string | null {
+  try {
+    return parseAmount(human, decimals);
+  } catch {
+    return null;
+  }
+}
+
 export function formatFiat(value: number | null | undefined): string {
   if (value == null) return '—';
   return `$${value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;


### PR DESCRIPTION
## What

Part of #609 (U1). The wallet's Connect `send` / `payment_request` intents now take the amount in **base units** (smallest indivisible unit), matching `mint` and the SDK. This updates the example dApp to convert correctly.

Before this, the Send panel sent the raw human input (`"10"`), which the wallet now reads as 10 **base units** → ~`0.00000000` for an 18-decimals coin.

## Changes

- **`lib/format.ts`** — add `parseAmount(human, decimals)` / `safeParseAmount` (the string-based, exact inverse of `formatAmount`). A comment points to the SDK's `parseTokenAmount` for apps that depend on it directly.
- **`CoinSelect`** — `onChange` now reports `(coinId, decimals)` so panels can convert.
- **`SendPanel` / `PaymentRequestPanel`** — track the coin's decimals, convert the human amount → base units before `intent(...)`, and show a live `= N base units` hint.
- **`browser/CONNECT.md`** — document `amount` is base units (with a `parseTokenAmount` / `parseUnits` pointer); fix the stale "coinId optional, default native" (it's required, lowercase 64-hex).

## Verification

- `npm run build` (`tsc -b` + `vite build`) → clean (exit 0)
