### PR TITLE
Sync to SDK 0.11.14 + surface the delivery-pending send contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ All four packages pin the same published SDK version:
 ## Documentation
 
 - [browser/CONNECT.md](browser/CONNECT.md) — full browser dApp integration guide
-- [sphere-sdk/docs/CONNECT.md](../../sphere-sdk/docs/CONNECT.md) — protocol reference
+- [sphere-sdk/docs/CONNECT.md](../sphere-sdk/docs/CONNECT.md) — protocol reference
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,96 +1,93 @@
 # Sphere Connect Example
 
-Demonstration project showing how to integrate the **Sphere Connect** protocol into browser and Node.js applications.
+Four runnable examples showing the different ways an app can work with a Sphere
+wallet — as a browser dApp, as a Node dApp, as a bot that runs its **own**
+wallet, or as a backend that just authenticates a user.
 
 ## What is Sphere Connect?
 
-Sphere Connect is a typed RPC protocol that allows web dApps to communicate with a Sphere wallet — reading balances, sending tokens, signing messages — without exposing private keys.
+Sphere Connect is a typed RPC protocol that lets a dApp talk to a user's Sphere
+wallet — reading balances, sending tokens, signing messages — **without ever
+seeing the private keys**. The dApp runs a `ConnectClient`; the wallet runs a
+`ConnectHost`; a transport carries messages between them.
 
 ```
 dApp (ConnectClient)  ←→  Transport  ←→  Wallet (ConnectHost)
 ```
 
-## Project Structure
+Not every example uses Connect: the **bot** runs its own wallet directly, and
+the **backend** in backend-auth only verifies a signature. See the guide below.
 
-```
-sphere-sdk-connect-example/
-├── browser/     # React dApp example (Vite + Tailwind)
-└── nodejs/      # Node.js CLI client + mock wallet server
-```
+## Which example do I need?
+
+The examples differ along two axes: **whose wallet** your app uses, and **what
+it needs to do** with it.
+
+| Example | Your app is… | The wallet is… | Can move tokens? | Reach for it when… |
+|---|---|---|---|---|
+| **`browser/`** | a web page / dApp | the **user's**, elsewhere | ✅ with per-action approval | your dApp runs in a browser and the user is present to approve each send — e.g. a **browser game** where the player approves in-game purchases |
+| **`nodejs/`** | a Node CLI / service | the **user's**, over WebSocket | ✅ with approval | you need a **CLI / desktop / server** dApp that drives a user's wallet over a WebSocket (see the caveat in its README) |
+| **`bot/`** | an autonomous agent | **its own** (own keys) | ✅ no approval — it owns the funds | you're building a **tipping bot, faucet, game NPC that pays rewards, or an agent** that acts from its own float with no human in the loop |
+| **`backend-auth/`** | a frontend + backend | the **user's** (frontend only signs) | ❌ **auth only** | you need to know **who** the player is — login, leaderboards, ownership, sessions — but do **not** need to move their tokens. **Recommended for games/apps that need authenticated identity, not custody or intents** |
+
+Rules of thumb:
+
+- **Need to move a *user's* tokens?** → `browser/` (web) or `nodejs/` (Node over WS). The user approves each action.
+- **Moving *your own* tokens autonomously?** → `bot/`. It is the wallet; no approval prompts.
+- **Just need to know who the user is?** → `backend-auth/`. It authenticates and stops there — it never touches funds.
 
 ## Quick Start
 
-### Browser dApp
+### `browser/` — web dApp over Connect
 
 ```bash
 cd browser
 npm install
 npm run dev        # http://localhost:5174
 ```
+Needs a Sphere wallet reachable at `http://localhost:5173` (or the Sphere extension). See [browser/README.md](browser/README.md).
 
-Requires a Sphere wallet at `http://localhost:5173` (or Sphere extension installed).
-
-### Node.js CLI
+### `nodejs/` — Node dApp over WebSocket
 
 ```bash
 cd nodejs
 npm install
-npm run server     # Terminal 1: mock wallet (ws://localhost:8765)
-npm run client     # Terminal 2: CLI client
+npm run server     # Terminal 1: mock wallet  (ws://localhost:8765)
+npm run client     # Terminal 2: CLI dApp
 ```
+Drives a wallet over `WebSocketTransport`. See [nodejs/README.md](nodejs/README.md).
 
-## Browser Example Features
+### `bot/` — a bot with its own wallet
 
-All queries, intents, and events are demonstrated:
-
-**Queries** (read-only):
-`sphere_getIdentity` · `sphere_getBalance` · `sphere_getAssets` · `sphere_getFiatBalance` · `sphere_getTokens` · `sphere_getHistory` · `sphere_resolve`
-
-**Intents** (require wallet approval):
-`send` · `mint` · `dm` · `payment_request` · `receive` · `sign_message`
-
-**Events** (real-time push):
-auto-pushed `wallet:locked` · `identity:changed` · subscribable `transfer:incoming` · `transfer:confirmed` · `transfer:failed` · and more
-
-## 3-Priority Transport Selection
-
-```typescript
-import { isInIframe, hasExtension } from './lib/detection';
-
-if (isInIframe()) {
-  // P1: dApp embedded inside Sphere as iframe
-  transport = PostMessageTransport.forClient();
-} else if (hasExtension()) {
-  // P2: Sphere browser extension installed
-  transport = ExtensionTransport.forClient();
-} else {
-  // P3: open Sphere as popup window
-  transport = PostMessageTransport.forClient({ target: popup, targetOrigin: WALLET_URL });
-}
+```bash
+cd bot
+npm install
+cp .env.example .env
+npm start          # boots its own wallet on testnet2, self-mints, DM-echoes
 ```
+No Connect involved — the bot *is* the wallet. See [bot/README.md](bot/README.md).
 
-## Auto-Connect on Page Load
+### `backend-auth/` — sign in with a Sphere wallet
 
-```typescript
-// Silent check — no popup if not approved
-const client = new ConnectClient({ transport, dapp, silent: true });
-try {
-  await client.connect();   // instant if already approved
-} catch {
-  // Show Connect button
-}
+```bash
+# Terminal 1 — backend  (http://localhost:8787)
+cd backend-auth/backend  && npm install && cp .env.example .env && npm start
+# Terminal 2 — frontend (http://localhost:5173)
+cd backend-auth/frontend && npm install && cp .env.example .env && npm run dev
 ```
+Frontend brokers a `sign_message`; backend recovers the pubkey and issues a JWT. See [backend-auth/README.md](backend-auth/README.md).
 
 ## Dependencies
 
-Both subprojects pin a published sphere-sdk version:
+All four packages pin the same published SDK version:
+
 ```json
-"@unicitylabs/sphere-sdk": "0.10.2"
+"@unicitylabs/sphere-sdk": "0.11.14"
 ```
 
 ## Documentation
 
-- [browser/CONNECT.md](browser/CONNECT.md) — full dApp integration guide
+- [browser/CONNECT.md](browser/CONNECT.md) — full browser dApp integration guide
 - [sphere-sdk/docs/CONNECT.md](../../sphere-sdk/docs/CONNECT.md) — protocol reference
 
 ## License

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ npm run dev        # http://localhost:5174
 ```
 Needs a Sphere wallet reachable at `http://localhost:5173` (or the Sphere extension). See [browser/README.md](browser/README.md).
 
+> **Testing a local dApp against the real (hosted) wallet?** It only works via
+> **iframe** — load your dApp as a custom agent at
+> **https://sphere.unicity.network/agents/custom**. The **popup path returns
+> `403`** against the hosted wallet. (Applies to both `browser/` and
+> `backend-auth/frontend`.)
+
 ### `nodejs/` — Node dApp over WebSocket
 
 ```bash

--- a/backend-auth/README.md
+++ b/backend-auth/README.md
@@ -74,6 +74,15 @@ Open `http://localhost:5173`, click **Sign in with your Sphere wallet**,
 approve the connection and the signature request in your wallet. On success
 the page shows the recovered `chainPubkey` and a truncated session JWT.
 
+> **Testing against the real (hosted) wallet — use the iframe, not a popup.**
+> The frontend uses `autoConnect`, which falls back to a **popup** when it's not
+> running inside a wallet — and the popup path **does NOT work against the hosted
+> wallet (`https://sphere.unicity.network`): it returns `403`.** To test a
+> *local* frontend against the **live** wallet, load it as a **custom agent** at
+> **https://sphere.unicity.network/agents/custom** so the wallet embeds it in an
+> **iframe** (the P1 transport). Popup/localhost only works for a wallet you run
+> yourself.
+
 ## The byte-exact-challenge gotcha
 
 `backend/src/challenge.ts` funnels both challenge creation (`GET /challenge`)

--- a/backend-auth/README.md
+++ b/backend-auth/README.md
@@ -29,6 +29,27 @@ and the backend. The backend is the only party that decides who signed in,
 and it decides that by cryptographically **recovering** the pubkey from the
 signature — never by reading an identifier out of a request body.
 
+## When to use this
+
+Reach for this when your backend needs to know **who** a user is — prove wallet
+ownership — but does **not** need to move their tokens.
+
+Concrete examples:
+
+- A **game backend** that authenticates the player for leaderboards, ownership
+  checks, or sessions, but never touches their funds. (This is how the Unicity
+  quests backend works — it verifies a signature and keys the user on their
+  `chainPubkey`.)
+- A classic **"Sign in with your wallet"** login for any web app.
+- **Gating an API**: issue a JWT keyed on the verified `chainPubkey`.
+
+The backend here has **no wallet connection and no intents at all** — it can
+only verify a signature and issue a session. If you need to *act* on a wallet,
+use a different example:
+
+- To **send / receive on the user's behalf** (they approve) → [`../browser/`](../browser) (web) or [`../nodejs/`](../nodejs) (Node).
+- To move **your own** tokens autonomously → [`../bot/`](../bot).
+
 ## Run it
 
 Two terminals:

--- a/backend-auth/README.md
+++ b/backend-auth/README.md
@@ -1,0 +1,114 @@
+# Sphere Connect — Backend Auth Example
+
+A two-part example showing how a **backend** authenticates a user by their
+Sphere wallet's signature — not by trusting anything the client claims. A
+`frontend/` dApp brokers a signature from the wallet; a `backend/` Express
+server independently recovers the signer's public key from that signature
+and issues a session JWT.
+
+## Topology
+
+```
+Wallet                Frontend                 Backend
+  |                       |                        |
+  |                       |── GET /challenge ─────►|  ?chainPubkey=<hint>
+  |                       |◄── { nonce, challenge }|  builds + stores challenge
+  |                       |                        |
+  |◄── intent: sign_message (challenge) ───|        |
+  |── { signature, publicKey } ───────────►|        |
+  |                       |                        |
+  |                       |── POST /verify ───────►|  { nonce, signature }
+  |                       |                        |  recoverPubkeyFromSignature
+  |                       |◄── { jwt, chainPubkey }|  keyed on recovered pubkey
+```
+
+The **wallet never talks to the backend** — it only ever sees the frontend,
+over the Connect protocol (`autoConnect` + the `sign_message` intent). The
+frontend never proves anything by itself; it's a courier between the wallet
+and the backend. The backend is the only party that decides who signed in,
+and it decides that by cryptographically **recovering** the pubkey from the
+signature — never by reading an identifier out of a request body.
+
+## Run it
+
+Two terminals:
+
+```bash
+# Terminal 1 — backend (http://localhost:8787)
+cd backend-auth/backend
+npm install
+cp .env.example .env
+npm start
+```
+
+```bash
+# Terminal 2 — frontend (http://localhost:5173)
+cd backend-auth/frontend
+npm install
+cp .env.example .env
+npm run dev
+```
+
+Open `http://localhost:5173`, click **Sign in with your Sphere wallet**,
+approve the connection and the signature request in your wallet. On success
+the page shows the recovered `chainPubkey` and a truncated session JWT.
+
+## The byte-exact-challenge gotcha
+
+`backend/src/challenge.ts` funnels both challenge creation (`GET /challenge`)
+and challenge reconstruction (`POST /verify`) through one `formatChallenge`
+function. This isn't stylistic — it's the whole safety property the flow
+relies on.
+
+`recoverPubkeyFromSignature(message, signature)` mathematically recovers
+*some* valid public key from any well-formed signature — for the *exact*
+message that was signed. If the backend reconstructs even a slightly
+different string on `/verify` than the one the wallet actually signed on
+`/challenge` (different whitespace, a different line ending, fields
+reordered, a re-serialized timestamp), recovery doesn't fail — it silently
+returns a **different, still valid-looking pubkey**. There is no exception,
+no mismatch error: the backend just authenticates the wrong identity.
+
+That's why:
+- The backend stores the exact fields it used to build the challenge
+  (`chainPubkey`, `domain`, `nonce`, `issuedAt`, `expiresAt`) and
+  reconstructs the string from those stored fields on `/verify`, rather than
+  re-deriving it from anything supplied by the request.
+- There is exactly one formatter (`formatChallenge` in `challenge.ts`) — no
+  second code path is allowed to assemble challenge text.
+- The frontend signs the `challenge` string returned by `/challenge`
+  **verbatim** — no trimming, re-encoding, or reformatting before it's
+  handed to the `sign_message` intent.
+
+## Don't trust the wallet's self-reported `publicKey`
+
+The `sign_message` intent's result includes a `publicKey` field alongside
+the `signature` — but that field is simply what the wallet *says* signed the
+message. The frontend ignores it entirely. The backend never receives it (it
+only gets `{ nonce, signature }` on `/verify`) and instead calls
+`recoverPubkeyFromSignature` itself. Identity in this example is proven by
+that recovery step alone; a value merely asserted by a client (a `publicKey`
+field, a `chainPubkey` in a body, anything self-reported) is not a trust
+input anywhere in this flow.
+
+## chainPubkey vs. directAddress — a production note
+
+This example keys identity purely on the **recovered `chainPubkey`**, and
+stays deliberately thin because of it: recovering a pubkey from a signature
+needs nothing but the `recoverPubkeyFromSignature` crypto helper — no
+`Sphere` instance, no storage, no network.
+
+A production deployment such as `sphere-api` goes one step further: it
+additionally resolves the recovered `chainPubkey` to a `directAddress` /
+nametag via `sphere.resolve()` (a Nostr binding lookup), and may key user
+records on that resolved address instead. Resolving requires a full
+`Sphere.init()` (storage, transport, oracle), which is why this example
+doesn't do it. Either way, the rule doesn't change: the key you trust is
+always something the backend **derived** itself — the recovered pubkey, or
+an address resolved from it — never a value a client handed you in a
+request.
+
+## Generating an example like this
+
+The `sphere-connect` Claude Code plugin's `backend-auth.md` skill can
+generate a backend-auth pair like this one from a prompt.

--- a/backend-auth/backend/.env.example
+++ b/backend-auth/backend/.env.example
@@ -1,0 +1,12 @@
+# HTTP port the Express server listens on
+PORT=8787
+# HMAC secret used to sign session JWTs. Dev-only value — replace in any
+# real deployment (e.g. a 64-hex random string) and never commit the real one.
+JWT_SECRET=dev-only-change-me
+# How long an issued session JWT stays valid, in seconds
+SESSION_TTL_SECONDS=7200
+# Domain bound into the signed challenge string (anti-phishing: ties a
+# signature to this backend so it can't be replayed against another site)
+AUTH_DOMAIN=localhost
+# Origin allowed to call this API (CORS) — the backend-auth frontend (Task 6)
+FRONTEND_ORIGIN=http://localhost:5173

--- a/backend-auth/backend/.gitignore
+++ b/backend-auth/backend/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+*.tsbuildinfo

--- a/backend-auth/backend/package-lock.json
+++ b/backend-auth/backend/package-lock.json
@@ -1,0 +1,3633 @@
+{
+  "name": "sphere-connect-backend-auth-example",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sphere-connect-backend-auth-example",
+      "version": "0.0.0",
+      "dependencies": {
+        "@unicitylabs/sphere-sdk": "0.11.14",
+        "dotenv": "^17.4.2",
+        "express": "^4.21.2",
+        "jsonwebtoken": "^9.0.2",
+        "nanoid": "^5.1.5"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.21",
+        "@types/jsonwebtoken": "^9.0.7",
+        "@types/node": "^22.0.0",
+        "tsx": "^4.19.0",
+        "typescript": "~5.6.0",
+        "vitest": "^4.1.10"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@chainsafe/is-ip": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.1.0.tgz",
+      "integrity": "sha512-KIjt+6IfysQ4GCv66xihEitBjvhU/bixbbbFxdJ1sqCp4uJ0wuZiYBPhksZoy4lfaF0k9cwNzY5upEW/VWdw3w==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@dnsquery/dns-packet": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@dnsquery/dns-packet/-/dns-packet-6.1.1.tgz",
+      "integrity": "sha512-WXTuFvL3G+74SchFAtz3FgIYVOe196ycvGsMgvSH/8Goptb1qpIQtIuM4SOK9G9lhMWYpHxnXyy544ZhluFOew==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.4",
+        "utf8-codec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/crypto": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
+      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/interface": "^3.2.5",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "multiformats": "^14.0.0",
+        "protons-runtime": "^7.0.0",
+        "uint8arraylist": "^3.0.2",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/crypto/node_modules/multiformats": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/interface": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
+      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@multiformats/dns": "^1.0.6",
+        "@multiformats/multiaddr": "^13.0.3",
+        "main-event": "^1.0.1",
+        "multiformats": "^14.0.0",
+        "progress-events": "^1.1.0",
+        "uint8arraylist": "^3.0.2"
+      }
+    },
+    "node_modules/@libp2p/interface/node_modules/multiformats": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/logger": {
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.10.tgz",
+      "integrity": "sha512-recRqNABHG32YXvpMvNepFCuU14d51dF5hs+vR2C/tkqXBQc0Sqg5LtWB2NYPoIJV+JUB50iWLrvBXZUOjLc9Q==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/interface": "^3.2.5",
+        "@multiformats/multiaddr": "^13.0.3",
+        "interface-datastore": "^10.0.1",
+        "multiformats": "^14.0.0",
+        "weald": "^1.1.0"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/interface-datastore": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-10.0.1.tgz",
+      "integrity": "sha512-DYMj/Og5Cz1Qwkx6/x5KRvR8SYEX7rVAv3KKCm2NzTwWSfpNAC4PahjcYbHyoZBP6zPWrhQv5n5wE+vaDdgSAg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "abort-error": "^1.0.2",
+        "interface-store": "^8.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/interface-store": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-8.0.0.tgz",
+      "integrity": "sha512-e2+s3EEROzM+Wlas4hU3zveTUscvVMf1BOvdsJfpzFm19SoEXLVadpACjWOnM491HqGpvtfFnevyiaN8W+I6Eg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "abort-error": "^1.0.2"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/multiformats": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/peer-id": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.12.tgz",
+      "integrity": "sha512-U44MeKs+U1SqZPqS0RDzjjcS9ERix2zJsJkTcqi8I+5flEz4uVAObBDxvkkaTaqRFRXCXEPjL5kA4UbgVubCZQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/interface": "^3.2.5",
+        "multiformats": "^14.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/peer-id/node_modules/multiformats": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@multiformats/dns": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.15.tgz",
+      "integrity": "sha512-W0zAMABtAn+3chgFcPGvllKND7M6GblMAAFcJQTy+iMmGiyFErZYPzAh2b50Y3SFf340iFV7+ckVgZkGfUyxzA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@dnsquery/dns-packet": "^6.1.1",
+        "@libp2p/interface": "^3.1.0",
+        "hashlru": "^2.3.0",
+        "p-queue": "^9.0.0",
+        "progress-events": "^1.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@multiformats/multiaddr": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-13.0.3.tgz",
+      "integrity": "sha512-mEqqJ4r3a/uuFMTpRkU316wGNIDQNhuVWpm+ebKTQeYsfv9jXbPONWM6VVnj3KGUrwfsX7GZOyp4TFqEA2SPCw==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "multiformats": "^14.0.0",
+        "uint8-varint": "^3.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/multiformats": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.9",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.9.tgz",
+      "integrity": "sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/nostr-js-sdk/-/nostr-js-sdk-0.6.0.tgz",
+      "integrity": "sha512-l6WcCmFok9nxI1WkYsjIVu67svouA2QyB5Vb+GTNugWrbw7hUgJMA1Elj8qu3u0qojvSINL/L9eWTmXVWRzZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^1.0.0",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/base": "^1.1.9",
+        "libphonenumber-js": "^1.11.14"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@unicitylabs/sphere-sdk": {
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.14.tgz",
+      "integrity": "sha512-bS3tRC/ofZK4uqj9pRO8TE4gfFxKUvLAmsl2GLove/1yY7OINjOLzsZbqa2BbWrxl09s5cJSgG/WMFRNXcWyuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^2.2.0",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "@unicitylabs/nostr-js-sdk": "^0.6.0",
+        "@unicitylabs/state-transition-sdk": "2.0.0-rc.68bc1e5",
+        "bip39": "^3.1.0",
+        "buffer": "^6.0.3",
+        "canonicalize": "^3.0.0",
+        "crypto-js": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "@libp2p/crypto": "^5.1.13",
+        "@libp2p/peer-id": "^6.0.4",
+        "ipns": "^10.0.0",
+        "multiformats": "^13.4.2"
+      },
+      "peerDependencies": {
+        "@libp2p/crypto": ">=5.0.0",
+        "@libp2p/peer-id": ">=6.0.0",
+        "ipns": ">=10.0.0",
+        "multiformats": ">=13.0.0",
+        "ws": ">=8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@libp2p/crypto": {
+          "optional": true
+        },
+        "@libp2p/peer-id": {
+          "optional": true
+        },
+        "ipns": {
+          "optional": true
+        },
+        "multiformats": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@unicitylabs/state-transition-sdk": {
+      "version": "2.0.0-rc.68bc1e5",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/state-transition-sdk/-/state-transition-sdk-2.0.0-rc.68bc1e5.tgz",
+      "integrity": "sha512-JJ1jQFTexMBRwpn3pmhm4s2FulBcOBGyNZmQ4qd5ZheenbVLUkY5KSJ++J3Gnh/Vmhd6WVuCBw+FCyqXN39aHQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "uuid": "14.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/abort-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/abort-error/-/abort-error-1.0.2.tgz",
+      "integrity": "sha512-lVgvB2NyPLqbXXhVmXcYFTC1x5K7CiVdPgdY7LGgFQWC8506oN01sPN3i9cl9ynuwF4iJ0TS9exnR7cZ9FuX4w==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bip39": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
+      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0"
+      }
+    },
+    "node_modules/bip39/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/canonicalize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-3.0.0.tgz",
+      "integrity": "sha512-yYLfHyDMIXRyRqsKBRLX023riFLpXY2YOfdtqKXZRZy9qsfOJ9U+4F9YZL7MEzL5+ziN2x2nlBvY/Voi3EBljA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cborg": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.7.tgz",
+      "integrity": "sha512-rGg2MG9zZEUKtKqjkBppIWUecTXf9N1vs1Qru43vJWoDaODhCrtmzdehCaA/aq/c1cPI5A0kPrJ5Tf+jIfhV4w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/interface-datastore": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-9.0.3.tgz",
+      "integrity": "sha512-NLZa7Mp+0qn48nSwIY/C36da4uVIKzwG2tuEIpaSJArsuB2RrdyDWwkoDUyjsJ+VrMntXz38VSk9vXTx/ZUpAw==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "interface-store": "^7.0.0",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/interface-datastore/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/interface-store": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-7.0.2.tgz",
+      "integrity": "sha512-KYOPcDH+1peaPhSeoZujR5nwkVeola1EdrnrlHTIM0HRNUs9B0aTsUQMH5kTmIjaQq1BOowoUyoCamgL8IMyww==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/ipns": {
+      "version": "10.1.6",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-10.1.6.tgz",
+      "integrity": "sha512-mTACIdTBBXY5kbCo3t/M3ycNWbjajLrSXhTvjD0MEGyOUaI3uMv94JbJSHGaJ2xxRlpOrRk1ifToOsyPZiglnA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/crypto": "^5.0.0",
+        "@libp2p/interface": "^3.0.2",
+        "@libp2p/logger": "^6.0.4",
+        "cborg": "^5.1.0",
+        "interface-datastore": "^9.0.2",
+        "multiformats": "^13.2.2",
+        "protons-runtime": "^6.0.1",
+        "timestamp-nano": "^1.0.1",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/ipns/node_modules/protons-runtime": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8-varint": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.5.tgz",
+      "integrity": "sha512-jeFLbL/x30wBRnWjKE1qVBXeumG46r7XmYkpis955lTQ+blccGKFrOsSMHlxePwYB1pI7L8YPHz1t4jLxEs3nA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8arraylist": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.9.tgz",
+      "integrity": "sha512-KxWjyEFzchzik3aoQlK66oaoxIReoMo5bQRm1fcjBUZvE8xv/tyR3CTKhjh6K/faV8VaF6hd5pjr45CzbwuwkA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.13.9",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.9.tgz",
+      "integrity": "sha512-VNS5vWMM7r0P66BYv+TQJATxExEgLxN+34hfHDVhDkUsGAE4cRg0shCNSLTXNKm7nIUscC7AfB51TjxEeF7msQ==",
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/main-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/main-event/-/main-event-1.0.4.tgz",
+      "integrity": "sha512-sKazUjIy2Jalv5lkQ446iOcrx8Q7TkaCuk6xfnzg5uUqMusMLDMPmRDmSNE2kjSVpSTJo4j1bQZusS+Ib7Bvrg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.1.tgz",
+      "integrity": "sha512-POWdiIPmsUPGwb4FeQ4OBg46aqmcInSWe45CKDsGHiOBiVQM9chqfQTuqhuTzcg2Vz9faTI65at0KkVyVEiCHw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/progress-events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.1.0.tgz",
+      "integrity": "sha512-82DVc5tI36neVB3IjdXR11ztwGuoBc98em9ijzubeZKxI47OlV2Znq6mlPqE5xPDzO2Uw98GHiQSjj2favBCRQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/protons-runtime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-7.0.0.tgz",
+      "integrity": "sha512-r/e72006xoVND4Uvf1aIs4OQOkJaASBU3ip4DzOWAktoKAkTiOYqKoS3TYMBm8HnnYU8+h0uEzr5gIRwk/pmTg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8-varint": "^3.0.0",
+        "uint8arraylist": "^3.0.0",
+        "uint8arrays": "^6.0.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/timestamp-nano": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/timestamp-nano/-/timestamp-nano-1.0.1.tgz",
+      "integrity": "sha512-4oGOVZWTu5sl89PtCDnhQBSt7/vL1zVEwAfxH1p49JhTosxzVQWYBYFRFZ8nJmo0G6f824iyP/44BFAwIoKvIA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uint8-varint": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-3.0.0.tgz",
+      "integrity": "sha512-S4DdpXBaLwKcFo7f0bWzWfHjbZ/i3QhM842qn+ZvHjxqFCfUcEB9SQNcmI69S+zMlcmIcKxsk9Iyw77S2Kxv6Q==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arraylist": "^3.0.1",
+        "uint8arrays": "^6.1.0"
+      }
+    },
+    "node_modules/uint8arraylist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-3.0.2.tgz",
+      "integrity": "sha512-LDVoq9BQaGJzGDUovEnoX6rpKCvnY/Jbtws4ikwnBzjRbq5qBAFpBZevUEbSmMM87aO0Sp+wOZy2ZXf5yODmXQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arrays": "^6.0.0"
+      }
+    },
+    "node_modules/uint8arrays": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-6.1.1.tgz",
+      "integrity": "sha512-iz7JN0XCSZYA111lhFG2Ui9EhFvTNekqSRHw3lvMHq+dzwWy1OQftxFQREEh4rffU0oSoXdQHsk2TiHKVm4fsA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^14.0.0"
+      }
+    },
+    "node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utf8-codec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utf8-codec/-/utf8-codec-1.0.0.tgz",
+      "integrity": "sha512-S/QSLezp3qvG4ld5PUfXiH7mCFxLKjSVZRFkB3DOjgwHuJPFDkInAXc/anf7BAbHt/D38ozDzL+QMZ6/7gsI6w==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/weald": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/weald/-/weald-1.1.3.tgz",
+      "integrity": "sha512-vMWtNbYuPb58NeG2+0sKA0Een4VMDwzf+3oHqh68buWRSOMUBlUeRb11LhV28czV+DUpJHRykifijZDuS9bInA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^4.0.0-nightly.202508271359",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/weald/node_modules/ms": {
+      "version": "4.0.0-nightly.202508271359",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-4.0.0-nightly.202508271359.tgz",
+      "integrity": "sha512-WC/Eo7NzFrOV/RRrTaI0fxKVbNCzEy76j2VqNV8SxDf9D69gSE2Lh0QwYvDlhiYmheBYExAvEAxVf5NoN0cj2A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/backend-auth/backend/package.json
+++ b/backend-auth/backend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "sphere-connect-backend-auth-example",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "start": "tsx src/server.ts",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@unicitylabs/sphere-sdk": "0.11.14",
+    "dotenv": "^17.4.2",
+    "express": "^4.21.2",
+    "jsonwebtoken": "^9.0.2",
+    "nanoid": "^5.1.5"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/jsonwebtoken": "^9.0.7",
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "~5.6.0",
+    "vitest": "^4.1.10"
+  }
+}

