### PR TITLE
chore: bump sphere-sdk to 0.10.3

### DIFF
--- a/browser/package-lock.json
+++ b/browser/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.16",
-        "@unicitylabs/sphere-sdk": "0.10.2",
+        "@unicitylabs/sphere-sdk": "0.10.3",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "lucide-react": "^0.400.0",
         "react": "^19.1.1",
@@ -1832,9 +1832,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.10.2.tgz",
-      "integrity": "sha512-W0Shfa5EBA/jggZeh5j0WpQnvKy9hO/BE7tUZax5iQyRDKI7LAEvOapxkPj4wLYjqE/DaWdfz7dAp55P9jbuvQ==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.10.3.tgz",
+      "integrity": "sha512-+ZD4KCJXsCEs5KLLncK1MVx/upm8aBLRAkc7VXX4QylzcDYbMx6gxwN5GhVkjoJEOeoL3c52wwtiYsEdNX0leg==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/browser/package.json
+++ b/browser/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.16",
-    "@unicitylabs/sphere-sdk": "0.10.2",
+    "@unicitylabs/sphere-sdk": "0.10.3",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "lucide-react": "^0.400.0",
     "react": "^19.1.1",

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "sphere-connect-nodejs-example",
       "version": "0.0.0",
       "dependencies": {
-        "@unicitylabs/sphere-sdk": "0.10.2",
+        "@unicitylabs/sphere-sdk": "0.10.3",
         "ws": "^8.18.0"
       },
       "devDependencies": {
@@ -765,9 +765,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.10.2.tgz",
-      "integrity": "sha512-W0Shfa5EBA/jggZeh5j0WpQnvKy9hO/BE7tUZax5iQyRDKI7LAEvOapxkPj4wLYjqE/DaWdfz7dAp55P9jbuvQ==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.10.3.tgz",
+      "integrity": "sha512-+ZD4KCJXsCEs5KLLncK1MVx/upm8aBLRAkc7VXX4QylzcDYbMx6gxwN5GhVkjoJEOeoL3c52wwtiYsEdNX0leg==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -8,7 +8,7 @@
     "client": "npx tsx src/index.ts"
   },
   "dependencies": {
-    "@unicitylabs/sphere-sdk": "0.10.2",
+    "@unicitylabs/sphere-sdk": "0.10.3",
     "ws": "^8.18.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Bump @unicitylabs/sphere-sdk 0.10.2 -> 0.10.3 (intents release) in both the browser and nodejs examples.