--- a/backend-auth/backend/src/challenge.test.ts
+++ b/backend-auth/backend/src/challenge.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { buildChallenge, reconstructChallenge } from './challenge';
+
+// Deterministic fixtures — never Date.now()/Math.random() in the functions
+// under test, so these values are injected explicitly.
+const CHAIN_PUBKEY = '02' + 'a'.repeat(64);
+const DOMAIN = 'localhost';
+const NOW = 1_700_000_000_000; // fixed epoch ms
+const NONCE = 'nonce-fixed-0001';
+const TTL_SECONDS = 300;
+
+describe('buildChallenge', () => {
+  it('returns a multi-line challenge containing nonce, issuedAt, expiresAt, domain, and chainPubkey', () => {
+    const { challenge, nonce, issuedAt, expiresAt } = buildChallenge({
+      chainPubkey: CHAIN_PUBKEY,
+      domain: DOMAIN,
+      now: NOW,
+      nonce: NONCE,
+      ttlSeconds: TTL_SECONDS,
+    });
+
+    expect(nonce).toBe(NONCE);
+    expect(issuedAt).toBe(NOW);
+    expect(expiresAt).toBe(NOW + TTL_SECONDS * 1000);
+
+    expect(challenge).toContain(NONCE);
+    expect(challenge).toContain(DOMAIN);
+    expect(challenge).toContain(CHAIN_PUBKEY);
+    expect(challenge).toContain(new Date(issuedAt).toISOString());
+    expect(challenge).toContain(new Date(expiresAt).toISOString());
+    expect(challenge.split('\n').length).toBeGreaterThan(1);
+  });
+
+  it('produces different challenges for different nonces (same everything else)', () => {
+    const a = buildChallenge({
+      chainPubkey: CHAIN_PUBKEY,
+      domain: DOMAIN,
+      now: NOW,
+      nonce: 'nonce-aaaa',
+      ttlSeconds: TTL_SECONDS,
+    });
+    const b = buildChallenge({
+      chainPubkey: CHAIN_PUBKEY,
+      domain: DOMAIN,
+      now: NOW,
+      nonce: 'nonce-bbbb',
+      ttlSeconds: TTL_SECONDS,
+    });
+
+    expect(a.challenge).not.toBe(b.challenge);
+  });
+});
+
+describe('reconstructChallenge', () => {
+  it('is byte-identical to the original buildChallenge output — the whole safety property', () => {
+    const built = buildChallenge({
+      chainPubkey: CHAIN_PUBKEY,
+      domain: DOMAIN,
+      now: NOW,
+      nonce: NONCE,
+      ttlSeconds: TTL_SECONDS,
+    });
+
+    // Simulate what the server stores keyed by nonce, then reconstructs on /verify.
+    const stored = {
+      chainPubkey: CHAIN_PUBKEY,
+      domain: DOMAIN,
+      nonce: built.nonce,
+      issuedAt: built.issuedAt,
+      expiresAt: built.expiresAt,
+    };
+
+    const reconstructed = reconstructChallenge(stored);
+
+    expect(reconstructed).toBe(built.challenge);
+    // Belt-and-braces: exact byte length match too, not just string equality
+    // semantics — guards against any hidden normalization difference.
+    expect(reconstructed.length).toBe(built.challenge.length);
+  });
+
+  it('reconstructs a different string when any stored field differs (drift is detectable)', () => {
+    const built = buildChallenge({
+      chainPubkey: CHAIN_PUBKEY,
+      domain: DOMAIN,
+      now: NOW,
+      nonce: NONCE,
+      ttlSeconds: TTL_SECONDS,
+    });
+
+    const wrongNonce = reconstructChallenge({
+      chainPubkey: CHAIN_PUBKEY,
+      domain: DOMAIN,
+      nonce: 'different-nonce',
+      issuedAt: built.issuedAt,
+      expiresAt: built.expiresAt,
+    });
+
+    expect(wrongNonce).not.toBe(built.challenge);
+  });
+});

--- a/backend-auth/backend/src/challenge.ts
+++ b/backend-auth/backend/src/challenge.ts
@@ -1,0 +1,78 @@
+/**
+ * Sign-in challenge construction/reconstruction.
+ *
+ * THE central safety property of chainPubkey-recovery auth: the string the
+ * backend feeds into `recoverPubkeyFromSignature` on /verify must be
+ * byte-identical to the string the wallet actually signed on /challenge. If
+ * it drifts by even one byte (whitespace, line-ending, field order, a
+ * re-serialized number), `recoverPubkeyFromSignature` silently returns a
+ * DIFFERENT-but-valid-looking pubkey — no error, wrong identity.
+ *
+ * To make that impossible, both directions go through the *same*
+ * `formatChallenge` — build() calls it with freshly-generated fields,
+ * reconstruct() calls it with the exact fields the server stored for the
+ * nonce. There is no second place that assembles challenge text.
+ *
+ * `now` and `nonce` are injected (never `Date.now()`/`Math.random()` inside
+ * these functions) so the pure logic here is deterministic and unit-testable
+ * without faking globals.
+ */
+
+export interface ChallengeRecord {
+  chainPubkey: string;
+  domain: string;
+  nonce: string;
+  issuedAt: number; // epoch ms
+  expiresAt: number; // epoch ms
+}
+
+export interface BuildChallengeParams {
+  chainPubkey: string;
+  domain: string;
+  now: number; // injected epoch ms ("current" time)
+  nonce: string; // injected nonce (caller generates, e.g. via nanoid)
+  ttlSeconds: number;
+}
+
+export interface BuiltChallenge {
+  challenge: string;
+  nonce: string;
+  issuedAt: number;
+  expiresAt: number;
+}
+
+/**
+ * The single formatter. Both `buildChallenge` and `reconstructChallenge`
+ * call this — never format challenge text anywhere else.
+ */
+function formatChallenge(fields: ChallengeRecord): string {
+  return [
+    'Sign in to the Sphere Connect example',
+    '',
+    `Domain: ${fields.domain}`,
+    `Chain Pubkey: ${fields.chainPubkey}`,
+    `Nonce: ${fields.nonce}`,
+    `Issued At: ${new Date(fields.issuedAt).toISOString()}`,
+    `Expiration Time: ${new Date(fields.expiresAt).toISOString()}`,
+  ].join('\n');
+}
+
+/** Builds a fresh challenge from injected `now`/`nonce`. */
+export function buildChallenge(params: BuildChallengeParams): BuiltChallenge {
+  const { chainPubkey, domain, now, nonce, ttlSeconds } = params;
+  const issuedAt = now;
+  const expiresAt = now + ttlSeconds * 1000;
+
+  const challenge = formatChallenge({ chainPubkey, domain, nonce, issuedAt, expiresAt });
+
+  return { challenge, nonce, issuedAt, expiresAt };
+}
+
+/**
+ * Rebuilds the exact challenge string for a stored record (looked up by
+ * nonce on /verify). Must never diverge from what `buildChallenge` produced
+ * for the same fields — that's why both funnel through `formatChallenge`.
+ */
+export function reconstructChallenge(stored: ChallengeRecord): string {
+  return formatChallenge(stored);
+}

--- a/backend-auth/backend/src/server.ts
+++ b/backend-auth/backend/src/server.ts
@@ -1,0 +1,165 @@
+/**
+ * Backend-auth example server: authenticate a Sphere wallet by cryptographic
+ * signature recovery — never by trusting a client-claimed identity.
+ *
+ * Flow:
+ *  1. GET /challenge?chainPubkey=<66-hex>  — the frontend (Task 6) passes the
+ *     connected wallet's chainPubkey so the challenge text binds to it. The
+ *     server builds+stores a single-use challenge and returns it.
+ *  2. The frontend asks the wallet (via Connect `sign_message`) to sign the
+ *     returned `challenge` string verbatim.
+ *  3. POST /verify { nonce, signature } — the server looks up the nonce,
+ *     deletes it (single-use), reconstructs the *exact* challenge text from
+ *     the stored fields, and recovers the signer's pubkey from the
+ *     signature. Identity is keyed ONLY on that recovered pubkey — the
+ *     chainPubkey passed to /challenge is a hint for challenge binding, not
+ *     a trust input.
+ *
+ * Production nuance (see sphere-api/src/services/auth.service.ts): a real
+ * deployment additionally resolves the recovered chainPubkey to a
+ * directAddress/nametag via `sphere.resolve()` (Nostr binding lookup) and
+ * keys the user record on that resolved directAddress instead of the raw
+ * pubkey — resolution needs a full `Sphere.init()` (storage, transport,
+ * oracle), which is out of scope for this thin example (see Task 7 notes).
+ * This example stays intentionally thin and keys identity on the recovered
+ * chainPubkey directly.
+ */
+
+import 'dotenv/config';
+import express from 'express';
+import type { Request, Response } from 'express';
+import jwt from 'jsonwebtoken';
+import { nanoid } from 'nanoid';
+import { recoverPubkeyFromSignature, verifySignedMessage } from '@unicitylabs/sphere-sdk';
+import { buildChallenge, reconstructChallenge, type ChallengeRecord } from './challenge.js';
+
+const PORT = Number(process.env.PORT ?? 8787);
+const JWT_SECRET = process.env.JWT_SECRET ?? 'dev-only-change-me';
+const SESSION_TTL_SECONDS = Number(process.env.SESSION_TTL_SECONDS ?? 7200);
+const AUTH_DOMAIN = process.env.AUTH_DOMAIN ?? 'localhost';
+const FRONTEND_ORIGIN = process.env.FRONTEND_ORIGIN ?? 'http://localhost:5173';
+
+// 66 lowercase hex chars — the shape of a compressed secp256k1 pubkey. This
+// is a cheap shape check on the binding *hint*, not a trust decision: /verify
+// never trusts this value, only the pubkey it independently recovers from
+// the signature.
+const CHAIN_PUBKEY_RE = /^[0-9a-f]{66}$/;
+
+const CHALLENGE_TTL_SECONDS = 5 * 60;
+
+/**
+ * In-memory nonce store, keyed by nonce → the fields needed to reconstruct
+ * the exact challenge text. This is a demo store: single-process, no
+ * persistence, no background eviction of expired-but-unused entries.
+ *
+ * Production replaces this with a TTL-indexed store (Redis / a DB collection
+ * with an expiry index) shared across server instances, but keeps the same
+ * two properties this example relies on: (1) single-use — deleted the
+ * instant it's consumed by /verify, so a captured signature+nonce can't be
+ * replayed; (2) expiring — /verify rejects a nonce whose expiresAt has
+ * passed even if it's still present.
+ */
+const nonceStore = new Map<string, ChallengeRecord>();
+
+const app = express();
+app.use(express.json());
+
+app.use((req: Request, res: Response, next) => {
+  res.setHeader('Access-Control-Allow-Origin', FRONTEND_ORIGIN);
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  if (req.method === 'OPTIONS') {
+    res.sendStatus(204);
+    return;
+  }
+  next();
+});
+
+app.get('/challenge', (req: Request, res: Response) => {
+  const chainPubkey = req.query.chainPubkey;
+
+  if (typeof chainPubkey !== 'string' || !CHAIN_PUBKEY_RE.test(chainPubkey)) {
+    res.status(400).json({
+      error: 'chainPubkey must be a 66-char lowercase-hex compressed secp256k1 public key (02/03 prefix)',
+    });
+    return;
+  }
+
+  const nonce = nanoid(24);
+  const built = buildChallenge({
+    chainPubkey,
+    domain: AUTH_DOMAIN,
+    now: Date.now(),
+    nonce,
+    ttlSeconds: CHALLENGE_TTL_SECONDS,
+  });
+
+  nonceStore.set(nonce, {
+    chainPubkey,
+    domain: AUTH_DOMAIN,
+    nonce: built.nonce,
+    issuedAt: built.issuedAt,
+    expiresAt: built.expiresAt,
+  });
+
+  res.json({ nonce: built.nonce, challenge: built.challenge, expiresAt: built.expiresAt });
+});
+
+app.post('/verify', (req: Request, res: Response) => {
+  const { nonce, signature } = req.body ?? {};
+
+  if (typeof nonce !== 'string' || typeof signature !== 'string') {
+    res.status(400).json({ error: 'Body must include { nonce: string, signature: string }' });
+    return;
+  }
+
+  // Single-use: look up AND delete atomically (synchronous — no other
+  // request can interleave in Node's single-threaded event loop) so a
+  // replayed (nonce, signature) pair can never verify twice.
+  const stored = nonceStore.get(nonce);
+  nonceStore.delete(nonce);
+
+  if (!stored) {
+    res.status(401).json({ error: 'Unknown or already-used nonce' });
+    return;
+  }
+
+  if (Date.now() > stored.expiresAt) {
+    res.status(401).json({ error: 'Challenge expired' });
+    return;
+  }
+
+  // Reconstruct the EXACT string the wallet was asked to sign. Must go
+  // through the same formatter buildChallenge used — see challenge.ts.
+  const challenge = reconstructChallenge(stored);
+
+  let recovered: string;
+  try {
+    recovered = recoverPubkeyFromSignature(challenge, signature);
+  } catch (err) {
+    res.status(401).json({ error: `Malformed signature: ${(err as Error).message}` });
+    return;
+  }
+
+  // Sanity re-check: the recovered pubkey must actually verify against the
+  // signature it was recovered from. (recoverPubkeyFromSignature already
+  // guarantees this mathematically, but re-checking via the independent
+  // verifySignedMessage path costs little and catches any future drift
+  // between the two implementations.)
+  if (!verifySignedMessage(challenge, signature, recovered)) {
+    res.status(401).json({ error: 'Signature verification failed' });
+    return;
+  }
+
+  // Identity is keyed ONLY on `recovered` — never on stored.chainPubkey
+  // (the hint the frontend supplied to bind the challenge) and never on any
+  // body-claimed identifier. This is the whole point of recovery-based auth.
+  const expiresIn = SESSION_TTL_SECONDS;
+  const token = jwt.sign({ sub: recovered }, JWT_SECRET, { expiresIn });
+
+  res.json({ jwt: token, chainPubkey: recovered, expiresIn });
+});
+
+app.listen(PORT, () => {
+  console.log(`backend-auth example listening on http://localhost:${PORT}`);
+});

--- a/backend-auth/backend/tsconfig.json
+++ b/backend-auth/backend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/backend-auth/frontend/.env.example
+++ b/backend-auth/frontend/.env.example
@@ -1,0 +1,7 @@
+# Base URL of the backend-auth backend (Task 5) this frontend talks to.
+VITE_BACKEND_URL=http://localhost:8787
+
+# Wallet URL used for the popup fallback (P3) when autoConnect can't use an
+# iframe or the browser extension. Only needed outside an iframe/extension
+# context. Same default as the browser/ example's VITE_WALLET_URL.
+VITE_WALLET_URL=https://sphere.unicity.network

--- a/backend-auth/frontend/.gitignore
+++ b/backend-auth/frontend/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+*.tsbuildinfo

--- a/backend-auth/frontend/index.html
+++ b/backend-auth/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Backend Auth — Sphere Connect Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/backend-auth/frontend/package-lock.json
+++ b/backend-auth/frontend/package-lock.json
@@ -1,0 +1,2557 @@
+{
+  "name": "sphere-connect-backend-auth-frontend",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sphere-connect-backend-auth-frontend",
+      "version": "0.0.0",
+      "dependencies": {
+        "@unicitylabs/sphere-sdk": "0.11.14",
+        "react": "^19.1.1",
+        "react-dom": "^19.2.4"
+      },
+      "devDependencies": {
+        "@types/react": "^19.1.16",
+        "@types/react-dom": "^19.1.9",
+        "@vitejs/plugin-react": "^5.0.4",
+        "typescript": "~5.6.0",
+        "vite": "^7.1.7"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@chainsafe/is-ip": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.1.0.tgz",
+      "integrity": "sha512-KIjt+6IfysQ4GCv66xihEitBjvhU/bixbbbFxdJ1sqCp4uJ0wuZiYBPhksZoy4lfaF0k9cwNzY5upEW/VWdw3w==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@dnsquery/dns-packet": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@dnsquery/dns-packet/-/dns-packet-6.1.1.tgz",
+      "integrity": "sha512-WXTuFvL3G+74SchFAtz3FgIYVOe196ycvGsMgvSH/8Goptb1qpIQtIuM4SOK9G9lhMWYpHxnXyy544ZhluFOew==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.4",
+        "utf8-codec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/crypto": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
+      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/interface": "^3.2.5",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "multiformats": "^14.0.0",
+        "protons-runtime": "^7.0.0",
+        "uint8arraylist": "^3.0.2",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/crypto/node_modules/multiformats": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/interface": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
+      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@multiformats/dns": "^1.0.6",
+        "@multiformats/multiaddr": "^13.0.3",
+        "main-event": "^1.0.1",
+        "multiformats": "^14.0.0",
+        "progress-events": "^1.1.0",
+        "uint8arraylist": "^3.0.2"
+      }
+    },
+    "node_modules/@libp2p/interface/node_modules/multiformats": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/logger": {
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.10.tgz",
+      "integrity": "sha512-recRqNABHG32YXvpMvNepFCuU14d51dF5hs+vR2C/tkqXBQc0Sqg5LtWB2NYPoIJV+JUB50iWLrvBXZUOjLc9Q==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/interface": "^3.2.5",
+        "@multiformats/multiaddr": "^13.0.3",
+        "interface-datastore": "^10.0.1",
+        "multiformats": "^14.0.0",
+        "weald": "^1.1.0"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/interface-datastore": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-10.0.1.tgz",
+      "integrity": "sha512-DYMj/Og5Cz1Qwkx6/x5KRvR8SYEX7rVAv3KKCm2NzTwWSfpNAC4PahjcYbHyoZBP6zPWrhQv5n5wE+vaDdgSAg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "abort-error": "^1.0.2",
+        "interface-store": "^8.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/interface-store": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-8.0.0.tgz",
+      "integrity": "sha512-e2+s3EEROzM+Wlas4hU3zveTUscvVMf1BOvdsJfpzFm19SoEXLVadpACjWOnM491HqGpvtfFnevyiaN8W+I6Eg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "abort-error": "^1.0.2"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/multiformats": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/peer-id": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.12.tgz",
+      "integrity": "sha512-U44MeKs+U1SqZPqS0RDzjjcS9ERix2zJsJkTcqi8I+5flEz4uVAObBDxvkkaTaqRFRXCXEPjL5kA4UbgVubCZQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/interface": "^3.2.5",
+        "multiformats": "^14.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/peer-id/node_modules/multiformats": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@multiformats/dns": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.15.tgz",
+      "integrity": "sha512-W0zAMABtAn+3chgFcPGvllKND7M6GblMAAFcJQTy+iMmGiyFErZYPzAh2b50Y3SFf340iFV7+ckVgZkGfUyxzA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@dnsquery/dns-packet": "^6.1.1",
+        "@libp2p/interface": "^3.1.0",
+        "hashlru": "^2.3.0",
+        "p-queue": "^9.0.0",
+        "progress-events": "^1.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@multiformats/multiaddr": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-13.0.3.tgz",
+      "integrity": "sha512-mEqqJ4r3a/uuFMTpRkU316wGNIDQNhuVWpm+ebKTQeYsfv9jXbPONWM6VVnj3KGUrwfsX7GZOyp4TFqEA2SPCw==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "multiformats": "^14.0.0",
+        "uint8-varint": "^3.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/multiformats": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/nostr-js-sdk/-/nostr-js-sdk-0.6.0.tgz",
+      "integrity": "sha512-l6WcCmFok9nxI1WkYsjIVu67svouA2QyB5Vb+GTNugWrbw7hUgJMA1Elj8qu3u0qojvSINL/L9eWTmXVWRzZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^1.0.0",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/base": "^1.1.9",
+        "libphonenumber-js": "^1.11.14"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@unicitylabs/sphere-sdk": {
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.14.tgz",
+      "integrity": "sha512-bS3tRC/ofZK4uqj9pRO8TE4gfFxKUvLAmsl2GLove/1yY7OINjOLzsZbqa2BbWrxl09s5cJSgG/WMFRNXcWyuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^2.2.0",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "@unicitylabs/nostr-js-sdk": "^0.6.0",
+        "@unicitylabs/state-transition-sdk": "2.0.0-rc.68bc1e5",
+        "bip39": "^3.1.0",
+        "buffer": "^6.0.3",
+        "canonicalize": "^3.0.0",
+        "crypto-js": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "@libp2p/crypto": "^5.1.13",
+        "@libp2p/peer-id": "^6.0.4",
+        "ipns": "^10.0.0",
+        "multiformats": "^13.4.2"
+      },
+      "peerDependencies": {
+        "@libp2p/crypto": ">=5.0.0",
+        "@libp2p/peer-id": ">=6.0.0",
+        "ipns": ">=10.0.0",
+        "multiformats": ">=13.0.0",
+        "ws": ">=8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@libp2p/crypto": {
+          "optional": true
+        },
+        "@libp2p/peer-id": {
+          "optional": true
+        },
+        "ipns": {
+          "optional": true
+        },
+        "multiformats": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@unicitylabs/state-transition-sdk": {
+      "version": "2.0.0-rc.68bc1e5",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/state-transition-sdk/-/state-transition-sdk-2.0.0-rc.68bc1e5.tgz",
+      "integrity": "sha512-JJ1jQFTexMBRwpn3pmhm4s2FulBcOBGyNZmQ4qd5ZheenbVLUkY5KSJ++J3Gnh/Vmhd6WVuCBw+FCyqXN39aHQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "uuid": "14.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/abort-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/abort-error/-/abort-error-1.0.2.tgz",
+      "integrity": "sha512-lVgvB2NyPLqbXXhVmXcYFTC1x5K7CiVdPgdY7LGgFQWC8506oN01sPN3i9cl9ynuwF4iJ0TS9exnR7cZ9FuX4w==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bip39": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
+      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0"
+      }
+    },
+    "node_modules/bip39/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/canonicalize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-3.0.0.tgz",
+      "integrity": "sha512-yYLfHyDMIXRyRqsKBRLX023riFLpXY2YOfdtqKXZRZy9qsfOJ9U+4F9YZL7MEzL5+ziN2x2nlBvY/Voi3EBljA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cborg": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.7.tgz",
+      "integrity": "sha512-rGg2MG9zZEUKtKqjkBppIWUecTXf9N1vs1Qru43vJWoDaODhCrtmzdehCaA/aq/c1cPI5A0kPrJ5Tf+jIfhV4w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.393",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
+      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/interface-datastore": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-9.0.3.tgz",
+      "integrity": "sha512-NLZa7Mp+0qn48nSwIY/C36da4uVIKzwG2tuEIpaSJArsuB2RrdyDWwkoDUyjsJ+VrMntXz38VSk9vXTx/ZUpAw==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "interface-store": "^7.0.0",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/interface-datastore/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/interface-store": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-7.0.2.tgz",
+      "integrity": "sha512-KYOPcDH+1peaPhSeoZujR5nwkVeola1EdrnrlHTIM0HRNUs9B0aTsUQMH5kTmIjaQq1BOowoUyoCamgL8IMyww==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/ipns": {
+      "version": "10.1.6",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-10.1.6.tgz",
+      "integrity": "sha512-mTACIdTBBXY5kbCo3t/M3ycNWbjajLrSXhTvjD0MEGyOUaI3uMv94JbJSHGaJ2xxRlpOrRk1ifToOsyPZiglnA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/crypto": "^5.0.0",
+        "@libp2p/interface": "^3.0.2",
+        "@libp2p/logger": "^6.0.4",
+        "cborg": "^5.1.0",
+        "interface-datastore": "^9.0.2",
+        "multiformats": "^13.2.2",
+        "protons-runtime": "^6.0.1",
+        "timestamp-nano": "^1.0.1",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/ipns/node_modules/protons-runtime": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8-varint": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.5.tgz",
+      "integrity": "sha512-jeFLbL/x30wBRnWjKE1qVBXeumG46r7XmYkpis955lTQ+blccGKFrOsSMHlxePwYB1pI7L8YPHz1t4jLxEs3nA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8arraylist": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.9.tgz",
+      "integrity": "sha512-KxWjyEFzchzik3aoQlK66oaoxIReoMo5bQRm1fcjBUZvE8xv/tyR3CTKhjh6K/faV8VaF6hd5pjr45CzbwuwkA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.13.9",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.9.tgz",
+      "integrity": "sha512-VNS5vWMM7r0P66BYv+TQJATxExEgLxN+34hfHDVhDkUsGAE4cRg0shCNSLTXNKm7nIUscC7AfB51TjxEeF7msQ==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/main-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/main-event/-/main-event-1.0.4.tgz",
+      "integrity": "sha512-sKazUjIy2Jalv5lkQ446iOcrx8Q7TkaCuk6xfnzg5uUqMusMLDMPmRDmSNE2kjSVpSTJo4j1bQZusS+Ib7Bvrg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.1.tgz",
+      "integrity": "sha512-POWdiIPmsUPGwb4FeQ4OBg46aqmcInSWe45CKDsGHiOBiVQM9chqfQTuqhuTzcg2Vz9faTI65at0KkVyVEiCHw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/progress-events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.1.0.tgz",
+      "integrity": "sha512-82DVc5tI36neVB3IjdXR11ztwGuoBc98em9ijzubeZKxI47OlV2Znq6mlPqE5xPDzO2Uw98GHiQSjj2favBCRQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/protons-runtime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-7.0.0.tgz",
+      "integrity": "sha512-r/e72006xoVND4Uvf1aIs4OQOkJaASBU3ip4DzOWAktoKAkTiOYqKoS3TYMBm8HnnYU8+h0uEzr5gIRwk/pmTg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8-varint": "^3.0.0",
+        "uint8arraylist": "^3.0.0",
+        "uint8arrays": "^6.0.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/timestamp-nano": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/timestamp-nano/-/timestamp-nano-1.0.1.tgz",
+      "integrity": "sha512-4oGOVZWTu5sl89PtCDnhQBSt7/vL1zVEwAfxH1p49JhTosxzVQWYBYFRFZ8nJmo0G6f824iyP/44BFAwIoKvIA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uint8-varint": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-3.0.0.tgz",
+      "integrity": "sha512-S4DdpXBaLwKcFo7f0bWzWfHjbZ/i3QhM842qn+ZvHjxqFCfUcEB9SQNcmI69S+zMlcmIcKxsk9Iyw77S2Kxv6Q==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arraylist": "^3.0.1",
+        "uint8arrays": "^6.1.0"
+      }
+    },
+    "node_modules/uint8arraylist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-3.0.2.tgz",
+      "integrity": "sha512-LDVoq9BQaGJzGDUovEnoX6rpKCvnY/Jbtws4ikwnBzjRbq5qBAFpBZevUEbSmMM87aO0Sp+wOZy2ZXf5yODmXQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arrays": "^6.0.0"
+      }
+    },
+    "node_modules/uint8arrays": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-6.1.1.tgz",
+      "integrity": "sha512-iz7JN0XCSZYA111lhFG2Ui9EhFvTNekqSRHw3lvMHq+dzwWy1OQftxFQREEh4rffU0oSoXdQHsk2TiHKVm4fsA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^14.0.0"
+      }
+    },
+    "node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/utf8-codec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utf8-codec/-/utf8-codec-1.0.0.tgz",
+      "integrity": "sha512-S/QSLezp3qvG4ld5PUfXiH7mCFxLKjSVZRFkB3DOjgwHuJPFDkInAXc/anf7BAbHt/D38ozDzL+QMZ6/7gsI6w==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/weald": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/weald/-/weald-1.1.3.tgz",
+      "integrity": "sha512-vMWtNbYuPb58NeG2+0sKA0Een4VMDwzf+3oHqh68buWRSOMUBlUeRb11LhV28czV+DUpJHRykifijZDuS9bInA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^4.0.0-nightly.202508271359",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/weald/node_modules/ms": {
+      "version": "4.0.0-nightly.202508271359",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-4.0.0-nightly.202508271359.tgz",
+      "integrity": "sha512-WC/Eo7NzFrOV/RRrTaI0fxKVbNCzEy76j2VqNV8SxDf9D69gSE2Lh0QwYvDlhiYmheBYExAvEAxVf5NoN0cj2A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/backend-auth/frontend/package.json
+++ b/backend-auth/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "sphere-connect-backend-auth-frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@unicitylabs/sphere-sdk": "0.11.14",
+    "react": "^19.1.1",
+    "react-dom": "^19.2.4"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.16",
+    "@types/react-dom": "^19.1.9",
+    "@vitejs/plugin-react": "^5.0.4",
+    "typescript": "~5.6.0",
+    "vite": "^7.1.7"
+  }
+}

--- a/backend-auth/frontend/src/App.tsx
+++ b/backend-auth/frontend/src/App.tsx
@@ -1,0 +1,222 @@
+import { useCallback, useState } from 'react';
+import { autoConnect } from '@unicitylabs/sphere-sdk/connect/browser';
+import type { AutoConnectResult } from '@unicitylabs/sphere-sdk/connect/browser';
+import { ERROR_CODES, INTENT_ACTIONS, PERMISSION_SCOPES, SPHERE_NETWORKS } from '@unicitylabs/sphere-sdk/connect';
+
+/**
+ * Backend-auth example frontend — brokers a Sphere wallet signature to the
+ * backend from Task 5. This page never handles keys or claims an identity
+ * itself; it only ferries a challenge to the wallet and a signature back to
+ * the backend, which independently recovers the signer from the signature.
+ *
+ * Flow:
+ *  1. autoConnect() to the wallet (iframe/extension/popup, whichever applies).
+ *  2. GET /challenge?chainPubkey=<connected identity> — binds the challenge
+ *     text to this wallet as a hint (the backend re-verifies, never trusts it).
+ *  3. Ask the wallet to sign the returned `challenge` string VERBATIM via the
+ *     `sign_message` intent. Do not trim/re-encode it — the backend
+ *     reconstructs the exact same string and any byte drift silently recovers
+ *     a different pubkey (see backend-auth/backend/src/challenge.ts).
+ *  4. POST /verify { nonce, signature } — the backend recovers the signer and
+ *     mints a session JWT keyed on that recovered pubkey.
+ */
+
+const BACKEND_URL = (import.meta.env.VITE_BACKEND_URL as string | undefined) || 'http://localhost:8787';
+const WALLET_URL = (import.meta.env.VITE_WALLET_URL as string | undefined) || 'https://sphere.unicity.network';
+
+type Step =
+  | 'idle'
+  | 'connecting'
+  | 'requesting-challenge'
+  | 'awaiting-signature'
+  | 'verifying'
+  | 'authenticated'
+  | 'error';
+
+interface Session {
+  jwt: string;
+  chainPubkey: string;
+}
+
+interface ChallengeResponse {
+  nonce: string;
+  challenge: string;
+  expiresAt: number;
+}
+
+interface VerifyResponse {
+  jwt: string;
+  chainPubkey: string;
+  expiresIn: number;
+}
+
+/** Result shape of the `sign_message` intent (confirmed against the wallet handler
+ *  and browser/src/components/intents/SignMessagePanel.tsx). `publicKey` is what the
+ *  wallet SAYS signed the message — never trusted; the backend recovers it itself. */
+interface SignMessageResult {
+  signature: string;
+  publicKey: string;
+}
+
+const STEP_LABEL: Record<Exclude<Step, 'idle' | 'authenticated' | 'error'>, string> = {
+  connecting: 'Connecting to your Sphere wallet…',
+  'requesting-challenge': 'Requesting a sign-in challenge…',
+  'awaiting-signature': 'Check your wallet — approve the signature request…',
+  verifying: 'Verifying your signature with the backend…',
+};
+
+/** Fetch helper that turns network failures and non-2xx backend responses into
+ *  readable Error messages instead of leaking raw fetch/JSON exceptions. */
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(url, init);
+  } catch {
+    throw new Error(`Could not reach the backend at ${BACKEND_URL}. Is it running?`);
+  }
+  if (!res.ok) {
+    const body: unknown = await res.json().catch(() => null);
+    const message =
+      body && typeof body === 'object' && 'error' in body && typeof (body as { error: unknown }).error === 'string'
+        ? (body as { error: string }).error
+        : `Backend request failed: ${res.status} ${res.statusText}`;
+    throw new Error(message);
+  }
+  return res.json() as Promise<T>;
+}
+
+/** Connect intent/handshake errors carry a numeric `.code` (see ConnectError in
+ *  @unicitylabs/sphere-sdk/connect). Duck-type on `.code` rather than `instanceof` —
+ *  the SDK's own ConnectClient comment flags instanceof as unsafe across bundles. */
+function isConnectErrorCode(err: unknown, code: number): boolean {
+  return typeof err === 'object' && err !== null && 'code' in err && (err as { code: unknown }).code === code;
+}
+
+function describeError(err: unknown): string {
+  if (isConnectErrorCode(err, ERROR_CODES.USER_REJECTED) || isConnectErrorCode(err, ERROR_CODES.INTENT_CANCELLED)) {
+    return 'You declined the signature request in your wallet.';
+  }
+  if (err instanceof Error) return err.message;
+  return 'Something went wrong.';
+}
+
+function truncate(value: string, head = 18, tail = 10): string {
+  return value.length <= head + tail + 1 ? value : `${value.slice(0, head)}…${value.slice(-tail)}`;
+}
+
+export default function App() {
+  const [step, setStep] = useState<Step>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [session, setSession] = useState<Session | null>(null);
+  const [connection, setConnection] = useState<AutoConnectResult | null>(null);
+
+  const signIn = useCallback(async () => {
+    setError(null);
+    setSession(null);
+
+    let auto: AutoConnectResult | null = null;
+    try {
+      setStep('connecting');
+      auto = await autoConnect({
+        dapp: {
+          name: 'Backend Auth Example',
+          description: 'Sign in with your Sphere wallet',
+          url: location.origin,
+        },
+        walletUrl: WALLET_URL,
+        network: SPHERE_NETWORKS.testnet2,
+        permissions: [PERMISSION_SCOPES.IDENTITY_READ, PERMISSION_SCOPES.SIGN_REQUEST],
+      });
+      setConnection(auto);
+
+      // Identity lives on connection.identity, NOT on the autoConnect result root.
+      const chainPubkey = auto.connection.identity.chainPubkey;
+
+      setStep('requesting-challenge');
+      const { nonce, challenge } = await fetchJson<ChallengeResponse>(
+        `${BACKEND_URL}/challenge?chainPubkey=${encodeURIComponent(chainPubkey)}`,
+      );
+
+      setStep('awaiting-signature');
+      // Sign the challenge text VERBATIM — no trim/normalize. Byte-exactness is the
+      // whole safety property the backend relies on (see challenge.ts comments).
+      const { signature } = await auto.client.intent<SignMessageResult>(INTENT_ACTIONS.SIGN_MESSAGE, {
+        message: challenge,
+      });
+      // `publicKey` from the wallet's response is intentionally ignored — the
+      // backend recovers the signer from the signature itself; that recovery,
+      // not this field, is what proves identity.
+
+      setStep('verifying');
+      const verified = await fetchJson<VerifyResponse>(`${BACKEND_URL}/verify`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nonce, signature }),
+      });
+
+      setSession({ jwt: verified.jwt, chainPubkey: verified.chainPubkey });
+      setStep('authenticated');
+    } catch (err) {
+      setError(describeError(err));
+      setStep('error');
+      // Best-effort cleanup so a retry starts from a fresh connection rather than
+      // a half-open transport/popup left over from the failed attempt.
+      await auto?.disconnect().catch(() => {});
+      setConnection(null);
+    }
+  }, []);
+
+  const signOut = useCallback(async () => {
+    await connection?.disconnect().catch(() => {});
+    setConnection(null);
+    setSession(null);
+    setError(null);
+    setStep('idle');
+  }, [connection]);
+
+  const busy = step !== 'idle' && step !== 'authenticated' && step !== 'error';
+
+  return (
+    <div className="page">
+      <div className="card">
+        <h1>Backend Auth Example</h1>
+        <p className="subtitle">Sign in with your Sphere wallet — proven by signature, not claimed.</p>
+
+        {step === 'authenticated' && session ? (
+          <div className="session">
+            <dl>
+              <dt>chainPubkey</dt>
+              <dd>{session.chainPubkey}</dd>
+              <dt>session jwt</dt>
+              <dd>{truncate(session.jwt)}</dd>
+            </dl>
+            <div className="proof-note">
+              <span className="badge">🔒</span>
+              <span>
+                This identity was <strong>proven</strong> by recovering the signer's public key from the
+                wallet's signature over the server-issued challenge — it was never simply asserted by the
+                client.
+              </span>
+            </div>
+            <button className="secondary" onClick={signOut}>
+              Sign out
+            </button>
+          </div>
+        ) : (
+          <>
+            {busy && (
+              <div className="step">
+                <span className="spinner" aria-hidden="true" />
+                <span>{STEP_LABEL[step as keyof typeof STEP_LABEL]}</span>
+              </div>
+            )}
+            <button className="primary" onClick={signIn} disabled={busy}>
+              {step === 'error' ? 'Try again' : 'Sign in with your Sphere wallet'}
+            </button>
+            {error && <div className="error-box">{error}</div>}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/backend-auth/frontend/src/index.css
+++ b/backend-auth/frontend/src/index.css
@@ -1,0 +1,149 @@
+:root {
+  color-scheme: dark;
+  font-family: -apple-system, 'Segoe UI', system-ui, sans-serif;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  background: #0b0d12;
+  color: #e8eaf0;
+}
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.card {
+  width: 100%;
+  max-width: 440px;
+  background: #14171f;
+  border: 1px solid #262b38;
+  border-radius: 16px;
+  padding: 32px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+}
+
+.card h1 {
+  font-size: 20px;
+  margin: 0 0 6px;
+}
+
+.card .subtitle {
+  font-size: 13px;
+  color: #8b93a7;
+  margin: 0 0 28px;
+}
+
+.step {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  color: #b7bdcc;
+  margin-bottom: 20px;
+}
+
+.spinner {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid #363c4c;
+  border-top-color: #ff7a3d;
+  animation: spin 0.8s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+button.primary {
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: 10px;
+  border: none;
+  background: #ff7a3d;
+  color: #14171f;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+button.primary:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+button.secondary {
+  width: 100%;
+  padding: 10px 16px;
+  border-radius: 10px;
+  border: 1px solid #363c4c;
+  background: transparent;
+  color: #b7bdcc;
+  font-size: 13px;
+  cursor: pointer;
+  margin-top: 10px;
+}
+
+.error-box {
+  margin-top: 16px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  background: rgba(240, 90, 90, 0.1);
+  border: 1px solid rgba(240, 90, 90, 0.35);
+  color: #ff9b9b;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.session dl {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 8px 14px;
+  margin: 0 0 18px;
+}
+
+.session dt {
+  font-size: 12px;
+  color: #8b93a7;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  align-self: center;
+}
+
+.session dd {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12.5px;
+  word-break: break-all;
+}
+
+.proof-note {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 12px 14px;
+  border-radius: 10px;
+  background: rgba(74, 200, 140, 0.1);
+  border: 1px solid rgba(74, 200, 140, 0.3);
+  font-size: 12.5px;
+  color: #a9e6c8;
+  line-height: 1.5;
+}
+
+.badge {
+  flex-shrink: 0;
+}

--- a/backend-auth/frontend/src/main.tsx
+++ b/backend-auth/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/backend-auth/frontend/tsconfig.json
+++ b/backend-auth/frontend/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "types": ["vite/client"],
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "paths": {
+      "@unicitylabs/sphere-sdk/connect": ["./node_modules/@unicitylabs/sphere-sdk/dist/connect/index.d.ts"],
+      "@unicitylabs/sphere-sdk/connect/browser": ["./node_modules/@unicitylabs/sphere-sdk/dist/impl/browser/connect/index.d.ts"]
+    }
+  },
+  "include": ["src"]
+}

--- a/backend-auth/frontend/vite.config.ts
+++ b/backend-auth/frontend/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    // Matches backend-auth/backend's default FRONTEND_ORIGIN (http://localhost:5173) —
+    // Vite's own default port, pinned explicitly here so the CORS pairing stays obvious.
+    port: 5173,
+  },
+});

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -7,4 +7,6 @@ BOT_MNEMONIC=
 BOT_DATA_DIR=./.bot-data
 # OPTIONAL: only needed to RECEIVE tokens from the hosted Sphere wallet, which
 # delivers via the wallet-api mailbox (not Nostr). Leave empty to run DM + send only.
+# Known endpoints:  prod = https://wallet-api.unicity.network
+#                   staging = https://wallet-api.staging.unicity.network
 WALLET_API_URL=

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -1,5 +1,15 @@
-# testnet2 aggregator key (public, non-secret)
-AGGREGATOR_API_KEY=sk_ddc3cfcc001e4a28ac3fad7407f99590
+# OPTIONAL testnet2 aggregator (SGW) key. Leave empty (default) and the bot
+# provisions its OWN per-wallet free-plan key on first boot — get-or-create by
+# the wallet's index-0 identity, gateway URL comes from the SDK's per-network
+# config (NETWORKS[network].aggregatorUrl) — and saves it to
+# BOT_DATA_DIR/aggregator-key.json, so each bot has its own rate-limit instead
+# of sharing one static key's limit with every other example wallet. Reused
+# on every later boot (no re-provisioning). Set this to force a specific key
+# instead (e.g. a shared/paid one) — this always wins over a saved key.
+AGGREGATOR_API_KEY=
+# Example public, non-secret testnet2 key (shared rate limit — prefer leaving
+# AGGREGATOR_API_KEY empty above so this bot gets its own):
+# AGGREGATOR_API_KEY=sk_ddc3cfcc001e4a28ac3fad7407f99590
 # The bot's own wallet. Leave BOT_MNEMONIC empty on first run to auto-generate
 # (the bot prints the generated mnemonic — save it). Set it to persist identity.
 BOT_MNEMONIC=

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -1,0 +1,10 @@
+# testnet2 aggregator key (public, non-secret)
+AGGREGATOR_API_KEY=sk_ddc3cfcc001e4a28ac3fad7407f99590
+# The bot's own wallet. Leave BOT_MNEMONIC empty on first run to auto-generate
+# (the bot prints the generated mnemonic — save it). Set it to persist identity.
+BOT_MNEMONIC=
+# Local file storage for the bot's wallet + tokens
+BOT_DATA_DIR=./.bot-data
+# OPTIONAL: only needed to RECEIVE tokens from the hosted Sphere wallet, which
+# delivers via the wallet-api mailbox (not Nostr). Leave empty to run DM + send only.
+WALLET_API_URL=

--- a/bot/.gitignore
+++ b/bot/.gitignore
@@ -1,0 +1,2 @@
+.env
+.bot-data/

--- a/bot/README.md
+++ b/bot/README.md
@@ -1,7 +1,121 @@
 # Sphere Connect — Own-Wallet Bot Example
 
-> Skeleton — filled in by a later task in the same plan
-> (`.superpowers/sdd/task-b1-brief.md` / Task 4).
+A Node bot that runs its **own** Sphere wallet: its own keys, its own local
+token storage, direct SDK usage. It boots a real `Sphere` instance against
+**testnet2** the same way a wallet app would — there is no Connect protocol
+involved anywhere in this example.
 
-A Node bot that runs its **own** Sphere wallet (own keys, direct SDK usage) —
-not a Connect dApp. See the plan doc for the full picture.
+This is the opposite shape from the `browser/` and `nodejs/` examples in this
+repo, which are **dApps** that connect *to* someone else's already-running
+wallet over Connect (`ConnectClient` + a transport). This bot doesn't connect
+to a wallet — **it *is* the wallet.**
+
+What it does once running:
+- Replies to any incoming Nostr DM with `echo: <message>`.
+- Self-mints 100 `UCT` on boot as a starting balance (best-effort — logs a
+  message instead of failing if minting isn't available).
+- Exposes a small `send` / `balance` / `help` / `exit` command loop on stdin.
+- Optionally logs incoming token transfers (see "Receiving tokens" below).
+
+## Prerequisites
+
+- Node.js **>= 22**.
+- No account setup needed to send/DM: `bot/.env.example` already ships a
+  **public, non-secret** testnet2 aggregator key (`AGGREGATOR_API_KEY`).
+
+## Run it
+
+```bash
+cd bot
+npm install
+cp .env.example .env
+npm start
+```
+
+On the **first run**, `BOT_MNEMONIC` is empty, so the bot generates a fresh
+mnemonic and prints it once:
+
+```
+=== GENERATED A NEW BOT MNEMONIC ===
+<12-word mnemonic>
+SAVE THIS — set BOT_MNEMONIC to persist this identity across runs.
+=====================================
+```
+
+Copy that mnemonic into `BOT_MNEMONIC` in `.env`. Without it, every restart
+generates a brand-new identity (and a brand-new empty wallet) instead of
+resuming the previous one. Wallet + token data are stored locally under
+`BOT_DATA_DIR` (default `./.bot-data`, split into `./.bot-data/wallet` and
+`./.bot-data/tokens`).
+
+Once it's running:
+
+```
+> help
+Commands:
+  send @to <human-amount> <symbolOrCoinId>  - Send L3 tokens (money-safe: no auto-resend on a possibly-committed outcome)
+  balance                                   - Show current balance
+  help                                      - Show this help
+  exit                                      - Shut down and exit
+
+> balance
+> send @sometag 1.5 UCT
+```
+
+`<symbolOrCoinId>` accepts a coin symbol (e.g. `UCT`) or a 64-hex coin ID.
+Amounts are human-readable decimals (`"1.5"`) — the bot converts them to
+exact integer base units itself, so there's no floating-point precision loss
+even for high-decimal coins.
+
+`npm test` runs the unit tests (currently just the base-unit/coin-resolution
+helpers in `src/coins.ts`).
+
+## Receiving tokens: the wallet-api nuance
+
+DMs and **sending** work out of the box against testnet2 — no extra config
+needed. **Receiving** tokens sent from the hosted Sphere wallet (e.g.
+`sphere.unicity.network`, or a locally-run `sphere` dev server) is different.
+
+The hosted Sphere wallet delivers sent tokens through the **wallet-api
+mailbox**, not over Nostr. If `WALLET_API_URL` is left unset, this bot never
+composes that mailbox rail, so it has no way to see those deliveries — a
+transfer sent to it from the hosted wallet will simply never show up, no
+error, nothing to catch. The bot logs this plainly on boot:
+
+```
+WALLET_API_URL not set — this bot will not receive tokens from the hosted wallet (see README).
+```
+
+To fix that, set `WALLET_API_URL` in `.env` to a wallet-api endpoint, e.g.
+the public testnet2 instance:
+
+```
+WALLET_API_URL=https://wallet-api.unicity.network
+```
+
+With it set, the bot composes an *own-storage* wallet-api rail — it keeps
+using its own local token storage and keys, it just also picks up mailbox
+deliveries — and logs each incoming transfer, replying with a DM thank-you.
+
+## Money-safety on send
+
+`send` is deliberately conservative about anything that isn't an unambiguous
+success or failure:
+
+- If the SDK reports the send as **delivery-pending**, that's a *success* —
+  the source token is already spent and the recipient's copy will land
+  later. The bot just logs `sent, delivery pending` and moves on.
+- If the SDK reports a **possibly-committed** outcome (the spend may or may
+  not have gone through), the bot logs `spend may already be committed — do
+  NOT retry` and stops there. It does **not** automatically resend.
+
+That last point matters for any bot you build on this pattern too: retrying
+a possibly-committed send doesn't "try again" — it spends a *different*
+source token for the same intent, which can pay the recipient twice. Treat a
+possibly-committed outcome as something a human (or a higher-level
+reconciliation step) needs to look at, never as "just retry."
+
+## Generating a bot like this
+
+The `sphere-connect` Claude Code plugin can scaffold an own-wallet bot like
+this one from a prompt.

--- a/bot/README.md
+++ b/bot/README.md
@@ -17,6 +17,23 @@ What it does once running:
 - Exposes a small `send` / `balance` / `help` / `exit` command loop on stdin.
 - Optionally logs incoming token transfers (see "Receiving tokens" below).
 
+## When to use this
+
+Reach for this shape when your agent should act **from its own wallet, with no
+human approving each action** — it holds the keys and owns the funds.
+
+Concrete examples:
+
+- A **tipping / reward bot** that pays out UCT from its own float.
+- A **faucet** that mints or sends test tokens on request.
+- A **game NPC or agent** that holds a balance and pays/receives autonomously.
+- Any **autonomous agent** that transacts on its own behalf.
+
+**Use a different example if:**
+
+- You need to act on a **user's** wallet (they approve each action) → [`../browser/`](../browser) (web) or [`../nodejs/`](../nodejs) (Node over WebSocket).
+- You only need to **know who a user is** (login), not hold funds → [`../backend-auth/`](../backend-auth).
+
 ## Prerequisites
 
 - Node.js **>= 22**.

--- a/bot/README.md
+++ b/bot/README.md
@@ -1,0 +1,7 @@
+# Sphere Connect — Own-Wallet Bot Example
+
+> Skeleton — filled in by a later task in the same plan
+> (`.superpowers/sdd/task-b1-brief.md` / Task 4).
+
+A Node bot that runs its **own** Sphere wallet (own keys, direct SDK usage) —
+not a Connect dApp. See the plan doc for the full picture.

--- a/bot/README.md
+++ b/bot/README.md
@@ -37,8 +37,9 @@ Concrete examples:
 ## Prerequisites
 
 - Node.js **>= 22**.
-- No account setup needed to send/DM: `bot/.env.example` already ships a
-  **public, non-secret** testnet2 aggregator key (`AGGREGATOR_API_KEY`).
+- No account setup needed to send/DM: leave `AGGREGATOR_API_KEY` unset and the
+  bot provisions its own free testnet2 aggregator key on first boot (see
+  "Aggregator key — two ways" below).
 
 ## Run it
 
@@ -85,7 +86,32 @@ exact integer base units itself, so there's no floating-point precision loss
 even for high-decimal coins.
 
 `npm test` runs the unit tests (currently just the base-unit/coin-resolution
-helpers in `src/coins.ts`).
+helpers in `src/coins.ts`, plus the SGW-provisioning challenge validator and
+key-resolution fallback chain in `src/sgwChallenge.ts` / `src/aggregatorKey.ts`).
+
+## Aggregator key — two ways
+
+The bot needs an aggregator (SGW) API key to submit transactions. There are
+two ways to get one, controlled by `AGGREGATOR_API_KEY` in `.env`:
+
+- **Auto (default) — leave `AGGREGATOR_API_KEY` empty.** On first boot the
+  bot provisions its own free-plan key from the SGW via a
+  challenge/sign/verify flow (`sphere.deriveAddress(0)` signs the challenge —
+  pure local crypto, no key needed to do it), then persists it to
+  `BOT_DATA_DIR/aggregator-key.json` and reuses it on every later boot
+  (no re-provisioning). This is a **get-or-create keyed by the wallet's
+  index-0 identity** — same wallet, same key, stable across restarts. The
+  gateway URL is taken from the SDK's per-network config
+  (`NETWORKS[network].aggregatorUrl`), so this works on mainnet too, not just
+  testnet2. The point is to give **each bot its own rate limit** — sharing one
+  static key across every instance of this example means they'd all share
+  (and contend for) that one key's rate limit.
+- **Explicit — set `AGGREGATOR_API_KEY`.** Forces that key and skips
+  provisioning entirely (e.g. to use a shared team key or a paid plan). This
+  always takes priority over a saved/provisioned key.
+
+The bot logs which path it took on boot: `Aggregator key: env` / `saved` /
+`provisioned`. The key value itself is never logged.
 
 ## Receiving tokens: the wallet-api nuance
 

--- a/bot/package-lock.json
+++ b/bot/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.0.0",
       "dependencies": {
         "@unicitylabs/sphere-sdk": "0.11.14",
-        "dotenv": "^17.4.2"
+        "dotenv": "^17.4.2",
+        "ws": "^8.21.1"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "@types/ws": "^8.18.1",
         "tsx": "^4.19.0",
         "typescript": "~5.6.0",
         "vitest": "^4.1.10"
@@ -1067,6 +1069,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@unicitylabs/nostr-js-sdk": {
@@ -2547,6 +2559,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     }
   }

--- a/bot/package-lock.json
+++ b/bot/package-lock.json
@@ -1,0 +1,2553 @@
+{
+  "name": "sphere-connect-bot-example",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sphere-connect-bot-example",
+      "version": "0.0.0",
+      "dependencies": {
+        "@unicitylabs/sphere-sdk": "0.11.14",
+        "dotenv": "^17.4.2"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.19.0",
+        "typescript": "~5.6.0",
+        "vitest": "^4.1.10"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@chainsafe/is-ip": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.1.0.tgz",
+      "integrity": "sha512-KIjt+6IfysQ4GCv66xihEitBjvhU/bixbbbFxdJ1sqCp4uJ0wuZiYBPhksZoy4lfaF0k9cwNzY5upEW/VWdw3w==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@dnsquery/dns-packet": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@dnsquery/dns-packet/-/dns-packet-6.1.1.tgz",
+      "integrity": "sha512-WXTuFvL3G+74SchFAtz3FgIYVOe196ycvGsMgvSH/8Goptb1qpIQtIuM4SOK9G9lhMWYpHxnXyy544ZhluFOew==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.4",
+        "utf8-codec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/crypto": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
+      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/interface": "^3.2.5",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "multiformats": "^14.0.0",
+        "protons-runtime": "^7.0.0",
+        "uint8arraylist": "^3.0.2",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/crypto/node_modules/multiformats": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/interface": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
+      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@multiformats/dns": "^1.0.6",
+        "@multiformats/multiaddr": "^13.0.3",
+        "main-event": "^1.0.1",
+        "multiformats": "^14.0.0",
+        "progress-events": "^1.1.0",
+        "uint8arraylist": "^3.0.2"
+      }
+    },
+    "node_modules/@libp2p/interface/node_modules/multiformats": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/logger": {
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.10.tgz",
+      "integrity": "sha512-recRqNABHG32YXvpMvNepFCuU14d51dF5hs+vR2C/tkqXBQc0Sqg5LtWB2NYPoIJV+JUB50iWLrvBXZUOjLc9Q==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/interface": "^3.2.5",
+        "@multiformats/multiaddr": "^13.0.3",
+        "interface-datastore": "^10.0.1",
+        "multiformats": "^14.0.0",
+        "weald": "^1.1.0"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/interface-datastore": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-10.0.1.tgz",
+      "integrity": "sha512-DYMj/Og5Cz1Qwkx6/x5KRvR8SYEX7rVAv3KKCm2NzTwWSfpNAC4PahjcYbHyoZBP6zPWrhQv5n5wE+vaDdgSAg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "abort-error": "^1.0.2",
+        "interface-store": "^8.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/interface-store": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-8.0.0.tgz",
+      "integrity": "sha512-e2+s3EEROzM+Wlas4hU3zveTUscvVMf1BOvdsJfpzFm19SoEXLVadpACjWOnM491HqGpvtfFnevyiaN8W+I6Eg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "abort-error": "^1.0.2"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/multiformats": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/peer-id": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.12.tgz",
+      "integrity": "sha512-U44MeKs+U1SqZPqS0RDzjjcS9ERix2zJsJkTcqi8I+5flEz4uVAObBDxvkkaTaqRFRXCXEPjL5kA4UbgVubCZQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/interface": "^3.2.5",
+        "multiformats": "^14.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/peer-id/node_modules/multiformats": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@multiformats/dns": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.15.tgz",
+      "integrity": "sha512-W0zAMABtAn+3chgFcPGvllKND7M6GblMAAFcJQTy+iMmGiyFErZYPzAh2b50Y3SFf340iFV7+ckVgZkGfUyxzA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@dnsquery/dns-packet": "^6.1.1",
+        "@libp2p/interface": "^3.1.0",
+        "hashlru": "^2.3.0",
+        "p-queue": "^9.0.0",
+        "progress-events": "^1.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@multiformats/multiaddr": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-13.0.3.tgz",
+      "integrity": "sha512-mEqqJ4r3a/uuFMTpRkU316wGNIDQNhuVWpm+ebKTQeYsfv9jXbPONWM6VVnj3KGUrwfsX7GZOyp4TFqEA2SPCw==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "multiformats": "^14.0.0",
+        "uint8-varint": "^3.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/multiformats": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/nostr-js-sdk/-/nostr-js-sdk-0.6.0.tgz",
+      "integrity": "sha512-l6WcCmFok9nxI1WkYsjIVu67svouA2QyB5Vb+GTNugWrbw7hUgJMA1Elj8qu3u0qojvSINL/L9eWTmXVWRzZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^1.0.0",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/base": "^1.1.9",
+        "libphonenumber-js": "^1.11.14"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@unicitylabs/sphere-sdk": {
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.14.tgz",
+      "integrity": "sha512-bS3tRC/ofZK4uqj9pRO8TE4gfFxKUvLAmsl2GLove/1yY7OINjOLzsZbqa2BbWrxl09s5cJSgG/WMFRNXcWyuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^2.2.0",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "@unicitylabs/nostr-js-sdk": "^0.6.0",
+        "@unicitylabs/state-transition-sdk": "2.0.0-rc.68bc1e5",
+        "bip39": "^3.1.0",
+        "buffer": "^6.0.3",
+        "canonicalize": "^3.0.0",
+        "crypto-js": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "@libp2p/crypto": "^5.1.13",
+        "@libp2p/peer-id": "^6.0.4",
+        "ipns": "^10.0.0",
+        "multiformats": "^13.4.2"
+      },
+      "peerDependencies": {
+        "@libp2p/crypto": ">=5.0.0",
+        "@libp2p/peer-id": ">=6.0.0",
+        "ipns": ">=10.0.0",
+        "multiformats": ">=13.0.0",
+        "ws": ">=8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@libp2p/crypto": {
+          "optional": true
+        },
+        "@libp2p/peer-id": {
+          "optional": true
+        },
+        "ipns": {
+          "optional": true
+        },
+        "multiformats": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@unicitylabs/state-transition-sdk": {
+      "version": "2.0.0-rc.68bc1e5",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/state-transition-sdk/-/state-transition-sdk-2.0.0-rc.68bc1e5.tgz",
+      "integrity": "sha512-JJ1jQFTexMBRwpn3pmhm4s2FulBcOBGyNZmQ4qd5ZheenbVLUkY5KSJ++J3Gnh/Vmhd6WVuCBw+FCyqXN39aHQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "uuid": "14.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/abort-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/abort-error/-/abort-error-1.0.2.tgz",
+      "integrity": "sha512-lVgvB2NyPLqbXXhVmXcYFTC1x5K7CiVdPgdY7LGgFQWC8506oN01sPN3i9cl9ynuwF4iJ0TS9exnR7cZ9FuX4w==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bip39": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
+      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0"
+      }
+    },
+    "node_modules/bip39/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/canonicalize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-3.0.0.tgz",
+      "integrity": "sha512-yYLfHyDMIXRyRqsKBRLX023riFLpXY2YOfdtqKXZRZy9qsfOJ9U+4F9YZL7MEzL5+ziN2x2nlBvY/Voi3EBljA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cborg": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.7.tgz",
+      "integrity": "sha512-rGg2MG9zZEUKtKqjkBppIWUecTXf9N1vs1Qru43vJWoDaODhCrtmzdehCaA/aq/c1cPI5A0kPrJ5Tf+jIfhV4w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/interface-datastore": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-9.0.3.tgz",
+      "integrity": "sha512-NLZa7Mp+0qn48nSwIY/C36da4uVIKzwG2tuEIpaSJArsuB2RrdyDWwkoDUyjsJ+VrMntXz38VSk9vXTx/ZUpAw==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "interface-store": "^7.0.0",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/interface-datastore/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/interface-store": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-7.0.2.tgz",
+      "integrity": "sha512-KYOPcDH+1peaPhSeoZujR5nwkVeola1EdrnrlHTIM0HRNUs9B0aTsUQMH5kTmIjaQq1BOowoUyoCamgL8IMyww==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/ipns": {
+      "version": "10.1.6",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-10.1.6.tgz",
+      "integrity": "sha512-mTACIdTBBXY5kbCo3t/M3ycNWbjajLrSXhTvjD0MEGyOUaI3uMv94JbJSHGaJ2xxRlpOrRk1ifToOsyPZiglnA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/crypto": "^5.0.0",
+        "@libp2p/interface": "^3.0.2",
+        "@libp2p/logger": "^6.0.4",
+        "cborg": "^5.1.0",
+        "interface-datastore": "^9.0.2",
+        "multiformats": "^13.2.2",
+        "protons-runtime": "^6.0.1",
+        "timestamp-nano": "^1.0.1",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/ipns/node_modules/protons-runtime": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8-varint": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.5.tgz",
+      "integrity": "sha512-jeFLbL/x30wBRnWjKE1qVBXeumG46r7XmYkpis955lTQ+blccGKFrOsSMHlxePwYB1pI7L8YPHz1t4jLxEs3nA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8arraylist": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.9.tgz",
+      "integrity": "sha512-KxWjyEFzchzik3aoQlK66oaoxIReoMo5bQRm1fcjBUZvE8xv/tyR3CTKhjh6K/faV8VaF6hd5pjr45CzbwuwkA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.13.9",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.9.tgz",
+      "integrity": "sha512-VNS5vWMM7r0P66BYv+TQJATxExEgLxN+34hfHDVhDkUsGAE4cRg0shCNSLTXNKm7nIUscC7AfB51TjxEeF7msQ==",
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/main-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/main-event/-/main-event-1.0.4.tgz",
+      "integrity": "sha512-sKazUjIy2Jalv5lkQ446iOcrx8Q7TkaCuk6xfnzg5uUqMusMLDMPmRDmSNE2kjSVpSTJo4j1bQZusS+Ib7Bvrg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/ms": {
+      "version": "4.0.0-nightly.202508271359",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-4.0.0-nightly.202508271359.tgz",
+      "integrity": "sha512-WC/Eo7NzFrOV/RRrTaI0fxKVbNCzEy76j2VqNV8SxDf9D69gSE2Lh0QwYvDlhiYmheBYExAvEAxVf5NoN0cj2A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.1.tgz",
+      "integrity": "sha512-POWdiIPmsUPGwb4FeQ4OBg46aqmcInSWe45CKDsGHiOBiVQM9chqfQTuqhuTzcg2Vz9faTI65at0KkVyVEiCHw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/progress-events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.1.0.tgz",
+      "integrity": "sha512-82DVc5tI36neVB3IjdXR11ztwGuoBc98em9ijzubeZKxI47OlV2Znq6mlPqE5xPDzO2Uw98GHiQSjj2favBCRQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/protons-runtime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-7.0.0.tgz",
+      "integrity": "sha512-r/e72006xoVND4Uvf1aIs4OQOkJaASBU3ip4DzOWAktoKAkTiOYqKoS3TYMBm8HnnYU8+h0uEzr5gIRwk/pmTg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8-varint": "^3.0.0",
+        "uint8arraylist": "^3.0.0",
+        "uint8arrays": "^6.0.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/timestamp-nano": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/timestamp-nano/-/timestamp-nano-1.0.1.tgz",
+      "integrity": "sha512-4oGOVZWTu5sl89PtCDnhQBSt7/vL1zVEwAfxH1p49JhTosxzVQWYBYFRFZ8nJmo0G6f824iyP/44BFAwIoKvIA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uint8-varint": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-3.0.0.tgz",
+      "integrity": "sha512-S4DdpXBaLwKcFo7f0bWzWfHjbZ/i3QhM842qn+ZvHjxqFCfUcEB9SQNcmI69S+zMlcmIcKxsk9Iyw77S2Kxv6Q==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arraylist": "^3.0.1",
+        "uint8arrays": "^6.1.0"
+      }
+    },
+    "node_modules/uint8arraylist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-3.0.2.tgz",
+      "integrity": "sha512-LDVoq9BQaGJzGDUovEnoX6rpKCvnY/Jbtws4ikwnBzjRbq5qBAFpBZevUEbSmMM87aO0Sp+wOZy2ZXf5yODmXQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arrays": "^6.0.0"
+      }
+    },
+    "node_modules/uint8arrays": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-6.1.1.tgz",
+      "integrity": "sha512-iz7JN0XCSZYA111lhFG2Ui9EhFvTNekqSRHw3lvMHq+dzwWy1OQftxFQREEh4rffU0oSoXdQHsk2TiHKVm4fsA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^14.0.0"
+      }
+    },
+    "node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/utf8-codec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utf8-codec/-/utf8-codec-1.0.0.tgz",
+      "integrity": "sha512-S/QSLezp3qvG4ld5PUfXiH7mCFxLKjSVZRFkB3DOjgwHuJPFDkInAXc/anf7BAbHt/D38ozDzL+QMZ6/7gsI6w==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/weald": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/weald/-/weald-1.1.3.tgz",
+      "integrity": "sha512-vMWtNbYuPb58NeG2+0sKA0Een4VMDwzf+3oHqh68buWRSOMUBlUeRb11LhV28czV+DUpJHRykifijZDuS9bInA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^4.0.0-nightly.202508271359",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/bot/package.json
+++ b/bot/package.json
@@ -12,10 +12,12 @@
   },
   "dependencies": {
     "@unicitylabs/sphere-sdk": "0.11.14",
-    "dotenv": "^17.4.2"
+    "dotenv": "^17.4.2",
+    "ws": "^8.21.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "@types/ws": "^8.18.1",
     "tsx": "^4.19.0",
     "typescript": "~5.6.0",
     "vitest": "^4.1.10"

--- a/bot/package.json
+++ b/bot/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "sphere-connect-bot-example",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@unicitylabs/sphere-sdk": "0.11.14",
+    "dotenv": "^17.4.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "~5.6.0",
+    "vitest": "^4.1.10"
+  }
+}

--- a/bot/src/aggregatorKey.test.ts
+++ b/bot/src/aggregatorKey.test.ts
@@ -1,0 +1,144 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolveAggregatorKey } from './aggregatorKey';
+
+// Fake sphere — resolution never touches it directly; it's only handed to
+// the (stubbed) provision function.
+const fakeSphere = {} as any;
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aggregator-key-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+function makeStubProvision() {
+  let calls = 0;
+  const provision = async () => {
+    calls += 1;
+    return { apiKey: 'sk_new', plan: 'free', created: true };
+  };
+  return { provision, callCount: () => calls };
+}
+
+describe('resolveAggregatorKey', () => {
+  it('uses the env key when present, without touching files or provisioning', async () => {
+    const { provision, callCount } = makeStubProvision();
+
+    const result = await resolveAggregatorKey(fakeSphere, {
+      network: 'testnet2',
+      dataDir,
+      envKey: 'sk_env',
+      provision,
+    });
+
+    expect(result).toEqual({ apiKey: 'sk_env', source: 'env' });
+    expect(callCount()).toBe(0);
+    expect(fs.existsSync(path.join(dataDir, 'aggregator-key.json'))).toBe(false);
+  });
+
+  it('treats a whitespace-only env key as unset and falls through', async () => {
+    const { provision, callCount } = makeStubProvision();
+
+    const result = await resolveAggregatorKey(fakeSphere, {
+      network: 'testnet2',
+      dataDir,
+      envKey: '   ',
+      provision,
+    });
+
+    expect(result).toEqual({ apiKey: 'sk_new', source: 'provisioned' });
+    expect(callCount()).toBe(1);
+  });
+
+  it('reuses a previously saved key without calling provision', async () => {
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(path.join(dataDir, 'aggregator-key.json'), JSON.stringify({ apiKey: 'sk_saved' }));
+    const { provision, callCount } = makeStubProvision();
+
+    const result = await resolveAggregatorKey(fakeSphere, {
+      network: 'testnet2',
+      dataDir,
+      provision,
+    });
+
+    expect(result).toEqual({ apiKey: 'sk_saved', source: 'saved' });
+    expect(callCount()).toBe(0);
+  });
+
+  it('provisions and persists when there is no env key and no saved file, then reuses it on a second call', async () => {
+    const { provision, callCount } = makeStubProvision();
+
+    const first = await resolveAggregatorKey(fakeSphere, {
+      network: 'testnet2',
+      dataDir,
+      provision,
+    });
+
+    expect(first).toEqual({ apiKey: 'sk_new', source: 'provisioned' });
+    expect(callCount()).toBe(1);
+
+    const filePath = path.join(dataDir, 'aggregator-key.json');
+    expect(fs.existsSync(filePath)).toBe(true);
+    const saved = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    expect(saved.apiKey).toBe('sk_new');
+
+    const second = await resolveAggregatorKey(fakeSphere, {
+      network: 'testnet2',
+      dataDir,
+      provision,
+    });
+
+    expect(second).toEqual({ apiKey: 'sk_new', source: 'saved' });
+    expect(callCount()).toBe(1); // not called again
+  });
+
+  it('falls through to provisioning when the saved file is missing', async () => {
+    const { provision, callCount } = makeStubProvision();
+
+    const result = await resolveAggregatorKey(fakeSphere, {
+      network: 'testnet2',
+      dataDir: path.join(dataDir, 'does-not-exist-yet'),
+      provision,
+    });
+
+    expect(result).toEqual({ apiKey: 'sk_new', source: 'provisioned' });
+    expect(callCount()).toBe(1);
+  });
+
+  it('falls through to provisioning when the saved file is corrupt JSON', async () => {
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(path.join(dataDir, 'aggregator-key.json'), '{ not valid json');
+    const { provision, callCount } = makeStubProvision();
+
+    const result = await resolveAggregatorKey(fakeSphere, {
+      network: 'testnet2',
+      dataDir,
+      provision,
+    });
+
+    expect(result).toEqual({ apiKey: 'sk_new', source: 'provisioned' });
+    expect(callCount()).toBe(1);
+  });
+
+  it('falls through to provisioning when the saved file has an empty apiKey', async () => {
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(path.join(dataDir, 'aggregator-key.json'), JSON.stringify({ apiKey: '' }));
+    const { provision, callCount } = makeStubProvision();
+
+    const result = await resolveAggregatorKey(fakeSphere, {
+      network: 'testnet2',
+      dataDir,
+      provision,
+    });
+
+    expect(result).toEqual({ apiKey: 'sk_new', source: 'provisioned' });
+    expect(callCount()).toBe(1);
+  });
+});

--- a/bot/src/aggregatorKey.ts
+++ b/bot/src/aggregatorKey.ts
@@ -1,0 +1,87 @@
+/**
+ * Resolves the bot's aggregator (SGW) API key with a fallback chain, so the
+ * bot doesn't hit the network to provision a new key on every boot:
+ *
+ *   1. explicit env override (`AGGREGATOR_API_KEY`) — highest priority, lets
+ *      an operator pin a shared/paid key without touching disk.
+ *   2. a previously provisioned key saved on disk (`aggregator-key.json`
+ *      under `dataDir`) — reused across restarts.
+ *   3. provision a fresh key via `provisionAggregatorKey` (Task 1's
+ *      challenge->sign->verify SGW flow) and persist it for next time.
+ *
+ * `provisionAggregatorKey` is itself idempotent get-or-create by the wallet's
+ * index-0 pubkey (see `provisionAggregatorKey.ts`), but resolving from disk
+ * first still saves a network round-trip (and the SGW challenge/verify
+ * exchange) on every boot.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { Sphere } from '@unicitylabs/sphere-sdk';
+import { provisionAggregatorKey } from './provisionAggregatorKey';
+
+export interface ResolveAggregatorKeyOptions {
+  network: string;
+  dataDir: string;
+  envKey?: string;
+  provision?: (sphere: Sphere, network: string) => Promise<{ apiKey: string; plan: string; created: boolean }>;
+}
+
+export interface ResolveAggregatorKeyResult {
+  apiKey: string;
+  source: 'env' | 'saved' | 'provisioned';
+}
+
+interface SavedAggregatorKeyFile {
+  apiKey: string;
+  plan?: string;
+  provisionedAt?: string;
+}
+
+const FILE_NAME = 'aggregator-key.json';
+
+function readSavedKey(filePath: string): string | undefined {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return undefined; // missing (or unreadable) — fall through to provision
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<SavedAggregatorKeyFile>;
+    return typeof parsed.apiKey === 'string' && parsed.apiKey.length > 0 ? parsed.apiKey : undefined;
+  } catch {
+    return undefined; // corrupt JSON — fall through to provision
+  }
+}
+
+export async function resolveAggregatorKey(
+  sphere: Sphere,
+  opts: ResolveAggregatorKeyOptions,
+): Promise<ResolveAggregatorKeyResult> {
+  const envKey = opts.envKey?.trim();
+  if (envKey) {
+    return { apiKey: envKey, source: 'env' };
+  }
+
+  const filePath = path.join(opts.dataDir, FILE_NAME);
+  const saved = readSavedKey(filePath);
+  if (saved) {
+    console.log(`[aggregatorKey] using saved key from ${filePath}`);
+    return { apiKey: saved, source: 'saved' };
+  }
+
+  const provision = opts.provision ?? provisionAggregatorKey;
+  const result = await provision(sphere, opts.network);
+
+  fs.mkdirSync(opts.dataDir, { recursive: true });
+  const toSave: SavedAggregatorKeyFile = {
+    apiKey: result.apiKey,
+    plan: result.plan,
+    provisionedAt: new Date().toISOString(),
+  };
+  fs.writeFileSync(filePath, JSON.stringify(toSave, null, 2));
+  console.log(`[aggregatorKey] provisioned a new key and saved it to ${filePath}`);
+
+  return { apiKey: result.apiKey, source: 'provisioned' };
+}

--- a/bot/src/coins.test.ts
+++ b/bot/src/coins.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TokenRegistry } from '@unicitylabs/sphere-sdk';
+import { resolveCoin, toBaseUnits } from './coins';
+
+describe('toBaseUnits', () => {
+  it('converts a fractional human amount to base units', () => {
+    expect(toBaseUnits('1.5', 6)).toBe('1500000');
+  });
+
+  it('converts a whole number with 0 decimals', () => {
+    expect(toBaseUnits('100', 0)).toBe('100');
+  });
+
+  it('rejects a fractional part longer than decimals', () => {
+    expect(() => toBaseUnits('1.1234567', 6)).toThrow();
+  });
+
+  it('is exact for high-decimal tokens (no float rounding)', () => {
+    // 1e-18 as a float would round to 0 / lose precision; string math must not.
+    expect(toBaseUnits('0.000000000000000001', 18)).toBe('1');
+  });
+
+  it('rejects a malformed amount', () => {
+    expect(() => toBaseUnits('abc', 6)).toThrow();
+    expect(() => toBaseUnits('-1', 6)).toThrow();
+    expect(() => toBaseUnits('', 6)).toThrow();
+  });
+});
+
+describe('resolveCoin', () => {
+  const FAKE_COIN_ID = 'b'.repeat(64);
+  let getInstanceSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+  afterEach(() => {
+    getInstanceSpy?.mockRestore();
+    getInstanceSpy = undefined;
+  });
+
+  it('returns a 64-hex coinId unchanged, with looked-up decimals', () => {
+    getInstanceSpy = vi.spyOn(TokenRegistry, 'getInstance').mockReturnValue({
+      getDefinition: (id: string) => (id === FAKE_COIN_ID ? { decimals: 8 } : undefined),
+    } as unknown as TokenRegistry);
+
+    expect(resolveCoin(FAKE_COIN_ID)).toEqual({ coinId: FAKE_COIN_ID, decimals: 8 });
+  });
+
+  it('accepts an uppercase-hex coinId too (case-insensitive match)', () => {
+    getInstanceSpy = vi.spyOn(TokenRegistry, 'getInstance').mockReturnValue({
+      getDefinition: () => ({ decimals: 8 }),
+    } as unknown as TokenRegistry);
+
+    expect(resolveCoin(FAKE_COIN_ID.toUpperCase())).toEqual({
+      coinId: FAKE_COIN_ID.toUpperCase(),
+      decimals: 8,
+    });
+  });
+
+  it('resolves a symbol to the registry hex id + decimals', () => {
+    getInstanceSpy = vi.spyOn(TokenRegistry, 'getInstance').mockReturnValue({
+      getCoinIdBySymbol: (symbol: string) => (symbol === 'UCT' ? FAKE_COIN_ID : undefined),
+      getDefinitionBySymbol: (symbol: string) =>
+        symbol === 'UCT' ? { decimals: 6, id: FAKE_COIN_ID, symbol: 'UCT' } : undefined,
+    } as unknown as TokenRegistry);
+
+    expect(resolveCoin('UCT')).toEqual({ coinId: FAKE_COIN_ID, decimals: 6 });
+  });
+
+  it('throws a clear error when the registry has no such symbol', () => {
+    getInstanceSpy = vi.spyOn(TokenRegistry, 'getInstance').mockReturnValue({
+      getCoinIdBySymbol: () => undefined,
+      getDefinitionBySymbol: () => undefined,
+    } as unknown as TokenRegistry);
+
+    expect(() => resolveCoin('NOPE')).toThrow(/unknown coin/i);
+  });
+
+  it('throws a clear error when the registry has no such coinId', () => {
+    getInstanceSpy = vi.spyOn(TokenRegistry, 'getInstance').mockReturnValue({
+      getDefinition: () => undefined,
+    } as unknown as TokenRegistry);
+
+    expect(() => resolveCoin('c'.repeat(64))).toThrow(/unknown coin/i);
+  });
+});

--- a/bot/src/coins.ts
+++ b/bot/src/coins.ts
@@ -1,0 +1,86 @@
+/**
+ * Pure coin/amount helpers for the own-wallet bot example.
+ *
+ * - `toBaseUnits` converts a human-readable decimal amount (e.g. "1.5") into
+ *   the integer base-unit string the SDK's `payments.send` / `mintFungibleToken`
+ *   expect. It is string-based and exact — never routes through `Number`/
+ *   `parseFloat`, which lose precision for high-decimal (e.g. 18-decimal) tokens.
+ * - `resolveCoin` accepts either a 64-hex coinId or a symbol (e.g. "UCT") and
+ *   resolves it to `{ coinId, decimals }` via the SDK's `TokenRegistry` singleton.
+ *
+ * TokenRegistry methods used here are verified against
+ * `sphere-sdk/registry/TokenRegistry.ts` (0.11.14 source):
+ *   - `TokenRegistry.getInstance()`               — TokenRegistry.ts:128
+ *   - `getDefinition(coinId): TokenDefinition | undefined`      — TokenRegistry.ts:460
+ *   - `getDefinitionBySymbol(symbol): TokenDefinition | undefined` — TokenRegistry.ts:470
+ *   - `getCoinIdBySymbol(symbol): string | undefined`           — TokenRegistry.ts:581
+ */
+import { TokenRegistry } from '@unicitylabs/sphere-sdk';
+
+/** Matches a lowercase-or-uppercase 64+ char hex coinId. */
+const HEX_COIN_ID_RE = /^[0-9a-f]{64,}$/i;
+
+/**
+ * Convert a human-readable decimal amount into an integer base-unit string.
+ *
+ * Exact, string-based arithmetic only — no `Number`/`parseFloat` on the
+ * amount, which would silently lose precision for 18-decimal tokens.
+ *
+ * @param human - Non-negative decimal amount, e.g. "1.5" or "100".
+ * @param decimals - Number of base-unit decimal places for the coin.
+ * @throws if `human` isn't a plain non-negative decimal, or its fractional
+ *   part has more digits than `decimals` (would silently truncate precision).
+ */
+export function toBaseUnits(human: string, decimals: number): string {
+  if (!Number.isInteger(decimals) || decimals < 0) {
+    throw new Error(`Invalid decimals: ${decimals}`);
+  }
+  if (!/^\d+(\.\d+)?$/.test(human)) {
+    throw new Error(`Invalid amount "${human}": expected a non-negative decimal string`);
+  }
+
+  const [intPart, fracPart = ''] = human.split('.');
+  if (fracPart.length > decimals) {
+    throw new Error(
+      `Amount "${human}" has ${fracPart.length} fractional digits, but the coin only supports ${decimals}`,
+    );
+  }
+
+  const combined = intPart + fracPart.padEnd(decimals, '0');
+  const normalized = combined.replace(/^0+(?=\d)/, '');
+  return normalized;
+}
+
+/** Resolved coin identity: canonical hex coinId + its decimal places. */
+export interface ResolvedCoin {
+  coinId: string;
+  decimals: number;
+}
+
+/**
+ * Resolve a coin symbol or hex coinId to `{ coinId, decimals }` via the
+ * SDK's `TokenRegistry` singleton.
+ *
+ * @param symbolOrId - Either a 64-hex coinId (case-insensitive) or a symbol
+ *   like "UCT". A hex coinId is returned unchanged (not re-cased).
+ * @throws if the input looks like a coinId but isn't in the registry, or if
+ *   the symbol has no known coinId/definition in the registry.
+ */
+export function resolveCoin(symbolOrId: string): ResolvedCoin {
+  const registry = TokenRegistry.getInstance();
+
+  if (HEX_COIN_ID_RE.test(symbolOrId)) {
+    const def = registry.getDefinition(symbolOrId);
+    if (!def) {
+      throw new Error(`Unknown coinId "${symbolOrId}": not found in the token registry`);
+    }
+    return { coinId: symbolOrId, decimals: def.decimals ?? 0 };
+  }
+
+  const coinId = registry.getCoinIdBySymbol(symbolOrId);
+  const def = registry.getDefinitionBySymbol(symbolOrId);
+  if (!coinId || !def) {
+    throw new Error(`Unknown coin symbol "${symbolOrId}": not found in the token registry`);
+  }
+  return { coinId, decimals: def.decimals ?? 0 };
+}

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -1,0 +1,186 @@
+/**
+ * Bot runtime behavior — the bot's OWN Sphere wallet (booted via
+ * `createBotSphere()`, Task 2) wired up to: DM auto-reply, a one-time
+ * self-mint float, optional incoming-transfer logging, and a small stdin
+ * command loop for a money-safe demo `send`.
+ *
+ * SDK symbols/field names below are verified against `sphere-sdk` 0.11.14
+ * source (this repo pins that exact version):
+ *
+ * - `sphere.communications` getter — `core/Sphere.ts:1388`.
+ * - `communications.onDirectMessage(handler: (m: DirectMessage) => void): () => void`
+ *   — `modules/communications/CommunicationsModule.ts:450`.
+ * - `communications.sendDM(recipient: string, content: string): Promise<DirectMessage>`
+ *   — `modules/communications/CommunicationsModule.ts:244`.
+ * - `DirectMessage` — `{ id, senderPubkey, senderNametag?, recipientPubkey,
+ *   recipientNametag?, content, timestamp, isRead }` — `types/index.ts:337-346`,
+ *   re-exported from the SDK root via `index.ts:134` (`export * from './types'`).
+ * - `sphere.payments` getter — `core/Sphere.ts:1382`.
+ * - `payments.mintFungibleToken(coinIdHex: string, amount: bigint): Promise<
+ *   { success: true; token: Token; tokenId: string } | { success: false; error: string }>`
+ *   — `modules/payments/PaymentsModule.ts:4655-4667`. NOTE: `amount` is a
+ *   `bigint`, not a base-unit string — `toBaseUnits()` (Task 1) returns a
+ *   string, so it must be wrapped in `BigInt(...)`. This does NOT throw on
+ *   an ordinary mint failure (e.g. no token engine) — it resolves to
+ *   `{ success: false, error }` — confirmed against the real call site in
+ *   `agentic-chatbot/packages/chess-bot/src/wallet.ts:137-146`, which checks
+ *   `result.success` AND wraps the call in try/catch (it can still throw for
+ *   genuinely exceptional errors). Mirrored here.
+ * - `payments.getBalance(coinId?: string): Asset[]` — synchronous —
+ *   `modules/payments/PaymentsModule.ts:3525-3527`.
+ * - `payments.send(request: TransferRequest): Promise<TransferResult>` —
+ *   `modules/payments/PaymentsModule.ts:1759-1762`. `TransferRequest` —
+ *   `{ coinId, amount, recipient, memo? }` — `types/index.ts:143-156`.
+ *   `TransferResult.deliveryPending?: boolean` — `types/index.ts:188` — true
+ *   means "sent, delivery pending" (source is terminally spent, recipient
+ *   delivery will land later) — a SUCCESS outcome, never resend.
+ * - `sphere.on<T>(type: T, handler): () => void` — `core/Sphere.ts:3390`.
+ *   `'transfer:incoming'` payload is `IncomingTransfer` — `{ id, senderPubkey,
+ *   senderNametag?, tokens, memo?, receivedAt }` — `types/index.ts:193-200`,
+ *   confirmed emitted by `PaymentsModule.ts:5239`.
+ * - Money-safety guard: `isPossiblyCommittedSendOutcome(err: unknown): boolean`
+ *   — `core/errors.ts:240-242` — true for `SphereError`s whose `code` is in
+ *   the possibly-committed set, which ALREADY includes `'SEND_PARTIALLY_COMPLETED'`
+ *   (`core/errors.ts:223-230`). Exported from the SDK root — `index.ts:51`
+ *   (`export { ..., isPossiblyCommittedSendOutcome } from './core'`). The
+ *   brief additionally asks for an explicit `err?.code === 'SEND_PARTIALLY_COMPLETED'`
+ *   check — redundant for a real `PartialSendConflictError` (already covered
+ *   above) but kept as a defensive belt-and-suspenders check for any
+ *   non-`SphereError`-shaped rejection that happens to carry that code.
+ * - `identity.chainPubkey` — `Identity` — `types/index.ts:30-37` — used to
+ *   skip the bot's own outgoing DMs echoing back to itself.
+ */
+import readline from 'readline';
+import { isPossiblyCommittedSendOutcome, type DirectMessage, type IncomingTransfer } from '@unicitylabs/sphere-sdk';
+import { createBotSphere } from './sphere';
+import { resolveCoin, toBaseUnits } from './coins';
+
+const MINT_SYMBOL = 'UCT';
+const MINT_AMOUNT_HUMAN = '100';
+
+async function main() {
+  const { sphere, identity, receivesPayments } = await createBotSphere();
+  console.log('Bot identity:', identity);
+
+  // --- 1. DMs (always): echo back anything sent to the bot, skip self-DMs ---
+  sphere.communications.onDirectMessage(async (m: DirectMessage) => {
+    console.log(`[dm] from ${m.senderNametag ?? m.senderPubkey}: ${m.content}`);
+    if (m.senderPubkey === identity.chainPubkey) {
+      return; // don't reply to ourselves (avoids an echo loop)
+    }
+    try {
+      await sphere.communications.sendDM(m.senderPubkey, `echo: ${m.content}`);
+    } catch (err) {
+      console.error('[dm] failed to send echo reply:', err instanceof Error ? err.message : err);
+    }
+  });
+
+  // --- 2. Self-mint a float, once on boot (best-effort — minting may be unavailable) ---
+  try {
+    const { coinId, decimals } = resolveCoin(MINT_SYMBOL);
+    const amount = BigInt(toBaseUnits(MINT_AMOUNT_HUMAN, decimals));
+    const result = await sphere.payments.mintFungibleToken(coinId, amount);
+    if (result.success) {
+      console.log(`[mint] self-minted ${MINT_AMOUNT_HUMAN} ${MINT_SYMBOL} (tokenId ${result.tokenId})`);
+    } else {
+      console.log(`[mint] self-mint unavailable: ${result.error}`);
+    }
+  } catch (err) {
+    console.error('[mint] self-mint threw:', err instanceof Error ? err.message : err);
+  }
+  console.log('[balance]', JSON.stringify(sphere.payments.getBalance(), null, 2));
+
+  // --- 3. Receive: only wired if the wallet-api mailbox rail was composed in ---
+  if (receivesPayments) {
+    sphere.on('transfer:incoming', (t: IncomingTransfer) => {
+      console.log(`[receive] incoming transfer ${t.id} from ${t.senderNametag ?? t.senderPubkey}`);
+      sphere.communications.sendDM(t.senderPubkey, 'thanks for the tokens!').catch((err) => {
+        console.error('[receive] failed to send thank-you DM:', err instanceof Error ? err.message : err);
+      });
+    });
+  } else {
+    console.log('WALLET_API_URL not set — this bot will not receive tokens from the hosted wallet (see README).');
+  }
+
+  // --- 4. Demo command loop: send / balance / help / exit ---
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+  function showPrompt() {
+    rl.question('\n> ', async (input) => {
+      const parts = input.trim().split(/\s+/);
+      const cmd = parts[0]?.toLowerCase();
+
+      if (!cmd) {
+        showPrompt();
+        return;
+      }
+
+      try {
+        switch (cmd) {
+          case 'send': {
+            const to = parts[1];
+            const humanAmount = parts[2];
+            const symbolOrId = parts[3];
+            if (!to || !humanAmount || !symbolOrId) {
+              console.log('Usage: send @to <human-amount> <symbolOrCoinId>');
+              break;
+            }
+            const { coinId, decimals } = resolveCoin(symbolOrId);
+            const amount = toBaseUnits(humanAmount, decimals);
+            try {
+              const result = await sphere.payments.send({ coinId, amount, recipient: to });
+              if (result.deliveryPending) {
+                console.log('sent, delivery pending');
+              } else {
+                console.log('Send result:', JSON.stringify(result, null, 2));
+              }
+            } catch (err) {
+              if (isPossiblyCommittedSendOutcome(err) || (err as { code?: string } | undefined)?.code === 'SEND_PARTIALLY_COMPLETED') {
+                console.log('spend may already be committed — do NOT retry');
+              } else {
+                console.error('Send failed:', err instanceof Error ? err.message : err);
+              }
+            }
+            break;
+          }
+          case 'balance': {
+            console.log('Balance:', JSON.stringify(sphere.payments.getBalance(), null, 2));
+            break;
+          }
+          case 'exit':
+          case 'quit': {
+            console.log('Shutting down...');
+            rl.close();
+            await sphere.destroy();
+            process.exit(0);
+            break;
+          }
+          case 'help': {
+            console.log(`
+Commands:
+  send @to <human-amount> <symbolOrCoinId>  - Send L3 tokens (money-safe: no auto-resend on a possibly-committed outcome)
+  balance                                   - Show current balance
+  help                                      - Show this help
+  exit                                      - Shut down and exit
+`);
+            break;
+          }
+          default:
+            console.log(`Unknown command: ${cmd}. Type "help" for available commands.`);
+        }
+      } catch (err) {
+        console.error('Error:', err instanceof Error ? err.message : err);
+      }
+
+      showPrompt();
+    });
+  }
+
+  console.log('\nBot is running. Type "help" for available commands.');
+  showPrompt();
+}
+
+main().catch((err) => {
+  console.error('Bot failed to start:', err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/bot/src/provisionAggregatorKey.ts
+++ b/bot/src/provisionAggregatorKey.ts
@@ -1,0 +1,62 @@
+/**
+ * Own-key provisioning from the aggregator-subscription gateway (SGW) — the
+ * same challenge->sign->verify flow the Sphere wallet uses
+ * (`sphere/src/services/subscriptionApi.ts` `provisionOrRecoverKey`), so the
+ * bot can get its OWN per-wallet free-plan aggregator key instead of sharing
+ * the static `AGGREGATOR_API_KEY` testnet2 key (and its rate limit) with
+ * every other example wallet.
+ *
+ * SDK symbols verified against `sphere-sdk` 0.11.14 source (this repo pins
+ * that exact version):
+ * - `getPublicKey(privateKey, compressed?)` — `core/crypto.ts:258`, exported
+ *   at the SDK root via `index.ts:99`.
+ * - `signMessage(privateKeyHex, message)` — `core/crypto.ts:502`, exported
+ *   at the SDK root via `index.ts:52`.
+ * - `NETWORKS` — `constants.ts:394`, exported at the SDK root via
+ *   `index.ts:342`. `NETWORKS.testnet2.aggregatorUrl` = SGW base URL
+ *   (`constants.ts:417-421`, `'https://gateway.testnet2.unicity.network'`).
+ * - `Sphere` — exported at the SDK root via `index.ts:51`.
+ * - `sphere.deriveAddress(0)` — `core/Sphere.ts:2972`, returns `AddressInfo`
+ *   (`{ privateKey, publicKey, path, index }`, `core/crypto.ts:64`).
+ */
+import type { Sphere } from '@unicitylabs/sphere-sdk';
+import { getPublicKey, signMessage, NETWORKS } from '@unicitylabs/sphere-sdk';
+import { verifySgwChallenge } from './sgwChallenge';
+
+export interface ProvisionResult {
+  apiKey: string;
+  plan: string;
+  created: boolean;
+}
+
+// Provisions (or recovers) THIS wallet's own free-plan aggregator key from the
+// SGW — the same challenge->sign->verify flow the Sphere wallet uses
+// (sphere/src/services/subscriptionApi.ts provisionOrRecoverKey). Idempotent
+// get-or-create by the wallet's index-0 pubkey.
+export async function provisionAggregatorKey(sphere: Sphere, network: string): Promise<ProvisionResult> {
+  const base = (NETWORKS as Record<string, { aggregatorUrl: string }>)[network].aggregatorUrl;
+  const { privateKey } = sphere.deriveAddress(0); // scope 'wallet' — stable identity
+  const pubkey = getPublicKey(privateKey);
+
+  const chRes = await fetch(`${base}/auth/challenge`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ pubkey }),
+  });
+  if (!chRes.ok) throw new Error(`SGW /auth/challenge failed: ${chRes.status}`);
+  const { nonce, challenge } = (await chRes.json()) as { nonce: string; challenge: string };
+
+  verifySgwChallenge(challenge, { network, pubkey, nonce }); // never sign unverified text
+  const signature = signMessage(privateKey, challenge); // signed VERBATIM
+
+  const vRes = await fetch(`${base}/auth/verify`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ nonce, signature }),
+  });
+  if (!vRes.ok) {
+    const body = (await vRes.json().catch(() => null)) as { error?: string } | null;
+    throw new Error(body?.error ?? `SGW /auth/verify failed: ${vRes.status}`);
+  }
+  return (await vRes.json()) as ProvisionResult;
+}

--- a/bot/src/sgwChallenge.test.ts
+++ b/bot/src/sgwChallenge.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { SGW_CHALLENGE_PREFIX, SgwChallengeError, verifySgwChallenge } from './sgwChallenge';
+
+const NETWORK = 'testnet2';
+const PUBKEY = '02'.padEnd(66, 'a'); // 33-byte compressed pubkey shape, not cryptographically real
+const NONCE = 'nonce-123';
+const NOW = Date.parse('2026-07-19T12:00:00.000Z');
+
+function buildChallenge(overrides: Partial<Record<'network' | 'pubkey' | 'nonce' | 'issuedAt' | 'expiresAt', string>> = {}) {
+  const body = {
+    network: NETWORK,
+    pubkey: PUBKEY,
+    nonce: NONCE,
+    issuedAt: new Date(NOW).toISOString(),
+    expiresAt: new Date(NOW + 10 * 60_000).toISOString(),
+    ...overrides,
+  };
+  return SGW_CHALLENGE_PREFIX + JSON.stringify(body);
+}
+
+const expect_ = { network: NETWORK, pubkey: PUBKEY, nonce: NONCE, nowMs: NOW };
+
+describe('verifySgwChallenge', () => {
+  it('accepts a valid challenge', () => {
+    expect(() => verifySgwChallenge(buildChallenge(), expect_)).not.toThrow();
+  });
+
+  it('rejects the wrong prefix', () => {
+    const challenge = 'unicity:sgw:auth:v2\n' + buildChallenge().slice(SGW_CHALLENGE_PREFIX.length);
+    expect(() => verifySgwChallenge(challenge, expect_)).toThrow(SgwChallengeError);
+  });
+
+  it('rejects a network mismatch', () => {
+    expect(() => verifySgwChallenge(buildChallenge({ network: 'mainnet' }), expect_)).toThrow(SgwChallengeError);
+  });
+
+  it('rejects a pubkey mismatch', () => {
+    expect(() => verifySgwChallenge(buildChallenge({ pubkey: '03' + PUBKEY.slice(2) }), expect_)).toThrow(
+      SgwChallengeError,
+    );
+  });
+
+  it('rejects a nonce mismatch', () => {
+    expect(() => verifySgwChallenge(buildChallenge({ nonce: 'other-nonce' }), expect_)).toThrow(SgwChallengeError);
+  });
+
+  it('rejects an expired challenge', () => {
+    const challenge = buildChallenge({
+      issuedAt: new Date(NOW - 20 * 60_000).toISOString(),
+      expiresAt: new Date(NOW - 10 * 60_000).toISOString(),
+    });
+    expect(() => verifySgwChallenge(challenge, expect_)).toThrow(SgwChallengeError);
+  });
+
+  it('rejects a validity window longer than 60 minutes', () => {
+    const challenge = buildChallenge({
+      issuedAt: new Date(NOW).toISOString(),
+      expiresAt: new Date(NOW + 61 * 60_000).toISOString(),
+    });
+    expect(() => verifySgwChallenge(challenge, expect_)).toThrow(SgwChallengeError);
+  });
+
+  it('rejects a multi-line body', () => {
+    const challenge = SGW_CHALLENGE_PREFIX + JSON.stringify({ network: NETWORK, pubkey: PUBKEY, nonce: NONCE, issuedAt: new Date(NOW).toISOString(), expiresAt: new Date(NOW + 60_000).toISOString() }) + '\nextra';
+    expect(() => verifySgwChallenge(challenge, expect_)).toThrow(SgwChallengeError);
+  });
+});

--- a/bot/src/sgwChallenge.ts
+++ b/bot/src/sgwChallenge.ts
@@ -1,0 +1,62 @@
+/**
+ * SGW auth-challenge template validation — ported VERBATIM from the Sphere
+ * wallet (`sphere/src/services/sgwChallenge.ts`). Self-contained, no sphere
+ * deps. The wallet must never sign unverified server-chosen text (same rule
+ * as the SDK's wallet-api verifyChallengeTemplate, ported for the SGW
+ * prefix/format).
+ * The challenge is still signed VERBATIM after validation — never re-serialize.
+ */
+export const SGW_CHALLENGE_PREFIX = 'unicity:sgw:auth:v1\n';
+
+const MAX_CLOCK_SKEW_MS = 5 * 60_000;
+const MAX_VALIDITY_WINDOW_MS = 60 * 60_000;
+const FIELDS = ['network', 'pubkey', 'nonce', 'issuedAt', 'expiresAt'] as const;
+
+export class SgwChallengeError extends Error {
+  constructor(message: string) {
+    super(`SGW challenge rejected: ${message}`);
+    this.name = 'SgwChallengeError';
+  }
+}
+
+export function verifySgwChallenge(
+  challenge: string,
+  expect: { network: string; pubkey: string; nonce: string; nowMs?: number },
+): void {
+  if (!challenge.startsWith(SGW_CHALLENGE_PREFIX)) throw new SgwChallengeError('unexpected prefix');
+
+  const body = challenge.slice(SGW_CHALLENGE_PREFIX.length);
+  if (body.includes('\n')) throw new SgwChallengeError('payload must be single-line');
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    throw new SgwChallengeError('payload is not valid JSON');
+  }
+  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
+    throw new SgwChallengeError('payload is not a JSON object');
+  }
+  for (const f of FIELDS) {
+    if (typeof payload[f] !== 'string' || payload[f] === '') throw new SgwChallengeError(`missing field ${f}`);
+  }
+
+  const p = payload as Record<(typeof FIELDS)[number], string>;
+  // Anti-cross-network relay: a challenge issued by ANOTHER network's SGW must
+  // not be signable here. Key derivation + the signMessage scheme are
+  // network-independent, so without this the wallet's index-0 signature over a
+  // (say) mainnet challenge is redeemable at the mainnet SGW — a confused
+  // deputy that harvests the victim's key on a network they never authenticated
+  // to. The SDK's own verifyChallengeTemplate enforces the same equality.
+  if (p.network.toLowerCase() !== expect.network.toLowerCase()) throw new SgwChallengeError('network mismatch');
+  if (p.pubkey.toLowerCase() !== expect.pubkey.toLowerCase()) throw new SgwChallengeError('pubkey mismatch');
+  if (p.nonce !== expect.nonce) throw new SgwChallengeError('nonce mismatch');
+
+  const now = expect.nowMs ?? Date.now();
+  const issuedAt = Date.parse(p.issuedAt);
+  const expiresAt = Date.parse(p.expiresAt);
+  if (Number.isNaN(issuedAt) || Number.isNaN(expiresAt)) throw new SgwChallengeError('unparseable timestamps');
+  if (issuedAt > now + MAX_CLOCK_SKEW_MS) throw new SgwChallengeError('issuedAt too far in the future');
+  if (expiresAt <= now) throw new SgwChallengeError('challenge expired');
+  if (expiresAt - issuedAt > MAX_VALIDITY_WINDOW_MS) throw new SgwChallengeError('validity window too long');
+}

--- a/bot/src/smoke.ts
+++ b/bot/src/smoke.ts
@@ -1,0 +1,25 @@
+/**
+ * DEV HELPER — not part of the bot's runtime behavior.
+ *
+ * Boots the bot's own Sphere wallet against the real testnet2 network and
+ * prints the resulting identity, then exits. Used to verify `createBotSphere()`
+ * (Task 2 of the own-wallet bot plan) against the live aggregator/Nostr —
+ * there is no unit test for `sphere.ts` since it's an integration boot, not
+ * pure logic (see `.superpowers/sdd/task-b2-brief.md`).
+ *
+ * Run: `npx tsx src/smoke.ts`
+ */
+import { createBotSphere } from './sphere';
+
+async function main() {
+  const { sphere, identity, receivesPayments } = await createBotSphere();
+  console.log('Bot identity:', identity);
+  console.log('receivesPayments (wallet-api mailbox rail composed):', receivesPayments);
+  await sphere.destroy();
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('Smoke check failed:', err);
+  process.exit(1);
+});

--- a/bot/src/sphere.ts
+++ b/bot/src/sphere.ts
@@ -43,11 +43,26 @@
  * - `sphere.identity` getter (`core/Sphere.ts:1418-1424`) returns `Identity | null`
  *   (`types/index.ts:30-37`, re-exported from the SDK root via `index.ts:134`
  *   `export * from './types'`): `{ chainPubkey, directAddress?, ipnsName?, nametag? }`.
+ * - `sphere.setOracleApiKey(apiKey): Promise<void>` — `core/Sphere.ts:1584`, public.
+ *   Re-keys the LIVE oracle + rebuilds the token engine without a full
+ *   Sphere rebuild (transport/socket/discovery stay up) — used below to apply
+ *   a saved/provisioned key discovered AFTER init.
+ * - Bootstrap-init finding (verified against `oracle/UnicityAggregatorProvider.ts`):
+ *   `UnicityAggregatorProviderConfig.apiKey` is `apiKey?: string` (:37) and
+ *   defaults to `''` at construction (:84, `config.apiKey ?? ''`) — the
+ *   provider does NOT validate/require a non-empty key at construction time,
+ *   it only affects request headers later. `createNodeProviders` /
+ *   `Sphere.init` never throw on an empty oracle key. So booting with
+ *   `oracle: { apiKey: '' }` when there's no env key yet is safe: init
+ *   succeeds, `sphere.deriveAddress(0)` + `signMessage` (pure local crypto,
+ *   no oracle involved) can sign the SGW provisioning challenge, and
+ *   `setOracleApiKey` re-keys the live oracle once a key is resolved.
  */
 import 'dotenv/config';
 import { Sphere, type Identity } from '@unicitylabs/sphere-sdk';
 import { createNodeProviders } from '@unicitylabs/sphere-sdk/impl/nodejs';
 import { createOwnStorageWalletApiProviders } from '@unicitylabs/sphere-sdk/impl/shared/wallet-api';
+import { resolveAggregatorKey } from './aggregatorKey';
 
 const TESTNET2 = 'testnet2' as const;
 
@@ -61,7 +76,11 @@ export interface BotSphere {
 /**
  * Boot the bot's own Sphere wallet against testnet2.
  *
- * - `AGGREGATOR_API_KEY` — testnet2 aggregator key (required; see `.env.example`).
+ * - `AGGREGATOR_API_KEY` — OPTIONAL testnet2 aggregator key (see
+ *   `.env.example`). Leave it unset and the bot provisions + persists its
+ *   OWN per-wallet free-plan key from the SGW on first boot (reused on every
+ *   later boot from `BOT_DATA_DIR/aggregator-key.json`) — see
+ *   `resolveAggregatorKey` / `provisionAggregatorKey`.
  * - `BOT_MNEMONIC` — persists the bot's identity across runs. Leave empty to
  *   auto-generate a fresh one (printed once — save it to persist).
  * - `BOT_DATA_DIR` — local file storage root for wallet + token data
@@ -73,19 +92,21 @@ export interface BotSphere {
  *   receive mailbox-delivered payments.
  */
 export async function createBotSphere(): Promise<BotSphere> {
-  const aggregatorApiKey = process.env.AGGREGATOR_API_KEY;
-  if (!aggregatorApiKey) {
-    throw new Error('AGGREGATOR_API_KEY is required (see bot/.env.example)');
-  }
+  const envKey = process.env.AGGREGATOR_API_KEY?.trim() || undefined;
   const botMnemonic = process.env.BOT_MNEMONIC || undefined;
   const botDataDir = process.env.BOT_DATA_DIR || './.bot-data';
   const walletApiUrl = process.env.WALLET_API_URL || undefined;
 
+  // Bootstrap init: the wallet must exist (to sign the SGW provisioning
+  // challenge with sphere.deriveAddress(0)) before a key can be resolved,
+  // but createNodeProviders wants SOME oracle apiKey up front. An empty
+  // string is safe here — see the bootstrap-init finding in the file-header
+  // comment above; it's re-keyed via setOracleApiKey below once resolved.
   const base = createNodeProviders({
     network: TESTNET2,
     dataDir: `${botDataDir}/wallet`,
     tokensDir: `${botDataDir}/tokens`,
-    oracle: { apiKey: aggregatorApiKey },
+    oracle: { apiKey: envKey ?? '' },
   });
 
   const receivesPayments = Boolean(walletApiUrl);
@@ -113,6 +134,19 @@ export async function createBotSphere(): Promise<BotSphere> {
   const identity = sphere.identity;
   if (!identity) {
     throw new Error('Sphere.init succeeded but sphere.identity is null');
+  }
+
+  const { apiKey, source } = await resolveAggregatorKey(sphere, {
+    network: TESTNET2,
+    dataDir: botDataDir,
+    envKey,
+  });
+  // eslint-disable-next-line no-console
+  console.log(`Aggregator key: ${source}`); // never log the key value itself
+  if (source !== 'env') {
+    // The env key (if any) was already the init-time oracle key; a saved or
+    // freshly-provisioned key still needs to be applied to the live oracle.
+    await sphere.setOracleApiKey(apiKey);
   }
 
   return { sphere, identity, receivesPayments };

--- a/bot/src/sphere.ts
+++ b/bot/src/sphere.ts
@@ -1,0 +1,119 @@
+/**
+ * Bot wallet init — the bot's OWN Sphere wallet (own keys, direct SDK usage,
+ * not a Connect dApp), with an optional wallet-api receive rail.
+ *
+ * SDK symbols/field names below are verified against
+ * `sphere-sdk` 0.11.14 source (this repo pins that exact version):
+ *
+ * - `createNodeProviders(config)` — `impl/nodejs/index.ts:171`. `config.network`
+ *   is REQUIRED (throws `INVALID_CONFIG` — `impl/nodejs/index.ts:192-195`).
+ *   Storage dirs are `dataDir` / `tokensDir` (NodeProvidersConfig —
+ *   `impl/nodejs/index.ts:99,104`), oracle key is `oracle.apiKey`
+ *   (`impl/nodejs/index.ts:108`, consumed at :250-258).
+ * - `createOwnStorageWalletApiProviders(base, config)` —
+ *   `impl/shared/wallet-api/composition.ts:178`. This is the "Inventory
+ *   Custody (Bring Your Own Storage)" preset (`docs/INTEGRATION.md:227-248`):
+ *   it keeps `base`'s own `tokenStorage` (the file-based storage `createNodeProviders`
+ *   already built) and adds ONLY `delivery` (wallet-api mailbox, custody
+ *   `'external'` — zero server inventory writes on claim, composition.ts:183)
+ *   + `walletApi` (the auth-session client). Deliberately NOT
+ *   `createWalletApiProviders` (composition.ts:153): that "External Custody"
+ *   preset REPLACES `tokenStorage` with a thin provider backed by the
+ *   wallet-api server's own encrypted archive (docs/INTEGRATION.md:205-217) —
+ *   the opposite of this bot's "own keys, own storage" identity described in
+ *   `bot/README.md` and `bot/.env.example`. `WalletApiCompositionConfig`
+ *   (composition.ts:84-110) takes `baseUrl` + `network` (plain `string`, e.g.
+ *   `'testnet2'`) + optional `deviceId`; it has no `tokenStorage` field —
+ *   own-storage custody works by simply not swapping `base.tokenStorage`.
+ * - `network` fields on both factories above are a plain `NetworkType` /
+ *   `string` (`'testnet2'`), NOT the `SPHERE_NETWORKS.testnet2` object
+ *   (`{ id: 4, name: 'testnet2' }`, `constants.ts:460-462`). That object is
+ *   the Connect-protocol network descriptor (`ConnectClient`/`autoConnect`,
+ *   `docs/CONNECT.md:41-57`) — passing it here would hand an object where a
+ *   string key is expected. Testnet2's networkId (4) is reachable purely via
+ *   the string network key; `SPHERE_NETWORKS` is intentionally unused here.
+ * - `Sphere.init(options): Promise<SphereInitResult>` — `core/Sphere.ts:711`.
+ *   `SphereInitOptions` (`core/Sphere.ts:362-434`) takes the provider bundle
+ *   spread directly (`storage`, `transport`, `oracle`, `delivery?`, `walletApi?`,
+ *   `tokenStorage?`, ...) plus `mnemonic?: string` (:384), `autoGenerate?: boolean`
+ *   (:386) and `network?: NetworkType` (:398). Mirrors the canonical
+ *   `docs/QUICKSTART-NODEJS.md:149-192` shape: `Sphere.init({ ...providers, ... })`.
+ *   `SphereInitResult` (`core/Sphere.ts:436-444`) exposes `sphere`, `created`
+ *   and `generatedMnemonic?` (only set when `autoGenerate` produced a new one).
+ * - `sphere.identity` getter (`core/Sphere.ts:1418-1424`) returns `Identity | null`
+ *   (`types/index.ts:30-37`, re-exported from the SDK root via `index.ts:134`
+ *   `export * from './types'`): `{ chainPubkey, directAddress?, ipnsName?, nametag? }`.
+ */
+import 'dotenv/config';
+import { Sphere, type Identity } from '@unicitylabs/sphere-sdk';
+import { createNodeProviders } from '@unicitylabs/sphere-sdk/impl/nodejs';
+import { createOwnStorageWalletApiProviders } from '@unicitylabs/sphere-sdk/impl/shared/wallet-api';
+
+const TESTNET2 = 'testnet2' as const;
+
+export interface BotSphere {
+  sphere: Sphere;
+  identity: Identity;
+  /** True when the wallet-api mailbox delivery rail was composed in (WALLET_API_URL set). */
+  receivesPayments: boolean;
+}
+
+/**
+ * Boot the bot's own Sphere wallet against testnet2.
+ *
+ * - `AGGREGATOR_API_KEY` — testnet2 aggregator key (required; see `.env.example`).
+ * - `BOT_MNEMONIC` — persists the bot's identity across runs. Leave empty to
+ *   auto-generate a fresh one (printed once — save it to persist).
+ * - `BOT_DATA_DIR` — local file storage root for wallet + token data
+ *   (default `./.bot-data`); split into `<dir>/wallet` and `<dir>/tokens`.
+ * - `WALLET_API_URL` — optional. When set, composes the wallet-api mailbox
+ *   delivery rail (own-storage custody preset) so the bot can RECEIVE tokens
+ *   sent from a hosted Sphere wallet, which deliver via that mailbox, not
+ *   Nostr. Left unset, the bot can still send + DM over Nostr, just not
+ *   receive mailbox-delivered payments.
+ */
+export async function createBotSphere(): Promise<BotSphere> {
+  const aggregatorApiKey = process.env.AGGREGATOR_API_KEY;
+  if (!aggregatorApiKey) {
+    throw new Error('AGGREGATOR_API_KEY is required (see bot/.env.example)');
+  }
+  const botMnemonic = process.env.BOT_MNEMONIC || undefined;
+  const botDataDir = process.env.BOT_DATA_DIR || './.bot-data';
+  const walletApiUrl = process.env.WALLET_API_URL || undefined;
+
+  const base = createNodeProviders({
+    network: TESTNET2,
+    dataDir: `${botDataDir}/wallet`,
+    tokensDir: `${botDataDir}/tokens`,
+    oracle: { apiKey: aggregatorApiKey },
+  });
+
+  const receivesPayments = Boolean(walletApiUrl);
+  const providers = walletApiUrl
+    ? createOwnStorageWalletApiProviders(base, { baseUrl: walletApiUrl, network: TESTNET2 })
+    : base;
+
+  const { sphere, generatedMnemonic } = await Sphere.init({
+    ...providers,
+    network: TESTNET2,
+    mnemonic: botMnemonic,
+    autoGenerate: !botMnemonic,
+  });
+
+  if (generatedMnemonic) {
+    // eslint-disable-next-line no-console
+    console.log(
+      '\n=== GENERATED A NEW BOT MNEMONIC ===\n' +
+        generatedMnemonic +
+        '\nSAVE THIS — set BOT_MNEMONIC to persist this identity across runs.\n' +
+        '=====================================\n',
+    );
+  }
+
+  const identity = sphere.identity;
+  if (!identity) {
+    throw new Error('Sphere.init succeeded but sphere.identity is null');
+  }
+
+  return { sphere, identity, receivesPayments };
+}

--- a/bot/tsconfig.json
+++ b/bot/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/browser/.env.example
+++ b/browser/.env.example
@@ -1,0 +1,5 @@
+# Sphere wallet URL — used for the popup (P3) fallback and as the origin your
+# dApp is loaded from when testing via the custom-agent iframe.
+# Defaults to the PRODUCTION hosted wallet if unset. Point it at a locally-run
+# wallet (e.g. http://localhost:5173) if you run one yourself.
+VITE_WALLET_URL=https://sphere.unicity.network

--- a/browser/README.md
+++ b/browser/README.md
@@ -37,6 +37,14 @@ Requires a Sphere wallet reachable at `http://localhost:5173`, or the Sphere
 browser extension installed. Open the dev URL, click **Connect**, approve, and
 each panel drives one query / intent / event.
 
+> **Testing against the real (hosted) wallet — use the iframe, not a popup.**
+> To connect a *local* dApp to the **live** wallet, load it as a **custom
+> agent** inside the wallet at **https://sphere.unicity.network/agents/custom** —
+> the wallet embeds your dApp in an **iframe** and acts as the Connect host (the
+> P1 transport). The **popup path (P3) does NOT work against the hosted wallet —
+> it returns `403`.** Popup/localhost only works for a Sphere wallet you run
+> yourself at `localhost:5173`.
+
 ## What it demonstrates
 
 **Queries** (read-only, no approval):

--- a/browser/README.md
+++ b/browser/README.md
@@ -55,23 +55,37 @@ each panel drives one query / intent / event.
 
 ## How the connection is made
 
-The example auto-selects a transport by priority (see `src/lib/detection.ts`):
+This example **hand-rolls** transport selection by priority (see
+`src/hooks/useWalletConnect.ts` + `src/lib/detection.ts`) so you can see each
+transport explicitly:
 
 ```typescript
-import { autoConnect } from '@unicitylabs/sphere-sdk/connect/browser';
-import { SPHERE_NETWORKS } from '@unicitylabs/sphere-sdk/connect';
+import { ConnectClient, SPHERE_NETWORKS } from '@unicitylabs/sphere-sdk/connect';
+import { PostMessageTransport, ExtensionTransport } from '@unicitylabs/sphere-sdk/connect/browser';
+import { isInIframe, hasExtension } from './lib/detection';
+
+const WALLET_URL = import.meta.env.VITE_WALLET_URL ?? 'https://sphere.unicity.network';
 
 // P1 iframe (dApp embedded in Sphere) → P2 extension → P3 popup window.
-const { client, connection, disconnect } = await autoConnect({
-  dapp: { name: 'My dApp', description: 'What it does', url: location.origin },
-  network: SPHERE_NETWORKS.testnet2,   // the {id,name} object — Connect wants this, not a string
-});
-// connection.identity → { chainPubkey, directAddress?, nametag? }
-const balance = await client.query('sphere_getBalance');
+let transport;
+if (isInIframe()) {
+  transport = PostMessageTransport.forClient();
+} else if (hasExtension()) {
+  transport = ExtensionTransport.forClient();
+} else {
+  const popup = window.open(`${WALLET_URL}/connect?origin=${encodeURIComponent(location.origin)}`, 'sphere', 'width=420,height=700');
+  transport = PostMessageTransport.forClient({ target: popup, targetOrigin: WALLET_URL });
+}
+
+const client = new ConnectClient({ transport, dapp, network: SPHERE_NETWORKS.testnet2 });
+const { identity } = await client.connect();   // silent on load if the origin is already approved
 ```
 
-`autoConnect` also handles **silent reconnect** on page load — no popup if the
-origin is already approved.
+> **Prefer the one-liner?** The SDK also ships `autoConnect()` (from
+> `@unicitylabs/sphere-sdk/connect/browser`), which does this whole P1/P2/P3
+> selection in a single call — pass `walletUrl` for the popup path, and read the
+> identity from `result.connection.identity`. See
+> [`../backend-auth/frontend`](../backend-auth/frontend) for that style.
 
 ## Documentation
 

--- a/browser/README.md
+++ b/browser/README.md
@@ -1,0 +1,79 @@
+# Sphere Connect — Browser dApp Example
+
+A React (Vite + Tailwind) **dApp** that connects to a user's Sphere wallet over
+the Connect protocol and exercises the full surface: every read query, every
+intent, and live events. The wallet stays separate — this app never sees a
+private key; it asks the wallet to act, and the user approves.
+
+## When to use this
+
+Reach for this shape when **your app runs in a browser** and **the user is
+present to approve actions** on their own wallet.
+
+Concrete examples:
+
+- A **browser game** where the player connects their wallet and approves each
+  in-game purchase / send.
+- A **web marketplace or tipping page** that asks the wallet to send tokens or
+  create a payment request.
+- Any web frontend that reads a user's balance / assets / history and
+  occasionally asks them to sign or send.
+
+**Use a different example if:**
+
+- Your app is a **Node CLI / server**, not a web page → [`../nodejs/`](../nodejs) (drives a wallet over WebSocket).
+- Your agent should act **from its own wallet, no user approval** → [`../bot/`](../bot).
+- You only need to **know who the user is** (login), not move their tokens → [`../backend-auth/`](../backend-auth).
+
+## Run it
+
+```bash
+cd browser
+npm install
+npm run dev        # http://localhost:5174
+```
+
+Requires a Sphere wallet reachable at `http://localhost:5173`, or the Sphere
+browser extension installed. Open the dev URL, click **Connect**, approve, and
+each panel drives one query / intent / event.
+
+## What it demonstrates
+
+**Queries** (read-only, no approval):
+`sphere_getIdentity` · `sphere_getBalance` · `sphere_getAssets` · `sphere_getFiatBalance` · `sphere_getTokens` · `sphere_getHistory` · `sphere_resolve`
+
+**Intents** (open the wallet for approval):
+`send` · `mint` · `dm` · `payment_request` · `receive` · `sign_message`
+
+> Amounts on `send` / `payment_request` are **base units** (an integer string —
+> convert a human amount with `parseTokenAmount(human, decimals)`); `coinId` is
+> the lowercase 64-hex id. A `send` can resolve as a success with
+> `deliveryPending: true` and **no `transferId`** — see the Send panel; never
+> re-send that (it would pay twice).
+
+**Events** (real-time push): auto-pushed `wallet:locked` · `identity:changed`; subscribable `transfer:incoming` · `transfer:confirmed` · `transfer:failed` · and more.
+
+## How the connection is made
+
+The example auto-selects a transport by priority (see `src/lib/detection.ts`):
+
+```typescript
+import { autoConnect } from '@unicitylabs/sphere-sdk/connect/browser';
+import { SPHERE_NETWORKS } from '@unicitylabs/sphere-sdk/connect';
+
+// P1 iframe (dApp embedded in Sphere) → P2 extension → P3 popup window.
+const { client, connection, disconnect } = await autoConnect({
+  dapp: { name: 'My dApp', description: 'What it does', url: location.origin },
+  network: SPHERE_NETWORKS.testnet2,   // the {id,name} object — Connect wants this, not a string
+});
+// connection.identity → { chainPubkey, directAddress?, nametag? }
+const balance = await client.query('sphere_getBalance');
+```
+
+`autoConnect` also handles **silent reconnect** on page load — no popup if the
+origin is already approved.
+
+## Documentation
+
+- [CONNECT.md](CONNECT.md) — full browser dApp integration guide
+- [../../sphere-sdk/docs/CONNECT.md](../../sphere-sdk/docs/CONNECT.md) — protocol reference

--- a/browser/package-lock.json
+++ b/browser/package-lock.json
@@ -21,7 +21,8 @@
         "@vitejs/plugin-react": "^5.0.4",
         "tailwindcss": "^4.1.16",
         "typescript": "~5.6.0",
-        "vite": "^7.1.7"
+        "vite": "^7.1.7",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1385,6 +1386,13 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.1.tgz",
@@ -1750,6 +1758,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1941,12 +1967,135 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abort-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/abort-error/-/abort-error-1.0.2.tgz",
       "integrity": "sha512-lVgvB2NyPLqbXXhVmXcYFTC1x5K7CiVdPgdY7LGgFQWC8506oN01sPN3i9cl9ynuwF4iJ0TS9exnR7cZ9FuX4w==",
       "license": "Apache-2.0 OR MIT",
       "optional": true
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/attr-accept": {
       "version": "2.2.5",
@@ -2112,6 +2261,16 @@
         "cborg": "lib/bin.js"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2179,6 +2338,13 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.27.4",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
@@ -2230,12 +2396,32 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2852,6 +3038,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/p-queue": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
@@ -2881,6 +3081,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3085,6 +3292,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3093,6 +3307,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "10.2.2",
@@ -3136,6 +3364,23 @@
         "node": ">= 4.5.0"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3150,6 +3395,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -3335,6 +3590,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/weald": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/weald/-/weald-1.1.3.tgz",
@@ -3354,6 +3699,23 @@
       "optional": true,
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/browser/package-lock.json
+++ b/browser/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.16",
-        "@unicitylabs/sphere-sdk": "0.10.3",
-        "@unicitylabs/sphere-ui": "^0.1.23",
+        "@unicitylabs/sphere-sdk": "0.11.14",
+        "@unicitylabs/sphere-ui": "^0.1.34",
         "lucide-react": "^0.400.0",
         "react": "^19.1.1",
         "react-dom": "^19.2.4"
@@ -1777,9 +1777,9 @@
       }
     },
     "node_modules/@unicitylabs/nostr-js-sdk": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/nostr-js-sdk/-/nostr-js-sdk-0.5.0.tgz",
-      "integrity": "sha512-v6qaZBkyuZzvfjyO/x+czqftYdAqxjyfBXipsB0QJIdqePBiWHR2aRs28zzJIhCMk1vP9HXzxGnpjRqlcnzroA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/nostr-js-sdk/-/nostr-js-sdk-0.6.0.tgz",
+      "integrity": "sha512-l6WcCmFok9nxI1WkYsjIVu67svouA2QyB5Vb+GTNugWrbw7hUgJMA1Elj8qu3u0qojvSINL/L9eWTmXVWRzZUw==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^1.0.0",
@@ -1832,21 +1832,20 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.10.3.tgz",
-      "integrity": "sha512-+ZD4KCJXsCEs5KLLncK1MVx/upm8aBLRAkc7VXX4QylzcDYbMx6gxwN5GhVkjoJEOeoL3c52wwtiYsEdNX0leg==",
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.14.tgz",
+      "integrity": "sha512-bS3tRC/ofZK4uqj9pRO8TE4gfFxKUvLAmsl2GLove/1yY7OINjOLzsZbqa2BbWrxl09s5cJSgG/WMFRNXcWyuw==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
-        "@unicitylabs/nostr-js-sdk": "^0.5.0",
+        "@unicitylabs/nostr-js-sdk": "^0.6.0",
         "@unicitylabs/state-transition-sdk": "2.0.0-rc.68bc1e5",
         "bip39": "^3.1.0",
         "buffer": "^6.0.3",
         "canonicalize": "^3.0.0",
-        "crypto-js": "^4.2.0",
-        "elliptic": "^6.6.1"
+        "crypto-js": "^4.2.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -1883,13 +1882,14 @@
       }
     },
     "node_modules/@unicitylabs/sphere-ui": {
-      "version": "0.1.23",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-ui/-/sphere-ui-0.1.23.tgz",
-      "integrity": "sha512-BsyhrYQ2XKFsuxW4/X72hJqV/F5k/ZG5rhWPWZ9md+/mbA73wF8HVICLNQ5xK52+VQGt/OeHOxOow6L4YLoYcw==",
+      "version": "0.1.34",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-ui/-/sphere-ui-0.1.34.tgz",
+      "integrity": "sha512-bUPS9C1v6pTtugixm34v19AftmvJwciwR90a9E8e7pHIrGwCPwSgm4+55G5bVjfdE6AzxS0kS7MI+hg+krIgXg==",
       "dependencies": {
         "framer-motion": "^11.18.2",
         "lucide-react": ">=0.400.0",
-        "react-dropzone": "^14.4.1"
+        "react-dropzone": "^14.4.1",
+        "react-easy-crop": "^6.2.2"
       },
       "peerDependencies": {
         "@dnd-kit/core": "^6.0.0",
@@ -2010,18 +2010,6 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-      "license": "MIT"
-    },
-    "node_modules/brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
-      "license": "MIT"
     },
     "node_modules/browserslist": {
       "version": "4.28.1",
@@ -2177,21 +2165,6 @@
       "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/elliptic": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
@@ -2350,33 +2323,12 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
-    "node_modules/hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
     "node_modules/hashlru": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
       "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-      "license": "MIT",
-      "dependencies": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -2397,12 +2349,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
     },
     "node_modules/interface-datastore": {
       "version": "9.0.3",
@@ -2536,9 +2482,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.6.tgz",
-      "integrity": "sha512-NdB6O6QvlGMCoG003m0YIKG2+Xw7DjmCZhmc1RH+K6HncADUbRf8TZeLegxBBN1VFyPHcNpPTKpIhYLXzJVy1Q==",
+      "version": "1.13.9",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.9.tgz",
+      "integrity": "sha512-VNS5vWMM7r0P66BYv+TQJATxExEgLxN+34hfHDVhDkUsGAE4cRg0shCNSLTXNKm7nIUscC7AfB51TjxEeF7msQ==",
       "license": "MIT"
     },
     "node_modules/lightningcss": {
@@ -2837,18 +2783,6 @@
       "license": "Apache-2.0 OR MIT",
       "optional": true
     },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "license": "ISC"
-    },
-    "node_modules/minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
-      "license": "MIT"
-    },
     "node_modules/motion-dom": {
       "version": "11.18.1",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
@@ -2902,6 +2836,12 @@
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/normalize-wheel": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
+      "integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -3054,6 +2994,19 @@
       },
       "peerDependencies": {
         "react": ">= 16.8 || 18.0.0"
+      }
+    },
+    "node_modules/react-easy-crop": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-6.2.2.tgz",
+      "integrity": "sha512-b0HOicSvLYoNk1yvZTwjH8sNjF5uD9xLtWrSDnv+fx1dXTbwd8bNLQaP6gjXw//A+tni9Mw5KDmPNOEjKF55NQ==",
+      "license": "MIT",
+      "dependencies": {
+        "normalize-wheel": "^1.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.0",
+        "react-dom": ">=16.4.0"
       }
     },
     "node_modules/react-is": {

--- a/browser/package.json
+++ b/browser/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.16",
@@ -22,6 +23,7 @@
     "@vitejs/plugin-react": "^5.0.4",
     "tailwindcss": "^4.1.16",
     "typescript": "~5.6.0",
-    "vite": "^7.1.7"
+    "vite": "^7.1.7",
+    "vitest": "^4.1.10"
   }
 }

--- a/browser/package.json
+++ b/browser/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.16",
-    "@unicitylabs/sphere-sdk": "0.10.3",
-    "@unicitylabs/sphere-ui": "^0.1.23",
+    "@unicitylabs/sphere-sdk": "0.11.14",
+    "@unicitylabs/sphere-ui": "^0.1.34",
     "lucide-react": "^0.400.0",
     "react": "^19.1.1",
     "react-dom": "^19.2.4"

--- a/browser/src/App.tsx
+++ b/browser/src/App.tsx
@@ -26,6 +26,9 @@ import { ChatPanel } from './components/chat/ChatPanel';
 // Events
 import { EventLogPanel } from './components/events/EventLogPanel';
 
+// Docs
+import { DocsPanel } from './components/docs/DocsPanel';
+
 export default function App() {
   const wallet = useWalletConnect();
   const [section, setSection] = useState<Section>('assets');
@@ -76,6 +79,7 @@ export default function App() {
     'mint': <MintPanel intent={intent} />,
     'chat': <ChatPanel query={query} intent={intent} on={on} walletPubkey={wallet.identity!.chainPubkey} />,
     'events': <EventLogPanel on={on} />,
+    'docs': <DocsPanel />,
   };
 
   return (

--- a/browser/src/components/docs/DocsPanel.tsx
+++ b/browser/src/components/docs/DocsPanel.tsx
@@ -1,0 +1,90 @@
+const REPOS: { name: string; description: string; url: string }[] = [
+  {
+    name: 'sphere-sdk',
+    description: 'The SDK itself — Connect protocol, transports, types, and the CONNECT.md guide.',
+    url: 'https://github.com/unicity-sphere/sphere-sdk',
+  },
+  {
+    name: 'sphere-sdk-connect-example',
+    description: 'This app. Every panel you see here is a small, readable source file.',
+    url: 'https://github.com/unicity-sphere/sphere-sdk-connect-example',
+  },
+  {
+    name: 'sphere-connect (Claude plugin)',
+    description: 'Marketplace plugin that teaches Claude Code to build this same integration for you.',
+    url: 'https://github.com/unicity-sphere/unicity-claude-marketplace/tree/main/plugins/sphere-connect',
+  },
+];
+
+const SNIPPET = `npm install @unicitylabs/sphere-sdk
+
+import { autoConnect } from '@unicitylabs/sphere-sdk/connect/browser';
+import { SPHERE_NETWORKS, INTENT_ACTIONS } from '@unicitylabs/sphere-sdk/connect';
+
+// 1. Connect — autoConnect picks the transport (iframe -> extension -> popup).
+const { client, identity, disconnect } = await autoConnect({
+  dapp: { name: 'My dApp', description: 'What it does', url: location.origin },
+  network: SPHERE_NETWORKS.testnet2,
+});
+
+// 2. Read — queries need no approval.
+const balance = await client.query('sphere_getBalance');
+
+// 3. Act — intents open the wallet for user approval.
+//    Amounts are BASE UNITS (an integer string), never human decimals.
+const result = await client.intent(INTENT_ACTIONS.SEND, {
+  to: '@alice',
+  amount: '1000000000000000000',
+  coinId: '<lowercase 64-hex coin id>',
+});`;
+
+export function DocsPanel() {
+  return (
+    <div className="space-y-4">
+      <div className="admin-card p-5">
+        <h2 className="text-lg font-semibold text-white mb-1">Integrating Sphere Connect</h2>
+        <p className="text-xs text-white/45 mb-4">
+          The whole integration is three moves: connect, query, intent. This app is a live reference for each one —
+          pick a panel on the left to see it, then read that panel's source.
+        </p>
+        <pre className="p-3 rounded-xl text-[11px] leading-relaxed overflow-auto font-mono bg-white/3 border border-white/8 text-white/70">
+          {SNIPPET}
+        </pre>
+        <div className="mt-4 p-3 rounded-xl bg-amber-500/10 border border-amber-500/25">
+          <p className="text-xs font-semibold text-amber-400">One rule worth more than the rest</p>
+          <p className="mt-1 text-xs leading-relaxed text-white/60">
+            A <code className="font-mono">send</code> can resolve with{' '}
+            <code className="font-mono">deliveryPending: true</code> and no{' '}
+            <code className="font-mono">transferId</code>. That is a success: the spend certified on-chain and
+            delivery is queued for retry. Never re-send it — a second send spends a different token and pays twice.
+            See the Send panel.
+          </p>
+        </div>
+      </div>
+
+      <div className="admin-card p-5">
+        <h2 className="text-lg font-semibold text-white mb-1">Source</h2>
+        <p className="text-xs text-white/45 mb-4">Everything here is open — read it, copy it, or have Claude write it.</p>
+        <div className="space-y-2">
+          {REPOS.map((repo) => (
+            <a
+              key={repo.url}
+              href={repo.url}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="block p-3 rounded-xl border border-white/8 hover:border-orange-400 transition-colors group"
+            >
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium text-white group-hover:text-orange-400 transition-colors">
+                  {repo.name}
+                </span>
+                <span className="text-white/30 text-xs">↗</span>
+              </div>
+              <p className="mt-0.5 text-xs text-white/45">{repo.description}</p>
+            </a>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/browser/src/components/docs/DocsPanel.tsx
+++ b/browser/src/components/docs/DocsPanel.tsx
@@ -22,10 +22,11 @@ import { autoConnect } from '@unicitylabs/sphere-sdk/connect/browser';
 import { SPHERE_NETWORKS, INTENT_ACTIONS } from '@unicitylabs/sphere-sdk/connect';
 
 // 1. Connect — autoConnect picks the transport (iframe -> extension -> popup).
-const { client, identity, disconnect } = await autoConnect({
+const { client, connection, disconnect } = await autoConnect({
   dapp: { name: 'My dApp', description: 'What it does', url: location.origin },
   network: SPHERE_NETWORKS.testnet2,
 });
+// connection.identity -> { chainPubkey, directAddress?, nametag? }
 
 // 2. Read — queries need no approval.
 const balance = await client.query('sphere_getBalance');

--- a/browser/src/components/intents/MintPanel.tsx
+++ b/browser/src/components/intents/MintPanel.tsx
@@ -21,23 +21,37 @@ const PRESETS: { label: string; coinId: string; amount: string }[] = [
   { label: 'ETH 0.5', coinId: '746a4e75aeb3221462f762fc41925735983c6039e89288bbb632a8fb1012e7d0', amount: '500000000000000000' },
 ];
 
+/**
+ * The wallet refuses a mint until the per-wallet subscription key is on the oracle
+ * (sphere ConnectIntentHandler: rejects INTERNAL_ERROR "Subscription is still being
+ * set up"). That is a transient wait, not a failure — and it only ever occurs when
+ * the wallet runs with subscriptions enabled.
+ */
+function isSubscriptionWarmup(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err ?? '');
+  return message.toLowerCase().includes('subscription is still being set up');
+}
+
 export function MintPanel({ intent }: Props) {
   const [coinId, setCoinId] = useState('');
   const [amount, setAmount] = useState('');
   const [raw, setRaw] = useState<unknown>(null);
   const [error, setError] = useState<string | null>(null);
+  const [warmingUp, setWarmingUp] = useState(false);
   const [loading, setLoading] = useState(false);
 
   const execute = async () => {
     if (!coinId || !amount) return;
     setLoading(true);
     setError(null);
+    setWarmingUp(false);
     setRaw(null);
     try {
       const result = await intent(INTENT_ACTIONS.MINT, { coinId, amount });
       setRaw(result);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed');
+      if (isSubscriptionWarmup(err)) setWarmingUp(true);
+      else setError(err instanceof Error ? err.message : 'Failed');
     } finally {
       setLoading(false);
     }
@@ -76,6 +90,16 @@ export function MintPanel({ intent }: Props) {
           {loading ? 'Minting...' : 'Mint'}
         </Button>
       </div>
+
+      {warmingUp && (
+        <div className="mt-4 p-3 rounded-xl bg-amber-500/10 border border-amber-500/25">
+          <p className="text-sm font-semibold text-amber-400">Subscription is still being set up</p>
+          <p className="mt-1 text-xs leading-relaxed text-white/60">
+            The wallet provisions a per-wallet subscription key before it can certify a mint. Nothing failed —
+            wait a moment and press Mint again. A dApp should treat this as a transient retry, not an error.
+          </p>
+        </div>
+      )}
 
       <ResultDisplay result={raw} error={error} />
     </div>

--- a/browser/src/components/intents/SendPanel.tsx
+++ b/browser/src/components/intents/SendPanel.tsx
@@ -4,6 +4,7 @@ import { Button, Input } from '@unicitylabs/sphere-ui';
 import { ResultDisplay } from '../ui/ResultDisplay';
 import { CoinSelect } from '../ui/CoinSelect';
 import { parseAmount, safeParseAmount } from '../../lib/format';
+import { interpretSendResult, SIMULATED_PENDING_RESULT, type SendOutcome } from '../../lib/sendResult';
 
 interface Props {
   intent: <T>(action: string, params: Record<string, unknown>) => Promise<T>;
@@ -17,14 +18,17 @@ export function SendPanel({ intent, query }: Props) {
   const [decimals, setDecimals] = useState(0);
   const [memo, setMemo] = useState('');
   const [raw, setRaw] = useState<unknown>(null);
+  const [outcome, setOutcome] = useState<SendOutcome | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [simulatePending, setSimulatePending] = useState(false);
 
   const execute = async () => {
     if (!recipient || !amount || !coinId) return;
     setLoading(true);
     setError(null);
     setRaw(null);
+    setOutcome(null);
     try {
       const to = recipient.startsWith('@') ? recipient : '@' + recipient;
       // Connect `send` takes the amount in BASE UNITS — convert the human input
@@ -32,8 +36,14 @@ export function SendPanel({ intent, query }: Props) {
       // it. (The SDK also exports `parseTokenAmount` for the same purpose.)
       const params: Record<string, unknown> = { to, amount: parseAmount(amount, decimals), coinId };
       if (memo) params.memo = memo;
-      const result = await intent(INTENT_ACTIONS.SEND, params);
+
+      // DEMO ONLY: short-circuit to the pending fixture so the state is reachable.
+      const result = simulatePending
+        ? SIMULATED_PENDING_RESULT
+        : await intent(INTENT_ACTIONS.SEND, params);
+
       setRaw(result);
+      setOutcome(interpretSendResult(result));
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed');
     } finally {
@@ -69,7 +79,64 @@ export function SendPanel({ intent, query }: Props) {
         </Button>
       </div>
 
+      {/* DEMO SCAFFOLDING — a delivery-pending send cannot be triggered on demand,
+          so this fakes the wallet's response locally. Never ship this in a real dApp. */}
+      <label className="mt-4 flex items-start gap-2 p-2.5 rounded-lg border border-dashed border-white/15 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={simulatePending}
+          onChange={(e) => setSimulatePending(e.target.checked)}
+          className="mt-0.5 accent-orange-500"
+        />
+        <span className="text-[11px] leading-snug text-white/45">
+          <span className="font-semibold text-white/70">Demo:</span> simulate a delivery-pending result
+          (does not contact the wallet) — shows how your dApp must handle a certified-but-undelivered send.
+        </span>
+      </label>
+
+      <SendOutcomeBanner outcome={outcome} />
       <ResultDisplay result={raw} error={error} />
+    </div>
+  );
+}
+
+function SendOutcomeBanner({ outcome }: { outcome: SendOutcome | null }) {
+  if (!outcome) return null;
+
+  if (outcome.kind === 'delivery-pending') {
+    return (
+      <div className="mt-4 p-3 rounded-xl bg-amber-500/10 border border-amber-500/25">
+        <p className="text-sm font-semibold text-amber-400">Delivery pending — the money already moved</p>
+        <p className="mt-1 text-xs leading-relaxed text-white/60">
+          The spend certified on-chain, but delivery to the recipient has not landed yet. The wallet journaled
+          it and will retry under the original transfer. There is no <code className="font-mono">transferId</code> to
+          show — pending results carry an empty id by design.
+        </p>
+        <p className="mt-2 text-xs font-semibold text-amber-400">
+          Do NOT re-send. A second send consumes a different source token and pays twice.
+        </p>
+        <p className="mt-1 text-[10px] font-mono text-white/30">status: {outcome.status}</p>
+      </div>
+    );
+  }
+
+  if (outcome.kind === 'delivered') {
+    return (
+      <div className="mt-4 p-3 rounded-xl bg-green-500/10 border border-green-500/25">
+        <p className="text-sm font-semibold text-green-400">Delivered</p>
+        <p className="mt-1 text-[10px] font-mono break-all text-white/45">
+          transferId: {outcome.transferId} · status: {outcome.status}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-4 p-3 rounded-xl bg-white/4 border border-white/10">
+      <p className="text-xs text-white/45">
+        Unrecognised result shape — see the raw JSON below. If you hit this, the wallet contract may have
+        changed; <code className="font-mono">src/lib/sendResult.ts</code> needs updating.
+      </p>
     </div>
   );
 }

--- a/browser/src/components/intents/SendPanel.tsx
+++ b/browser/src/components/intents/SendPanel.tsx
@@ -106,11 +106,11 @@ function SendOutcomeBanner({ outcome }: { outcome: SendOutcome | null }) {
   if (outcome.kind === 'delivery-pending') {
     return (
       <div className="mt-4 p-3 rounded-xl bg-amber-500/10 border border-amber-500/25">
-        <p className="text-sm font-semibold text-amber-400">Delivery pending — the money already moved</p>
+        <p className="text-sm font-semibold text-amber-400">Delivery pending — the money may already have moved</p>
         <p className="mt-1 text-xs leading-relaxed text-white/60">
-          The spend certified on-chain, but delivery to the recipient has not landed yet. The wallet journaled
-          it and will retry under the original transfer. There is no <code className="font-mono">transferId</code> to
-          show — pending results carry an empty id by design.
+          The spend is committed on-chain — or, on some resolutions, may already be — and delivery to the recipient
+          has not landed yet. The wallet kept the transfer open to settle and deliver it under the original id.
+          There is no <code className="font-mono">transferId</code> to show — pending results carry an empty id by design.
         </p>
         <p className="mt-2 text-xs font-semibold text-amber-400">
           Do NOT re-send. A second send consumes a different source token and pays twice.

--- a/browser/src/components/layout/PageShell.tsx
+++ b/browser/src/components/layout/PageShell.tsx
@@ -34,6 +34,9 @@ const CHAT: NavItem[] = [
 const EVENTS: NavItem[] = [
   { key: 'events', label: 'Event Log' },
 ];
+const DOCS: NavItem[] = [
+  { key: 'docs', label: 'Docs & Source' },
+];
 
 function NavGroup({ title, color, items, active, onSelect }: {
   title: string; color: string; items: NavItem[]; active: Section; onSelect: (s: Section) => void;
@@ -66,7 +69,7 @@ export function PageShell({ identity, onDisconnect, section, onSectionChange, ch
       {/* Mobile horizontal nav */}
       <div className="lg:hidden border-b border-white/8 bg-(--bg-surface) overflow-x-auto">
         <div className="flex gap-1 px-3 py-2 min-w-max">
-          {[...QUERIES, ...INTENTS, ...CHAT, ...EVENTS].map((item) => (
+          {[...QUERIES, ...INTENTS, ...CHAT, ...EVENTS, ...DOCS].map((item) => (
             <button
               key={item.key}
               onClick={() => onSectionChange(item.key)}
@@ -89,6 +92,7 @@ export function PageShell({ identity, onDisconnect, section, onSectionChange, ch
           <NavGroup title="Intents" color="text-orange-500" items={INTENTS} active={section} onSelect={onSectionChange} />
           <NavGroup title="Chat" color="text-green-500" items={CHAT} active={section} onSelect={onSectionChange} />
           <NavGroup title="Events" color="text-purple-500" items={EVENTS} active={section} onSelect={onSectionChange} />
+          <NavGroup title="Reference" color="text-white/45" items={DOCS} active={section} onSelect={onSectionChange} />
         </aside>
 
         <main className="flex-1 overflow-y-auto p-4 lg:p-6">

--- a/browser/src/lib/sendResult.test.ts
+++ b/browser/src/lib/sendResult.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { interpretSendResult, SIMULATED_PENDING_RESULT } from './sendResult';
+
+describe('interpretSendResult', () => {
+  it('reads a normal delivered send', () => {
+    expect(
+      interpretSendResult({ success: true, transferId: 'abc123', status: 'completed', deliveryPending: false }),
+    ).toEqual({ kind: 'delivered', transferId: 'abc123', status: 'completed' });
+  });
+
+  // CANARY: this is the exact shape the wallet sends for a certified-but-undelivered
+  // spend (sphere useTransfer.ts returns { id: '', status: 'pending', deliveryPending: true },
+  // and ConnectIntentHandler drops transferId because '' is falsy). If the wallet
+  // contract drifts, this test must fail loudly — a silent drift here means dApps
+  // start re-sending certified spends and double-paying.
+  it('reads a delivery-pending send that carries NO transferId', () => {
+    expect(interpretSendResult({ success: true, status: 'pending', deliveryPending: true })).toEqual({
+      kind: 'delivery-pending',
+      status: 'pending',
+    });
+  });
+
+  it('treats deliveryPending as authoritative even if a transferId is present', () => {
+    expect(
+      interpretSendResult({ success: true, transferId: 'abc123', status: 'pending', deliveryPending: true }),
+    ).toEqual({ kind: 'delivery-pending', status: 'pending' });
+  });
+
+  it('does not invent a delivered outcome when transferId is missing', () => {
+    const raw = { success: true, status: 'completed', deliveryPending: false };
+    expect(interpretSendResult(raw)).toEqual({ kind: 'unknown', raw });
+  });
+
+  it('survives a non-object result', () => {
+    expect(interpretSendResult(null)).toEqual({ kind: 'unknown', raw: null });
+  });
+
+  it('ships a simulated pending fixture matching the real wire shape', () => {
+    expect(interpretSendResult(SIMULATED_PENDING_RESULT)).toEqual({ kind: 'delivery-pending', status: 'pending' });
+  });
+});

--- a/browser/src/lib/sendResult.ts
+++ b/browser/src/lib/sendResult.ts
@@ -34,8 +34,9 @@ export type SendOutcome =
 /**
  * Maps a raw `send` intent result to an outcome the UI can act on.
  *
- * MONEY SAFETY: `deliveryPending` wins over everything. It means the spend
- * certified on-chain and the SDK journaled delivery for retry under the ORIGINAL
+ * MONEY SAFETY: `deliveryPending` wins over everything. It means the spend is
+ * committed — or, on possibly-certified resolutions, may already be committed —
+ * on-chain, and the SDK kept the intent open to settle it under the ORIGINAL
  * transferId. Re-issuing send() would consume a different source token and pay
  * twice. Never map this to a failure and never offer a retry for it.
  */

--- a/browser/src/lib/sendResult.ts
+++ b/browser/src/lib/sendResult.ts
@@ -1,0 +1,69 @@
+/**
+ * The `send` intent result contract, as the Sphere wallet actually resolves it.
+ *
+ * Source of truth: sphere/src/components/connect/ConnectIntentHandler.tsx — the
+ * wallet resolves { success, ...(id ? { transferId: id } : {}), status, deliveryPending }.
+ * Connect itself does not type intent results (SphereIntentResult.result is
+ * `unknown`), so this interface is a hand-maintained mirror. sendResult.test.ts
+ * is the canary that fails if the wallet drifts away from it.
+ */
+export type TransferStatusWire =
+  | 'pending'
+  | 'submitted'
+  | 'confirmed'
+  | 'delivered'
+  | 'completed'
+  | 'failed';
+
+export interface SendIntentResult {
+  success: true;
+  /**
+   * OMITTED on a delivery-pending send: the wallet's TransferResult carries
+   * id: '' in that case, and '' is falsy, so the field never reaches the dApp.
+   */
+  transferId?: string;
+  status: TransferStatusWire;
+  deliveryPending: boolean;
+}
+
+export type SendOutcome =
+  | { kind: 'delivered'; transferId: string; status: TransferStatusWire }
+  | { kind: 'delivery-pending'; status: TransferStatusWire }
+  | { kind: 'unknown'; raw: unknown };
+
+/**
+ * Maps a raw `send` intent result to an outcome the UI can act on.
+ *
+ * MONEY SAFETY: `deliveryPending` wins over everything. It means the spend
+ * certified on-chain and the SDK journaled delivery for retry under the ORIGINAL
+ * transferId. Re-issuing send() would consume a different source token and pay
+ * twice. Never map this to a failure and never offer a retry for it.
+ */
+export function interpretSendResult(raw: unknown): SendOutcome {
+  if (!raw || typeof raw !== 'object') return { kind: 'unknown', raw };
+
+  const r = raw as Partial<SendIntentResult>;
+
+  if (r.deliveryPending === true) {
+    return { kind: 'delivery-pending', status: r.status ?? 'pending' };
+  }
+
+  if (typeof r.transferId === 'string' && r.transferId.length > 0) {
+    return { kind: 'delivered', transferId: r.transferId, status: r.status ?? 'completed' };
+  }
+
+  return { kind: 'unknown', raw };
+}
+
+/**
+ * DEMO SCAFFOLDING — not part of any real integration.
+ *
+ * A delivery-pending send cannot be triggered on demand (it depends on an
+ * internal SDK condition), so the example ships this fixture to make the state
+ * reachable and reviewable. Do NOT copy this into a real dApp.
+ */
+export const SIMULATED_PENDING_RESULT: SendIntentResult = {
+  success: true,
+  status: 'pending',
+  deliveryPending: true,
+};

--- a/browser/src/lib/types.ts
+++ b/browser/src/lib/types.ts
@@ -79,4 +79,5 @@ export type Section =
   | 'identity' | 'assets' | 'balance' | 'tokens' | 'history' | 'resolve'
   | 'send' | 'dm' | 'payment-request' | 'receive' | 'sign-message' | 'mint'
   | 'chat'
-  | 'events';
+  | 'events'
+  | 'docs';

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -1,0 +1,86 @@
+# Sphere Connect — Node.js dApp Example
+
+A Node **CLI dApp** that connects to a Sphere wallet over the Connect protocol
+using `WebSocketTransport`, and drives the full surface from the terminal:
+queries, intents, and DM chat. It is the same *role* as the `browser/` example
+— a dApp that acts on **someone else's** wallet — but over a WebSocket instead
+of the browser's postMessage/extension transports.
+
+This is the only example that exercises `WebSocketTransport`, the third Connect
+transport (the other two, `PostMessageTransport` and `ExtensionTransport`, are
+browser-only).
+
+## When to use this
+
+Reach for this when your app is a **Node process — a CLI, a desktop tool, a
+server** — that needs to drive a user's wallet over a WebSocket.
+
+Concrete examples:
+
+- A **CLI admin / ops tool** that reads a connected wallet's balances and
+  occasionally sends or signs.
+- A **desktop or server-side dApp** that speaks to a wallet exposing a WebSocket
+  `ConnectHost`.
+
+> **Honest caveat — read before you build on this.** This example connects to a
+> **mock wallet server** (`src/mock-wallet-server.ts`), because today there is
+> **no standard Sphere wallet that exposes a WebSocket `ConnectHost`** — the
+> hosted Sphere wallet is a web app and speaks postMessage / popup / extension.
+> So treat `nodejs/` primarily as a **reference for `WebSocketTransport` and the
+> Connect message flow from Node**, not as a plug-and-play "connect to your real
+> wallet from a terminal" path.
+
+**Use a different example if:**
+
+- Your dApp runs in a **browser** → [`../browser/`](../browser) (postMessage / extension / popup).
+- Your Node process should act **from its own wallet, no approval** → [`../bot/`](../bot) (it *is* the wallet; direct SDK, no Connect).
+- You only need to **authenticate a user** (login), not move tokens → [`../backend-auth/`](../backend-auth).
+
+## Run it
+
+Two terminals:
+
+```bash
+cd nodejs
+npm install
+npm run server     # Terminal 1: mock wallet  (ws://localhost:8765)
+npm run client     # Terminal 2: CLI dApp — type "help"
+```
+
+The client connects, then gives you a command loop:
+
+```
+identity | balance | assets | tokens | history | resolve @tag      # queries
+send @to <amount-base-units> <coinId-hex>                          # intents
+mint <coinId-hex> <amount-base-units> | dm @to <msg> | receive | sign <msg>
+conversations | messages <pubkey> | unread | read <id...>          # chat
+```
+
+> Amounts are **base units** (integer strings) and `coinId` is the lowercase
+> 64-hex id — the same contract the wallet enforces. A `send` may resolve with
+> `deliveryPending: true` and no `transferId`; that is a success, not a retry.
+
+## How the connection is made
+
+```typescript
+import { ConnectClient, SPHERE_NETWORKS } from '@unicitylabs/sphere-sdk/connect';
+import { WebSocketTransport } from '@unicitylabs/sphere-sdk/connect/nodejs';
+import WebSocket from 'ws';
+
+const transport = WebSocketTransport.createClient({
+  url: 'ws://localhost:8765',
+  createWebSocket: (url) => new WebSocket(url),
+});
+await transport.connect();
+
+const client = new ConnectClient({
+  transport,
+  dapp: { name: 'CLI Example', description: '…', url: 'cli://local' },
+  network: SPHERE_NETWORKS.testnet2,   // the {id,name} object — Connect wants this, not a string
+});
+const { identity } = await client.connect();
+```
+
+## Documentation
+
+- [../../sphere-sdk/docs/CONNECT.md](../../sphere-sdk/docs/CONNECT.md) — protocol reference

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -50,10 +50,11 @@ npm run client     # Terminal 2: CLI dApp — type "help"
 The client connects, then gives you a command loop:
 
 ```
-identity | balance | assets | tokens | history | resolve @tag      # queries
-send @to <amount-base-units> <coinId-hex>                          # intents
+identity | balance | assets | fiat | tokens | history | resolve @tag   # queries
+send @to <amount-base-units> <coinId-hex>                              # intents
+pay  @to <amount-base-units> <coinId-hex> [msg]                        # payment request
 mint <coinId-hex> <amount-base-units> | dm @to <msg> | receive | sign <msg>
-conversations | messages <pubkey> | unread | read <id...>          # chat
+conversations | messages <pubkey> | unread | read <id...>              # chat
 ```
 
 > Amounts are **base units** (integer strings) and `coinId` is the lowercase

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "sphere-connect-nodejs-example",
       "version": "0.0.0",
       "dependencies": {
-        "@unicitylabs/sphere-sdk": "0.10.3",
+        "@unicitylabs/sphere-sdk": "0.11.14",
         "ws": "^8.18.0"
       },
       "devDependencies": {
@@ -710,9 +710,9 @@
       }
     },
     "node_modules/@unicitylabs/nostr-js-sdk": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/nostr-js-sdk/-/nostr-js-sdk-0.5.0.tgz",
-      "integrity": "sha512-v6qaZBkyuZzvfjyO/x+czqftYdAqxjyfBXipsB0QJIdqePBiWHR2aRs28zzJIhCMk1vP9HXzxGnpjRqlcnzroA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/nostr-js-sdk/-/nostr-js-sdk-0.6.0.tgz",
+      "integrity": "sha512-l6WcCmFok9nxI1WkYsjIVu67svouA2QyB5Vb+GTNugWrbw7hUgJMA1Elj8qu3u0qojvSINL/L9eWTmXVWRzZUw==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^1.0.0",
@@ -765,21 +765,20 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.10.3.tgz",
-      "integrity": "sha512-+ZD4KCJXsCEs5KLLncK1MVx/upm8aBLRAkc7VXX4QylzcDYbMx6gxwN5GhVkjoJEOeoL3c52wwtiYsEdNX0leg==",
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.14.tgz",
+      "integrity": "sha512-bS3tRC/ofZK4uqj9pRO8TE4gfFxKUvLAmsl2GLove/1yY7OINjOLzsZbqa2BbWrxl09s5cJSgG/WMFRNXcWyuw==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
-        "@unicitylabs/nostr-js-sdk": "^0.5.0",
+        "@unicitylabs/nostr-js-sdk": "^0.6.0",
         "@unicitylabs/state-transition-sdk": "2.0.0-rc.68bc1e5",
         "bip39": "^3.1.0",
         "buffer": "^6.0.3",
         "canonicalize": "^3.0.0",
-        "crypto-js": "^4.2.0",
-        "elliptic": "^6.6.1"
+        "crypto-js": "^4.2.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -877,18 +876,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-      "license": "MIT"
-    },
-    "node_modules/brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
-      "license": "MIT"
-    },
     "node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -940,21 +927,6 @@
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
       "license": "MIT"
-    },
-    "node_modules/elliptic": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -1033,33 +1005,12 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "node_modules/hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
     "node_modules/hashlru": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
       "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-      "license": "MIT",
-      "dependencies": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -1080,12 +1031,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
     },
     "node_modules/interface-datastore": {
       "version": "9.0.3",
@@ -1178,9 +1123,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.6.tgz",
-      "integrity": "sha512-NdB6O6QvlGMCoG003m0YIKG2+Xw7DjmCZhmc1RH+K6HncADUbRf8TZeLegxBBN1VFyPHcNpPTKpIhYLXzJVy1Q==",
+      "version": "1.13.9",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.9.tgz",
+      "integrity": "sha512-VNS5vWMM7r0P66BYv+TQJATxExEgLxN+34hfHDVhDkUsGAE4cRg0shCNSLTXNKm7nIUscC7AfB51TjxEeF7msQ==",
       "license": "MIT"
     },
     "node_modules/main-event": {
@@ -1189,18 +1134,6 @@
       "integrity": "sha512-sKazUjIy2Jalv5lkQ446iOcrx8Q7TkaCuk6xfnzg5uUqMusMLDMPmRDmSNE2kjSVpSTJo4j1bQZusS+Ib7Bvrg==",
       "license": "Apache-2.0 OR MIT",
       "optional": true
-    },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "license": "ISC"
-    },
-    "node_modules/minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
-      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "4.0.0-nightly.202508271359",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -8,7 +8,7 @@
     "client": "npx tsx src/index.ts"
   },
   "dependencies": {
-    "@unicitylabs/sphere-sdk": "0.10.3",
+    "@unicitylabs/sphere-sdk": "0.11.14",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/nodejs/src/index.ts
+++ b/nodejs/src/index.ts
@@ -113,9 +113,9 @@ async function main() {
           case 'send': {
             const to = parts[1];
             const amount = parts[2];
-            const coinId = parts[3] ?? 'UCT';
-            if (!to || !amount) {
-              console.log('Usage: send @nametag amount [coinId]');
+            const coinId = parts[3];
+            if (!to || !amount || !coinId) {
+              console.log('Usage: send @nametag <amount-base-units> <coinId-hex>');
               break;
             }
             const sendResult = await client.intent(INTENT_ACTIONS.SEND, {
@@ -157,10 +157,10 @@ async function main() {
           case 'pay': {
             const payTo = parts[1];
             const payAmount = parts[2];
-            const payCoin = parts[3] ?? 'UCT';
+            const payCoin = parts[3];
             const payMsg = parts.slice(4).join(' ') || undefined;
-            if (!payTo || !payAmount) {
-              console.log('Usage: pay @nametag amount [coinId] [message]');
+            if (!payTo || !payAmount || !payCoin) {
+              console.log('Usage: pay @nametag <amount-base-units> <coinId-hex> [message]');
               break;
             }
             const payResult = await client.intent(INTENT_ACTIONS.PAYMENT_REQUEST, {
@@ -248,10 +248,10 @@ Commands:
     resolve @tag       - Resolve nametag/address to peer info
 
   INTENTS (require wallet approval)
-    send @to amt [coin]              - Send L3 tokens
+    send @to <amount> <coinId>       - Send L3 tokens (amount in smallest units, coinId lowercase hex)
     mint <coinId> <amount>           - Self-mint a fungible token (coinId = lowercase hex)
     dm @to message                   - Send direct message
-    pay @to amt [coin] [message]     - Send payment request
+    pay @to <amount> <coinId> [msg]  - Send payment request (amount in smallest units, coinId lowercase hex)
     receive                          - Receive incoming tokens
     sign message text                - Sign a message
 


### PR DESCRIPTION
## Summary
- Bumps `@unicitylabs/sphere-sdk` 0.10.3 -> 0.11.14 and `@unicitylabs/sphere-ui` ^0.1.23 -> ^0.1.34.
- Pins the wallet's `send` result contract in a tested pure interpreter (`src/lib/sendResult.ts`).
- `SendPanel` now renders delivery-pending as a distinct never-retry state instead of dumping raw JSON.
- `MintPanel` shows the subscription warm-up gate as a retry state, not an error.
- New **Docs & Source** panel: minimal integration snippet + links to sphere-sdk, this example, and the Claude plugin.

## Why
The wallet can resolve a `send` as `{ success: true, status: 'pending', deliveryPending: true }` with **no `transferId`** — the spend certified on-chain and delivery was journaled for retry. Nothing dApp-facing said so, so an integrator would read it as a failure and re-send, consuming a different source token and **double-paying**. This makes the contract explicit and testable.

## Notes
- Connect protocol itself did not change between 0.10.3 and 0.11.14 (`SPHERE_CONNECT_VERSION` is still `'2.0'`) — this is behaviour/docs sync only.
- Adds a minimal vitest setup (none existed) for one canary test over the pending shape.
- The "simulate a delivery-pending result" toggle is demo scaffolding — a pending send cannot be triggered on demand.
