### PR TITLE
feat(connect): graceful wallet lock — example + docs stop teaching the inverted model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  browser:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: browser
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: browser/package-lock.json
+      # npm install, not npm ci: the lockfile carries a file: link to the local SDK
+      # until the last commit on this branch restores the published pin.
+      - run: npm install
+      - run: npm test
+      # tsc -b covers src/**, which now includes the test files.
+      - run: npx tsc -b
+
+  nodejs:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: nodejs
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: nodejs/package-lock.json
+      - run: npm install
+      - run: npm test
+      - run: npx tsc --noEmit
+
+  backend-auth-frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend-auth/frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend-auth/frontend/package-lock.json
+      - run: npm install
+      - run: npm test
+      - run: npx tsc -b

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules
 dist
 .vite
 *.tsbuildinfo
+
+# Local-only design docs: specs and plans never ship in the repo.
+docs/superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,9 +126,10 @@ Frontend brokers a `sign_message`; backend recovers the pubkey via `recoverPubke
 
 ## Dependencies
 
-All four subprojects pin the same published sphere-sdk version:
+All five subprojects pin the same sphere-sdk version. This branch develops against the sibling
+`sphere-sdk` checkout; the published pin is restored when the graceful-lock release is cut:
 ```json
-"@unicitylabs/sphere-sdk": "0.11.14"
+"@unicitylabs/sphere-sdk": "file:../../sphere-sdk"
 ```
 
 - **Browser / backend-auth frontend:** React 19, Vite 7
@@ -230,7 +231,7 @@ The browser `tsconfig.json` requires explicit path mappings for connect submodul
 
 ```typescript
 SPHERE_CONNECT_NAMESPACE = 'sphere-connect'
-SPHERE_CONNECT_VERSION = '2.0'
+SPHERE_CONNECT_VERSION = '2.1'
 HOST_READY_TYPE = 'sphere-connect:host-ready'
 HOST_READY_TIMEOUT = 30_000  // ms
 ```
@@ -290,22 +291,28 @@ Token metadata (symbol, name, decimals, iconUrl) comes from the wallet's TokenRe
 
 ### useWalletConnect Hook (`browser/src/hooks/useWalletConnect.ts`)
 
-Central state management for wallet connection:
-- Manages `ConnectClient` lifecycle (create → connect → disconnect → cleanup)
-- Handles popup window open/close detection
-- Implements `HOST_READY` handshake timeout
-- Exposes: `client`, `identity`, `isConnected`, `isConnecting`, `error`, `connect()`, `disconnect()`
-- Exposes: `query()`, `intent()`, `on()` — passed to panels as props
+- Manages `ConnectClient` lifecycle (create → connect → disconnect → cleanup) through one `handshake()` helper
+- Handles popup window open/close detection and a permanent `HOST_READY` re-handshake
+- Exposes state: `isConnected`, `isConnecting`, `isAutoConnecting`, `isWalletLocked`, `walletChanged`, `unlockEpoch`, `walletProtocol`, `identity`, `permissions`, `error`
+- Exposes: `connect()`, `connectViaExtension()`, `connectViaPopup()`, `disconnect()`, `query()`, `intent()`, `on()`
+- **A lock never disconnects** against a Connect ≥ 2.1 wallet: `wallet:locked` only sets `isWalletLocked`; a resume that lands on a locked wallet succeeds with `ConnectResult.locked === true`; `wallet:unlocked` compares the identity in the payload before resuming and re-subscribes to nothing (the host re-arms); `wallet:disconnected` is the only event that tears anything down. A 2.0 wallet (`walletProtocol`) still gets the old teardown — there, `wallet:locked` also revoked the session
+- Failures are classified by `.code` and `data.reason` (`src/lib/connectErrors.ts`), never by a message regex
 
 ### Mock Wallet Server (`nodejs/src/mock-wallet-server.ts`)
 
-Testing-only server that emulates wallet behavior:
-- Creates `ConnectHost` with mock `SphereInstance`
+- Creates `ConnectHost` with a mock `SphereInstance` (`src/mockSphere.ts`, shared with the tests)
 - Auto-approves all connection requests with full permissions
-- Auto-approves all intents with action-specific success responses (send, mint, dm, payment_request, receive, sign_message)
+- Auto-approves all intents with action-specific success responses
 - Returns rich mock data: identity, assets (UCT + USDU with fiat/24h change), tokens (with statuses), history
+- stdin commands: `lock` (`setLocked()`), `unlock` (`updateSphere()`), `logout` (`revokeSession()`), `unavailable` (`setUnavailable()`), `status` (`walletState` + session + waiting count)
+- `onLockedRequest` is notify-only and increments the passive "N requests waiting — Unlock" counter a real wallet renders in its permanent chrome. It **never** raises a credential surface — no dApp request may
 
 ### Event Subscriptions
+
+- `wallet:locked` — wallet locked, **session alive**, requests answer 4009
+- `wallet:unlocked` — same session resumed; payload carries the current identity; subscriptions already re-armed
+- `wallet:disconnected` — session destroyed; re-handshake to continue
+- `identity:changed` — address switch
 
 Subscribable events (via `client.on()`):
 - `transfer:incoming` — Received tokens
@@ -342,13 +349,20 @@ sphere-sdk/impl/nodejs/connect/
 
 ```bash
 # Browser
-cd browser && npm run dev      # Dev server (:5174)
-cd browser && npm run build    # Type-check + Vite build
-cd browser && npm run preview  # Preview production build
+cd browser && npm run dev        # Dev server (:5174)
+cd browser && npm run build      # Type-check + Vite build
+cd browser && npm test           # vitest run (jsdom + React Testing Library)
+cd browser && npx vitest run src/hooks/useWalletConnect.test.ts   # one file
 
 # Node.js
-cd nodejs && npm run server    # Mock wallet (ws://localhost:8765)
-cd nodejs && npm run client    # CLI client
+cd nodejs && npm run server      # Mock wallet (ws://localhost:8765) — type "lock" / "unlock"
+cd nodejs && npm run client      # CLI client
+cd nodejs && npm test            # vitest run — headless 4009 lock-gate test
+
+# Backend auth / bot
+cd backend-auth/frontend && npm test
+cd backend-auth/backend  && npm test
+cd bot && npm test
 ```
 
 ## Code Style

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,10 +126,9 @@ Frontend brokers a `sign_message`; backend recovers the pubkey via `recoverPubke
 
 ## Dependencies
 
-All five subprojects pin the same sphere-sdk version. This branch develops against the sibling
-`sphere-sdk` checkout; the published pin is restored when the graceful-lock release is cut:
+All five packages pin the same published SDK version:
 ```json
-"@unicitylabs/sphere-sdk": "file:../../sphere-sdk"
+"@unicitylabs/sphere-sdk": "0.13.0"
 ```
 
 - **Browser / backend-auth frontend:** React 19, Vite 7

--- a/README.md
+++ b/README.md
@@ -85,12 +85,10 @@ Frontend brokers a `sign_message`; backend recovers the pubkey and issues a JWT.
 
 ## Dependencies
 
-All five packages pin the same published SDK version. This branch develops against the
-sibling `sphere-sdk` checkout (`file:../../sphere-sdk`); the published pin is restored when
-the graceful-lock release is cut:
+All five packages pin the same published SDK version:
 
 ```json
-"@unicitylabs/sphere-sdk": "file:../../sphere-sdk"
+"@unicitylabs/sphere-sdk": "0.13.0"
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -85,10 +85,12 @@ Frontend brokers a `sign_message`; backend recovers the pubkey and issues a JWT.
 
 ## Dependencies
 
-All four packages pin the same published SDK version:
+All five packages pin the same published SDK version. This branch develops against the
+sibling `sphere-sdk` checkout (`file:../../sphere-sdk`); the published pin is restored when
+the graceful-lock release is cut:
 
 ```json
-"@unicitylabs/sphere-sdk": "0.11.14"
+"@unicitylabs/sphere-sdk": "file:../../sphere-sdk"
 ```
 
 ## Documentation

--- a/backend-auth/backend/package-lock.json
+++ b/backend-auth/backend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "sphere-connect-backend-auth-example",
       "version": "0.0.0",
       "dependencies": {
-        "@unicitylabs/sphere-sdk": "0.12.0",
+        "@unicitylabs/sphere-sdk": "0.13.0",
         "dotenv": "^17.4.2",
         "express": "^4.21.2",
         "jsonwebtoken": "^9.0.2",
@@ -1256,9 +1256,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.12.0.tgz",
-      "integrity": "sha512-y3t64uac9cjKLmhgbVav5nCfz5iyovJ9YofSKeTr+Zl6dsp9rshsuJXPtMJELu1Sze8f8A7qvpu997QnD5q3Tw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.13.0.tgz",
+      "integrity": "sha512-uK7/xplYUNwsQ+tKJDDVClWXYxz9x7gKP8aVoSbJAbrGshG1XsG7D260AUDfIvG+pSONRfwX42ga3lW3TT/dmw==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/backend-auth/backend/package.json
+++ b/backend-auth/backend/package.json
@@ -11,7 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@unicitylabs/sphere-sdk": "0.12.0",
+    "@unicitylabs/sphere-sdk": "0.13.0",
     "dotenv": "^17.4.2",
     "express": "^4.21.2",
     "jsonwebtoken": "^9.0.2",

--- a/backend-auth/frontend/package-lock.json
+++ b/backend-auth/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "sphere-connect-backend-auth-frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@unicitylabs/sphere-sdk": "0.12.0",
+        "@unicitylabs/sphere-sdk": "file:../../../sphere-sdk",
         "react": "^19.1.1",
         "react-dom": "^19.2.4"
       },
@@ -17,7 +17,79 @@
         "@types/react-dom": "^19.1.9",
         "@vitejs/plugin-react": "^5.0.4",
         "typescript": "~5.6.0",
-        "vite": "^7.1.7"
+        "vite": "^7.1.7",
+        "vitest": "^4.1.10"
+      }
+    },
+    "../../../sphere-sdk": {
+      "name": "@unicitylabs/sphere-sdk",
+      "version": "0.12.0",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^2.2.0",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "@unicitylabs/nostr-js-sdk": "^0.6.0",
+        "@unicitylabs/state-transition-sdk": "2.0.1",
+        "bip39": "^3.1.0",
+        "buffer": "^6.0.3",
+        "canonicalize": "^3.0.0",
+        "crypto-js": "^4.2.0"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.39.2",
+        "@libp2p/bootstrap": "^12.0.11",
+        "@libp2p/crypto": "^5.1.13",
+        "@libp2p/interface": "^3.1.0",
+        "@libp2p/peer-id": "^6.0.4",
+        "@types/crypto-js": "^4.2.2",
+        "@types/node": "^22.0.0",
+        "@types/ws": "^8.18.1",
+        "@typescript-eslint/eslint-plugin": "^8.54.0",
+        "@typescript-eslint/parser": "^8.54.0",
+        "eslint": "^9.39.2",
+        "fake-indexeddb": "^6.2.5",
+        "multiformats": "^13.4.2",
+        "testcontainers": "^11.11.0",
+        "tsup": "^8.5.1",
+        "tsx": "^4.21.0",
+        "typescript": "~5.6.0",
+        "typescript-eslint": "^8.54.0",
+        "vitest": "^2.0.0",
+        "ws": "^8.18.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "@libp2p/crypto": "^5.1.13",
+        "@libp2p/peer-id": "^6.0.4",
+        "ipns": "^10.0.0",
+        "multiformats": "^13.4.2"
+      },
+      "peerDependencies": {
+        "@libp2p/crypto": ">=5.0.0",
+        "@libp2p/peer-id": ">=6.0.0",
+        "ipns": ">=10.0.0",
+        "multiformats": ">=13.0.0",
+        "ws": ">=8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@libp2p/crypto": {
+          "optional": true
+        },
+        "@libp2p/peer-id": {
+          "optional": true
+        },
+        "ipns": {
+          "optional": true
+        },
+        "multiformats": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -300,27 +372,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@chainsafe/is-ip": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.1.0.tgz",
-      "integrity": "sha512-KIjt+6IfysQ4GCv66xihEitBjvhU/bixbbbFxdJ1sqCp4uJ0wuZiYBPhksZoy4lfaF0k9cwNzY5upEW/VWdw3w==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@dnsquery/dns-packet": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@dnsquery/dns-packet/-/dns-packet-6.1.1.tgz",
-      "integrity": "sha512-WXTuFvL3G+74SchFAtz3FgIYVOe196ycvGsMgvSH/8Goptb1qpIQtIuM4SOK9G9lhMWYpHxnXyy544ZhluFOew==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@leichtgewicht/ip-codec": "^2.0.4",
-        "utf8-codec": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -815,195 +866,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@leichtgewicht/ip-codec": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
-      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@libp2p/interface": "^3.2.5",
-        "@noble/curves": "^2.0.1",
-        "@noble/hashes": "^2.0.1",
-        "multiformats": "^14.0.0",
-        "protons-runtime": "^7.0.0",
-        "uint8arraylist": "^3.0.2",
-        "uint8arrays": "^6.1.1"
-      }
-    },
-    "node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/@libp2p/interface": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
-      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@multiformats/dns": "^1.0.6",
-        "@multiformats/multiaddr": "^13.0.3",
-        "main-event": "^1.0.1",
-        "multiformats": "^14.0.0",
-        "progress-events": "^1.1.0",
-        "uint8arraylist": "^3.0.2"
-      }
-    },
-    "node_modules/@libp2p/interface/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/@libp2p/logger": {
-      "version": "6.2.10",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.10.tgz",
-      "integrity": "sha512-recRqNABHG32YXvpMvNepFCuU14d51dF5hs+vR2C/tkqXBQc0Sqg5LtWB2NYPoIJV+JUB50iWLrvBXZUOjLc9Q==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@libp2p/interface": "^3.2.5",
-        "@multiformats/multiaddr": "^13.0.3",
-        "interface-datastore": "^10.0.1",
-        "multiformats": "^14.0.0",
-        "weald": "^1.1.0"
-      }
-    },
-    "node_modules/@libp2p/logger/node_modules/interface-datastore": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-10.0.1.tgz",
-      "integrity": "sha512-DYMj/Og5Cz1Qwkx6/x5KRvR8SYEX7rVAv3KKCm2NzTwWSfpNAC4PahjcYbHyoZBP6zPWrhQv5n5wE+vaDdgSAg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "abort-error": "^1.0.2",
-        "interface-store": "^8.0.0",
-        "uint8arrays": "^6.1.1"
-      }
-    },
-    "node_modules/@libp2p/logger/node_modules/interface-store": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-8.0.0.tgz",
-      "integrity": "sha512-e2+s3EEROzM+Wlas4hU3zveTUscvVMf1BOvdsJfpzFm19SoEXLVadpACjWOnM491HqGpvtfFnevyiaN8W+I6Eg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "abort-error": "^1.0.2"
-      }
-    },
-    "node_modules/@libp2p/logger/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/@libp2p/peer-id": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.12.tgz",
-      "integrity": "sha512-U44MeKs+U1SqZPqS0RDzjjcS9ERix2zJsJkTcqi8I+5flEz4uVAObBDxvkkaTaqRFRXCXEPjL5kA4UbgVubCZQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@libp2p/crypto": "^5.1.21",
-        "@libp2p/interface": "^3.2.5",
-        "multiformats": "^14.0.0",
-        "uint8arrays": "^6.1.1"
-      }
-    },
-    "node_modules/@libp2p/peer-id/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/@multiformats/dns": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.15.tgz",
-      "integrity": "sha512-W0zAMABtAn+3chgFcPGvllKND7M6GblMAAFcJQTy+iMmGiyFErZYPzAh2b50Y3SFf340iFV7+ckVgZkGfUyxzA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@dnsquery/dns-packet": "^6.1.1",
-        "@libp2p/interface": "^3.1.0",
-        "hashlru": "^2.3.0",
-        "p-queue": "^9.0.0",
-        "progress-events": "^1.0.0",
-        "uint8arrays": "^6.1.1"
-      }
-    },
-    "node_modules/@multiformats/multiaddr": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-13.0.3.tgz",
-      "integrity": "sha512-mEqqJ4r3a/uuFMTpRkU316wGNIDQNhuVWpm+ebKTQeYsfv9jXbPONWM6VVnj3KGUrwfsX7GZOyp4TFqEA2SPCw==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@chainsafe/is-ip": "^2.0.1",
-        "multiformats": "^14.0.0",
-        "uint8-varint": "^3.0.0",
-        "uint8arrays": "^6.1.1"
-      }
-    },
-    "node_modules/@multiformats/multiaddr/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/@noble/ciphers": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
-      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "2.2.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -1361,14 +1223,12 @@
         "win32"
       ]
     },
-    "node_modules/@scure/base": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
-      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1415,6 +1275,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1442,124 +1320,9 @@
         "@types/react": "^19.2.0"
       }
     },
-    "node_modules/@unicitylabs/nostr-js-sdk": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/nostr-js-sdk/-/nostr-js-sdk-0.6.0.tgz",
-      "integrity": "sha512-l6WcCmFok9nxI1WkYsjIVu67svouA2QyB5Vb+GTNugWrbw7hUgJMA1Elj8qu3u0qojvSINL/L9eWTmXVWRzZUw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/ciphers": "^1.0.0",
-        "@noble/curves": "^1.6.0",
-        "@noble/hashes": "^1.5.0",
-        "@scure/base": "^1.1.9",
-        "libphonenumber-js": "^1.11.14"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.12.0.tgz",
-      "integrity": "sha512-y3t64uac9cjKLmhgbVav5nCfz5iyovJ9YofSKeTr+Zl6dsp9rshsuJXPtMJELu1Sze8f8A7qvpu997QnD5q3Tw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/ciphers": "^2.2.0",
-        "@noble/curves": "^2.0.1",
-        "@noble/hashes": "^2.0.1",
-        "@unicitylabs/nostr-js-sdk": "^0.6.0",
-        "@unicitylabs/state-transition-sdk": "2.0.1",
-        "bip39": "^3.1.0",
-        "buffer": "^6.0.3",
-        "canonicalize": "^3.0.0",
-        "crypto-js": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      },
-      "optionalDependencies": {
-        "@libp2p/crypto": "^5.1.13",
-        "@libp2p/peer-id": "^6.0.4",
-        "ipns": "^10.0.0",
-        "multiformats": "^13.4.2"
-      },
-      "peerDependencies": {
-        "@libp2p/crypto": ">=5.0.0",
-        "@libp2p/peer-id": ">=6.0.0",
-        "ipns": ">=10.0.0",
-        "multiformats": ">=13.0.0",
-        "ws": ">=8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@libp2p/crypto": {
-          "optional": true
-        },
-        "@libp2p/peer-id": {
-          "optional": true
-        },
-        "ipns": {
-          "optional": true
-        },
-        "multiformats": {
-          "optional": true
-        },
-        "ws": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@unicitylabs/state-transition-sdk": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/state-transition-sdk/-/state-transition-sdk-2.0.1.tgz",
-      "integrity": "sha512-O0pjxaL32VgHYjSM3Ei64UWBG2qwBzdQ9aIdlyhzTnPdI+kKu3h9saSMF1uV9XTfqKHsNGUpE/2dFUulNfmdmg==",
-      "license": "ISC",
-      "dependencies": {
-        "@noble/curves": "2.2.0",
-        "@noble/hashes": "2.2.0",
-        "uuid": "14.0.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
+      "resolved": "../../../sphere-sdk",
+      "link": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
@@ -1582,32 +1345,128 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/abort-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/abort-error/-/abort-error-1.0.2.tgz",
-      "integrity": "sha512-lVgvB2NyPLqbXXhVmXcYFTC1x5K7CiVdPgdY7LGgFQWC8506oN01sPN3i9cl9ynuwF4iJ0TS9exnR7cZ9FuX4w==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
         },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
+        "vite": {
+          "optional": true
         }
-      ],
-      "license": "MIT"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.43",
@@ -1620,27 +1479,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/bip39": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
-      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
-      "license": "ISC",
-      "dependencies": {
-        "@noble/hashes": "^1.2.0"
-      }
-    },
-    "node_modules/bip39/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/browserslist": {
@@ -1677,30 +1515,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001806",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
@@ -1722,26 +1536,14 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/canonicalize": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-3.0.0.tgz",
-      "integrity": "sha512-yYLfHyDMIXRyRqsKBRLX023riFLpXY2YOfdtqKXZRZy9qsfOJ9U+4F9YZL7MEzL5+ziN2x2nlBvY/Voi3EBljA==",
-      "license": "Apache-2.0",
-      "bin": {
-        "canonicalize": "bin/canonicalize.js"
-      },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/cborg": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.7.tgz",
-      "integrity": "sha512-rGg2MG9zZEUKtKqjkBppIWUecTXf9N1vs1Qru43vJWoDaODhCrtmzdehCaA/aq/c1cPI5A0kPrJ5Tf+jIfhV4w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "bin": {
-        "cborg": "lib/bin.js"
       }
     },
     "node_modules/convert-source-map": {
@@ -1749,12 +1551,6 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/crypto-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
       "license": "MIT"
     },
     "node_modules/csstype": {
@@ -1788,6 +1584,13 @@
       "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -1841,12 +1644,25 @@
         "node": ">=6"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
       "license": "MIT",
-      "optional": true
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1891,123 +1707,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/hashlru": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
-      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/interface-datastore": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-9.0.3.tgz",
-      "integrity": "sha512-NLZa7Mp+0qn48nSwIY/C36da4uVIKzwG2tuEIpaSJArsuB2RrdyDWwkoDUyjsJ+VrMntXz38VSk9vXTx/ZUpAw==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "interface-store": "^7.0.0",
-        "uint8arrays": "^5.1.0"
-      }
-    },
-    "node_modules/interface-datastore/node_modules/uint8arrays": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
-      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
-    },
-    "node_modules/interface-store": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-7.0.2.tgz",
-      "integrity": "sha512-KYOPcDH+1peaPhSeoZujR5nwkVeola1EdrnrlHTIM0HRNUs9B0aTsUQMH5kTmIjaQq1BOowoUyoCamgL8IMyww==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/ipns": {
-      "version": "10.1.6",
-      "resolved": "https://registry.npmjs.org/ipns/-/ipns-10.1.6.tgz",
-      "integrity": "sha512-mTACIdTBBXY5kbCo3t/M3ycNWbjajLrSXhTvjD0MEGyOUaI3uMv94JbJSHGaJ2xxRlpOrRk1ifToOsyPZiglnA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@libp2p/crypto": "^5.0.0",
-        "@libp2p/interface": "^3.0.2",
-        "@libp2p/logger": "^6.0.4",
-        "cborg": "^5.1.0",
-        "interface-datastore": "^9.0.2",
-        "multiformats": "^13.2.2",
-        "protons-runtime": "^6.0.1",
-        "timestamp-nano": "^1.0.1",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.1.0"
-      }
-    },
-    "node_modules/ipns/node_modules/protons-runtime": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
-      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8-varint": "^2.0.4",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.1.0"
-      }
-    },
-    "node_modules/ipns/node_modules/uint8-varint": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.5.tgz",
-      "integrity": "sha512-jeFLbL/x30wBRnWjKE1qVBXeumG46r7XmYkpis955lTQ+blccGKFrOsSMHlxePwYB1pI7L8YPHz1t4jLxEs3nA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/ipns/node_modules/uint8arraylist": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.9.tgz",
-      "integrity": "sha512-KxWjyEFzchzik3aoQlK66oaoxIReoMo5bQRm1fcjBUZvE8xv/tyR3CTKhjh6K/faV8VaF6hd5pjr45CzbwuwkA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8arrays": "^5.0.1"
-      }
-    },
-    "node_modules/ipns/node_modules/uint8arrays": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
-      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2041,12 +1740,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/libphonenumber-js": {
-      "version": "1.13.9",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.9.tgz",
-      "integrity": "sha512-VNS5vWMM7r0P66BYv+TQJATxExEgLxN+34hfHDVhDkUsGAE4cRg0shCNSLTXNKm7nIUscC7AfB51TjxEeF7msQ==",
-      "license": "MIT"
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2057,12 +1750,15 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/main-event": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/main-event/-/main-event-1.0.4.tgz",
-      "integrity": "sha512-sKazUjIy2Jalv5lkQ446iOcrx8Q7TkaCuk6xfnzg5uUqMusMLDMPmRDmSNE2kjSVpSTJo4j1bQZusS+Ib7Bvrg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2070,13 +1766,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/multiformats": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
-      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.16",
@@ -2107,35 +1796,26 @@
         "node": ">=18"
       }
     },
-    "node_modules/p-queue": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.1.tgz",
-      "integrity": "sha512-POWdiIPmsUPGwb4FeQ4OBg46aqmcInSWe45CKDsGHiOBiVQM9chqfQTuqhuTzcg2Vz9faTI65at0KkVyVEiCHw==",
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
       "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "eventemitter3": "^5.0.4",
-        "p-timeout": "^7.0.0"
-      },
       "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=12.20.0"
       }
     },
-    "node_modules/p-timeout": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
-      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2184,25 +1864,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/progress-events": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.1.0.tgz",
-      "integrity": "sha512-82DVc5tI36neVB3IjdXR11ztwGuoBc98em9ijzubeZKxI47OlV2Znq6mlPqE5xPDzO2Uw98GHiQSjj2favBCRQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/protons-runtime": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-7.0.0.tgz",
-      "integrity": "sha512-r/e72006xoVND4Uvf1aIs4OQOkJaASBU3ip4DzOWAktoKAkTiOYqKoS3TYMBm8HnnYU8+h0uEzr5gIRwk/pmTg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8-varint": "^3.0.0",
-        "uint8arraylist": "^3.0.0",
-        "uint8arrays": "^6.0.0"
       }
     },
     "node_modules/react": {
@@ -2297,6 +1958,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2307,27 +1975,35 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/supports-color": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
-      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/timestamp-nano": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/timestamp-nano/-/timestamp-nano-1.0.1.tgz",
-      "integrity": "sha512-4oGOVZWTu5sl89PtCDnhQBSt7/vL1zVEwAfxH1p49JhTosxzVQWYBYFRFZ8nJmo0G6f824iyP/44BFAwIoKvIA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 4.5.0"
       }
     },
     "node_modules/tinyglobby": {
@@ -2347,6 +2023,16 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
@@ -2360,44 +2046,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/uint8-varint": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-3.0.0.tgz",
-      "integrity": "sha512-S4DdpXBaLwKcFo7f0bWzWfHjbZ/i3QhM842qn+ZvHjxqFCfUcEB9SQNcmI69S+zMlcmIcKxsk9Iyw77S2Kxv6Q==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8arraylist": "^3.0.1",
-        "uint8arrays": "^6.1.0"
-      }
-    },
-    "node_modules/uint8arraylist": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-3.0.2.tgz",
-      "integrity": "sha512-LDVoq9BQaGJzGDUovEnoX6rpKCvnY/Jbtws4ikwnBzjRbq5qBAFpBZevUEbSmMM87aO0Sp+wOZy2ZXf5yODmXQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8arrays": "^6.0.0"
-      }
-    },
-    "node_modules/uint8arrays": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-6.1.1.tgz",
-      "integrity": "sha512-iz7JN0XCSZYA111lhFG2Ui9EhFvTNekqSRHw3lvMHq+dzwWy1OQftxFQREEh4rffU0oSoXdQHsk2TiHKVm4fsA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "multiformats": "^14.0.0"
-      }
-    },
-    "node_modules/uint8arrays/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -2428,26 +2076,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/utf8-codec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utf8-codec/-/utf8-codec-1.0.0.tgz",
-      "integrity": "sha512-S/QSLezp3qvG4ld5PUfXiH7mCFxLKjSVZRFkB3DOjgwHuJPFDkInAXc/anf7BAbHt/D38ozDzL+QMZ6/7gsI6w==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vite": {
@@ -2525,25 +2153,111 @@
         }
       }
     },
-    "node_modules/weald": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/weald/-/weald-1.1.3.tgz",
-      "integrity": "sha512-vMWtNbYuPb58NeG2+0sKA0Een4VMDwzf+3oHqh68buWRSOMUBlUeRb11LhV28czV+DUpJHRykifijZDuS9bInA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ms": "^4.0.0-nightly.202508271359",
-        "supports-color": "^10.0.0"
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
       }
     },
-    "node_modules/weald/node_modules/ms": {
-      "version": "4.0.0-nightly.202508271359",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-4.0.0-nightly.202508271359.tgz",
-      "integrity": "sha512-WC/Eo7NzFrOV/RRrTaI0fxKVbNCzEy76j2VqNV8SxDf9D69gSE2Lh0QwYvDlhiYmheBYExAvEAxVf5NoN0cj2A==",
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
       "engines": {
-        "node": ">=20"
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/backend-auth/frontend/package-lock.json
+++ b/backend-auth/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "sphere-connect-backend-auth-frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@unicitylabs/sphere-sdk": "file:../../../sphere-sdk",
+        "@unicitylabs/sphere-sdk": "0.13.0",
         "react": "^19.1.1",
         "react-dom": "^19.2.4"
       },
@@ -19,77 +19,6 @@
         "typescript": "~5.6.0",
         "vite": "^7.1.7",
         "vitest": "^4.1.10"
-      }
-    },
-    "../../../sphere-sdk": {
-      "name": "@unicitylabs/sphere-sdk",
-      "version": "0.12.0",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/ciphers": "^2.2.0",
-        "@noble/curves": "^2.0.1",
-        "@noble/hashes": "^2.0.1",
-        "@unicitylabs/nostr-js-sdk": "^0.6.0",
-        "@unicitylabs/state-transition-sdk": "2.0.1",
-        "bip39": "^3.1.0",
-        "buffer": "^6.0.3",
-        "canonicalize": "^3.0.0",
-        "crypto-js": "^4.2.0"
-      },
-      "devDependencies": {
-        "@eslint/js": "^9.39.2",
-        "@libp2p/bootstrap": "^12.0.11",
-        "@libp2p/crypto": "^5.1.13",
-        "@libp2p/interface": "^3.1.0",
-        "@libp2p/peer-id": "^6.0.4",
-        "@types/crypto-js": "^4.2.2",
-        "@types/node": "^22.0.0",
-        "@types/ws": "^8.18.1",
-        "@typescript-eslint/eslint-plugin": "^8.54.0",
-        "@typescript-eslint/parser": "^8.54.0",
-        "eslint": "^9.39.2",
-        "fake-indexeddb": "^6.2.5",
-        "multiformats": "^13.4.2",
-        "testcontainers": "^11.11.0",
-        "tsup": "^8.5.1",
-        "tsx": "^4.21.0",
-        "typescript": "~5.6.0",
-        "typescript-eslint": "^8.54.0",
-        "vitest": "^2.0.0",
-        "ws": "^8.18.1"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      },
-      "optionalDependencies": {
-        "@libp2p/crypto": "^5.1.13",
-        "@libp2p/peer-id": "^6.0.4",
-        "ipns": "^10.0.0",
-        "multiformats": "^13.4.2"
-      },
-      "peerDependencies": {
-        "@libp2p/crypto": ">=5.0.0",
-        "@libp2p/peer-id": ">=6.0.0",
-        "ipns": ">=10.0.0",
-        "multiformats": ">=13.0.0",
-        "ws": ">=8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@libp2p/crypto": {
-          "optional": true
-        },
-        "@libp2p/peer-id": {
-          "optional": true
-        },
-        "ipns": {
-          "optional": true
-        },
-        "multiformats": {
-          "optional": true
-        },
-        "ws": {
-          "optional": true
-        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -372,6 +301,27 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@chainsafe/is-ip": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.1.0.tgz",
+      "integrity": "sha512-KIjt+6IfysQ4GCv66xihEitBjvhU/bixbbbFxdJ1sqCp4uJ0wuZiYBPhksZoy4lfaF0k9cwNzY5upEW/VWdw3w==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@dnsquery/dns-packet": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@dnsquery/dns-packet/-/dns-packet-6.1.1.tgz",
+      "integrity": "sha512-WXTuFvL3G+74SchFAtz3FgIYVOe196ycvGsMgvSH/8Goptb1qpIQtIuM4SOK9G9lhMWYpHxnXyy544ZhluFOew==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.4",
+        "utf8-codec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -866,6 +816,195 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/crypto": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
+      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/interface": "^3.2.5",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "multiformats": "^14.0.0",
+        "protons-runtime": "^7.0.0",
+        "uint8arraylist": "^3.0.2",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/crypto/node_modules/multiformats": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/interface": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
+      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@multiformats/dns": "^1.0.6",
+        "@multiformats/multiaddr": "^13.0.3",
+        "main-event": "^1.0.1",
+        "multiformats": "^14.0.0",
+        "progress-events": "^1.1.0",
+        "uint8arraylist": "^3.0.2"
+      }
+    },
+    "node_modules/@libp2p/interface/node_modules/multiformats": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/logger": {
+      "version": "6.2.11",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.11.tgz",
+      "integrity": "sha512-zZ4m2EKyyRY2G8GAzmG/ZJm4CIqmaJucl5X7zTmGs1SXlb4Ayj4aP1vsaP/cVWadf/RuPWjgmIJP+Y/sZoE7Rg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/interface": "^3.2.5",
+        "@multiformats/multiaddr": "^13.0.3",
+        "interface-datastore": "^10.0.1",
+        "multiformats": "^14.0.0",
+        "weald": "^1.1.0"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/interface-datastore": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-10.0.1.tgz",
+      "integrity": "sha512-DYMj/Og5Cz1Qwkx6/x5KRvR8SYEX7rVAv3KKCm2NzTwWSfpNAC4PahjcYbHyoZBP6zPWrhQv5n5wE+vaDdgSAg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "abort-error": "^1.0.2",
+        "interface-store": "^8.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/interface-store": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-8.0.0.tgz",
+      "integrity": "sha512-e2+s3EEROzM+Wlas4hU3zveTUscvVMf1BOvdsJfpzFm19SoEXLVadpACjWOnM491HqGpvtfFnevyiaN8W+I6Eg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "abort-error": "^1.0.2"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/multiformats": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/peer-id": {
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.13.tgz",
+      "integrity": "sha512-A3sP3QUjunp7Wo5aGOkRsuYtGJZbLD4KPlHKObMam1fUCx+gHKnfyKeaWMQLkjeaUNETz9R6llquWyi41QzkLg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/interface": "^3.2.5",
+        "multiformats": "^14.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/peer-id/node_modules/multiformats": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@multiformats/dns": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.15.tgz",
+      "integrity": "sha512-W0zAMABtAn+3chgFcPGvllKND7M6GblMAAFcJQTy+iMmGiyFErZYPzAh2b50Y3SFf340iFV7+ckVgZkGfUyxzA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@dnsquery/dns-packet": "^6.1.1",
+        "@libp2p/interface": "^3.1.0",
+        "hashlru": "^2.3.0",
+        "p-queue": "^9.0.0",
+        "progress-events": "^1.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@multiformats/multiaddr": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-13.0.3.tgz",
+      "integrity": "sha512-mEqqJ4r3a/uuFMTpRkU316wGNIDQNhuVWpm+ebKTQeYsfv9jXbPONWM6VVnj3KGUrwfsX7GZOyp4TFqEA2SPCw==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "multiformats": "^14.0.0",
+        "uint8-varint": "^3.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/multiformats": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -1223,6 +1362,15 @@
         "win32"
       ]
     },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1320,9 +1468,124 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@unicitylabs/nostr-js-sdk": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/nostr-js-sdk/-/nostr-js-sdk-0.6.0.tgz",
+      "integrity": "sha512-l6WcCmFok9nxI1WkYsjIVu67svouA2QyB5Vb+GTNugWrbw7hUgJMA1Elj8qu3u0qojvSINL/L9eWTmXVWRzZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^1.0.0",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/base": "^1.1.9",
+        "libphonenumber-js": "^1.11.14"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "resolved": "../../../sphere-sdk",
-      "link": true
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.13.0.tgz",
+      "integrity": "sha512-uK7/xplYUNwsQ+tKJDDVClWXYxz9x7gKP8aVoSbJAbrGshG1XsG7D260AUDfIvG+pSONRfwX42ga3lW3TT/dmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^2.2.0",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "@unicitylabs/nostr-js-sdk": "^0.6.0",
+        "@unicitylabs/state-transition-sdk": "2.0.1",
+        "bip39": "^3.1.0",
+        "buffer": "^6.0.3",
+        "canonicalize": "^3.0.0",
+        "crypto-js": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "@libp2p/crypto": "^5.1.13",
+        "@libp2p/peer-id": "^6.0.4",
+        "ipns": "^10.0.0",
+        "multiformats": "^13.4.2"
+      },
+      "peerDependencies": {
+        "@libp2p/crypto": ">=5.0.0",
+        "@libp2p/peer-id": ">=6.0.0",
+        "ipns": ">=10.0.0",
+        "multiformats": ">=13.0.0",
+        "ws": ">=8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@libp2p/crypto": {
+          "optional": true
+        },
+        "@libp2p/peer-id": {
+          "optional": true
+        },
+        "ipns": {
+          "optional": true
+        },
+        "multiformats": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@unicitylabs/state-transition-sdk": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/state-transition-sdk/-/state-transition-sdk-2.0.1.tgz",
+      "integrity": "sha512-O0pjxaL32VgHYjSM3Ei64UWBG2qwBzdQ9aIdlyhzTnPdI+kKu3h9saSMF1uV9XTfqKHsNGUpE/2dFUulNfmdmg==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "uuid": "14.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
@@ -1458,6 +1721,13 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abort-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/abort-error/-/abort-error-1.0.2.tgz",
+      "integrity": "sha512-lVgvB2NyPLqbXXhVmXcYFTC1x5K7CiVdPgdY7LGgFQWC8506oN01sPN3i9cl9ynuwF4iJ0TS9exnR7cZ9FuX4w==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1467,6 +1737,26 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.43",
@@ -1479,6 +1769,27 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bip39": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
+      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0"
+      }
+    },
+    "node_modules/bip39/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/browserslist": {
@@ -1515,6 +1826,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001806",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
@@ -1536,6 +1871,28 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canonicalize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-3.0.0.tgz",
+      "integrity": "sha512-yYLfHyDMIXRyRqsKBRLX023riFLpXY2YOfdtqKXZRZy9qsfOJ9U+4F9YZL7MEzL5+ziN2x2nlBvY/Voi3EBljA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cborg": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.8.tgz",
+      "integrity": "sha512-enonPtLyeEF8M8GF/5NdjLHmRGslrwKR2LvkN+yFYQJw7mzt6iOoPvkVs3vcb3rUvltzL0QfvtM6FQ44o8nhSg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1551,6 +1908,12 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
       "license": "MIT"
     },
     "node_modules/csstype": {
@@ -1654,6 +2017,13 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -1707,6 +2077,123 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/interface-datastore": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-9.0.3.tgz",
+      "integrity": "sha512-NLZa7Mp+0qn48nSwIY/C36da4uVIKzwG2tuEIpaSJArsuB2RrdyDWwkoDUyjsJ+VrMntXz38VSk9vXTx/ZUpAw==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "interface-store": "^7.0.0",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/interface-datastore/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/interface-store": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-7.0.2.tgz",
+      "integrity": "sha512-KYOPcDH+1peaPhSeoZujR5nwkVeola1EdrnrlHTIM0HRNUs9B0aTsUQMH5kTmIjaQq1BOowoUyoCamgL8IMyww==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/ipns": {
+      "version": "10.1.6",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-10.1.6.tgz",
+      "integrity": "sha512-mTACIdTBBXY5kbCo3t/M3ycNWbjajLrSXhTvjD0MEGyOUaI3uMv94JbJSHGaJ2xxRlpOrRk1ifToOsyPZiglnA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/crypto": "^5.0.0",
+        "@libp2p/interface": "^3.0.2",
+        "@libp2p/logger": "^6.0.4",
+        "cborg": "^5.1.0",
+        "interface-datastore": "^9.0.2",
+        "multiformats": "^13.2.2",
+        "protons-runtime": "^6.0.1",
+        "timestamp-nano": "^1.0.1",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/ipns/node_modules/protons-runtime": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8-varint": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.5.tgz",
+      "integrity": "sha512-jeFLbL/x30wBRnWjKE1qVBXeumG46r7XmYkpis955lTQ+blccGKFrOsSMHlxePwYB1pI7L8YPHz1t4jLxEs3nA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8arraylist": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.9.tgz",
+      "integrity": "sha512-KxWjyEFzchzik3aoQlK66oaoxIReoMo5bQRm1fcjBUZvE8xv/tyR3CTKhjh6K/faV8VaF6hd5pjr45CzbwuwkA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1740,6 +2227,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.13.9",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.9.tgz",
+      "integrity": "sha512-VNS5vWMM7r0P66BYv+TQJATxExEgLxN+34hfHDVhDkUsGAE4cRg0shCNSLTXNKm7nIUscC7AfB51TjxEeF7msQ==",
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -1760,12 +2253,26 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/main-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/main-event/-/main-event-1.0.4.tgz",
+      "integrity": "sha512-sKazUjIy2Jalv5lkQ446iOcrx8Q7TkaCuk6xfnzg5uUqMusMLDMPmRDmSNE2kjSVpSTJo4j1bQZusS+Ib7Bvrg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.16",
@@ -1808,6 +2315,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.3.tgz",
+      "integrity": "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pathe": {
@@ -1864,6 +2401,25 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/progress-events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.1.0.tgz",
+      "integrity": "sha512-82DVc5tI36neVB3IjdXR11ztwGuoBc98em9ijzubeZKxI47OlV2Znq6mlPqE5xPDzO2Uw98GHiQSjj2favBCRQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/protons-runtime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-7.0.0.tgz",
+      "integrity": "sha512-r/e72006xoVND4Uvf1aIs4OQOkJaASBU3ip4DzOWAktoKAkTiOYqKoS3TYMBm8HnnYU8+h0uEzr5gIRwk/pmTg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8-varint": "^3.0.0",
+        "uint8arraylist": "^3.0.0",
+        "uint8arrays": "^6.0.0"
       }
     },
     "node_modules/react": {
@@ -1989,6 +2545,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/timestamp-nano": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/timestamp-nano/-/timestamp-nano-1.0.1.tgz",
+      "integrity": "sha512-4oGOVZWTu5sl89PtCDnhQBSt7/vL1zVEwAfxH1p49JhTosxzVQWYBYFRFZ8nJmo0G6f824iyP/44BFAwIoKvIA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -2047,6 +2626,44 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uint8-varint": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-3.0.0.tgz",
+      "integrity": "sha512-S4DdpXBaLwKcFo7f0bWzWfHjbZ/i3QhM842qn+ZvHjxqFCfUcEB9SQNcmI69S+zMlcmIcKxsk9Iyw77S2Kxv6Q==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arraylist": "^3.0.1",
+        "uint8arrays": "^6.1.0"
+      }
+    },
+    "node_modules/uint8arraylist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-3.0.2.tgz",
+      "integrity": "sha512-LDVoq9BQaGJzGDUovEnoX6rpKCvnY/Jbtws4ikwnBzjRbq5qBAFpBZevUEbSmMM87aO0Sp+wOZy2ZXf5yODmXQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arrays": "^6.0.0"
+      }
+    },
+    "node_modules/uint8arrays": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-6.1.1.tgz",
+      "integrity": "sha512-iz7JN0XCSZYA111lhFG2Ui9EhFvTNekqSRHw3lvMHq+dzwWy1OQftxFQREEh4rffU0oSoXdQHsk2TiHKVm4fsA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^14.0.0"
+      }
+    },
+    "node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -2076,6 +2693,26 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/utf8-codec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utf8-codec/-/utf8-codec-1.0.0.tgz",
+      "integrity": "sha512-S/QSLezp3qvG4ld5PUfXiH7mCFxLKjSVZRFkB3DOjgwHuJPFDkInAXc/anf7BAbHt/D38ozDzL+QMZ6/7gsI6w==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vite": {
@@ -2241,6 +2878,27 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/weald": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/weald/-/weald-1.1.3.tgz",
+      "integrity": "sha512-vMWtNbYuPb58NeG2+0sKA0Een4VMDwzf+3oHqh68buWRSOMUBlUeRb11LhV28czV+DUpJHRykifijZDuS9bInA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^4.0.0-nightly.202508271359",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/weald/node_modules/ms": {
+      "version": "4.0.0-nightly.202508271359",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-4.0.0-nightly.202508271359.tgz",
+      "integrity": "sha512-WC/Eo7NzFrOV/RRrTaI0fxKVbNCzEy76j2VqNV8SxDf9D69gSE2Lh0QwYvDlhiYmheBYExAvEAxVf5NoN0cj2A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/why-is-node-running": {

--- a/backend-auth/frontend/package.json
+++ b/backend-auth/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "@unicitylabs/sphere-sdk": "file:../../../sphere-sdk",
@@ -18,6 +19,7 @@
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.4",
     "typescript": "~5.6.0",
-    "vite": "^7.1.7"
+    "vite": "^7.1.7",
+    "vitest": "^4.1.10"
   }
 }

--- a/backend-auth/frontend/package.json
+++ b/backend-auth/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "vitest run --passWithNoTests"
+    "test": "vitest run"
   },
   "dependencies": {
     "@unicitylabs/sphere-sdk": "file:../../../sphere-sdk",

--- a/backend-auth/frontend/package.json
+++ b/backend-auth/frontend/package.json
@@ -10,7 +10,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@unicitylabs/sphere-sdk": "file:../../../sphere-sdk",
+    "@unicitylabs/sphere-sdk": "0.13.0",
     "react": "^19.1.1",
     "react-dom": "^19.2.4"
   },

--- a/backend-auth/frontend/package.json
+++ b/backend-auth/frontend/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@unicitylabs/sphere-sdk": "0.12.0",
+    "@unicitylabs/sphere-sdk": "file:../../../sphere-sdk",
     "react": "^19.1.1",
     "react-dom": "^19.2.4"
   },

--- a/backend-auth/frontend/src/App.tsx
+++ b/backend-auth/frontend/src/App.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useState } from 'react';
 import { autoConnect } from '@unicitylabs/sphere-sdk/connect/browser';
 import type { AutoConnectResult } from '@unicitylabs/sphere-sdk/connect/browser';
-import { ERROR_CODES, INTENT_ACTIONS, PERMISSION_SCOPES, SPHERE_NETWORKS } from '@unicitylabs/sphere-sdk/connect';
+import { INTENT_ACTIONS, PERMISSION_SCOPES, SPHERE_NETWORKS } from '@unicitylabs/sphere-sdk/connect';
+import { describeError, isWalletLocked } from './errors';
 
 /**
  * Backend-auth example frontend — brokers a Sphere wallet signature to the
@@ -85,21 +86,6 @@ async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
   return res.json() as Promise<T>;
 }
 
-/** Connect intent/handshake errors carry a numeric `.code` (see ConnectError in
- *  @unicitylabs/sphere-sdk/connect). Duck-type on `.code` rather than `instanceof` —
- *  the SDK's own ConnectClient comment flags instanceof as unsafe across bundles. */
-function isConnectErrorCode(err: unknown, code: number): boolean {
-  return typeof err === 'object' && err !== null && 'code' in err && (err as { code: unknown }).code === code;
-}
-
-function describeError(err: unknown): string {
-  if (isConnectErrorCode(err, ERROR_CODES.USER_REJECTED) || isConnectErrorCode(err, ERROR_CODES.INTENT_CANCELLED)) {
-    return 'You declined the signature request in your wallet.';
-  }
-  if (err instanceof Error) return err.message;
-  return 'Something went wrong.';
-}
-
 function truncate(value: string, head = 18, tail = 10): string {
   return value.length <= head + tail + 1 ? value : `${value.slice(0, head)}…${value.slice(-tail)}`;
 }
@@ -159,10 +145,14 @@ export default function App() {
     } catch (err) {
       setError(describeError(err));
       setStep('error');
-      // Best-effort cleanup so a retry starts from a fresh connection rather than
-      // a half-open transport/popup left over from the failed attempt.
-      await auto?.disconnect().catch(() => {});
-      setConnection(null);
+      // A locked wallet is NOT a dead connection: the host preserved this session and will push
+      // wallet:unlocked on it. Disconnecting here would throw away a live session and force a
+      // fresh approval for nothing. Everything else still gets the best-effort cleanup so a
+      // retry starts from a fresh connection rather than a half-open transport/popup.
+      if (!isWalletLocked(err)) {
+        await auto?.disconnect().catch(() => {});
+        setConnection(null);
+      }
     }
   }, []);
 

--- a/backend-auth/frontend/src/errors.test.ts
+++ b/backend-auth/frontend/src/errors.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { ERROR_CODES } from '@unicitylabs/sphere-sdk/connect';
+import { describeError, isConnectErrorCode, isWalletLocked } from './errors';
+
+const coded = (code: number, message = 'refused') => Object.assign(new Error(message), { code });
+
+describe('isWalletLocked', () => {
+  it('is true only for 4009', () => {
+    expect(isWalletLocked(coded(ERROR_CODES.WALLET_LOCKED))).toBe(true);
+    expect(isWalletLocked(coded(ERROR_CODES.USER_REJECTED))).toBe(false);
+    expect(isWalletLocked(new Error('boom'))).toBe(false);
+  });
+});
+
+describe('describeError', () => {
+  it('explains a locked wallet without implying a disconnect', () => {
+    const text = describeError(coded(ERROR_CODES.WALLET_LOCKED, 'Wallet is locked'));
+    expect(text).toMatch(/locked/i);
+    expect(text).toMatch(/still connected/i);
+  });
+
+  it('keeps the existing user-rejection copy', () => {
+    expect(describeError(coded(ERROR_CODES.USER_REJECTED))).toBe(
+      'You declined the signature request in your wallet.',
+    );
+  });
+
+  it('treats a cancelled intent as a rejection too', () => {
+    expect(describeError(coded(ERROR_CODES.INTENT_CANCELLED))).toBe(
+      'You declined the signature request in your wallet.',
+    );
+  });
+
+  it('falls back to the error message', () => {
+    expect(describeError(new Error('Could not reach the backend'))).toBe('Could not reach the backend');
+  });
+
+  it('falls back to a generic line for a non-Error', () => {
+    expect(describeError(null)).toBe('Something went wrong.');
+  });
+});
+
+describe('isConnectErrorCode', () => {
+  it('duck-types on a numeric code', () => {
+    expect(isConnectErrorCode(coded(4003), 4003)).toBe(true);
+    expect(isConnectErrorCode(undefined, 4003)).toBe(false);
+  });
+
+  it('ignores a string code — SphereError.code is a string', () => {
+    expect(isConnectErrorCode({ code: 'USER_REJECTED' }, 4003)).toBe(false);
+  });
+});

--- a/backend-auth/frontend/src/errors.ts
+++ b/backend-auth/frontend/src/errors.ts
@@ -1,0 +1,23 @@
+import { ERROR_CODES } from '@unicitylabs/sphere-sdk/connect';
+
+/** Connect intent/handshake errors carry a numeric `.code` (see ConnectError in
+ *  @unicitylabs/sphere-sdk/connect). Duck-type on `.code` rather than `instanceof` —
+ *  the SDK's own ConnectClient comment flags instanceof as unsafe across bundles. */
+export function isConnectErrorCode(err: unknown, code: number): boolean {
+  return typeof err === 'object' && err !== null && 'code' in err && (err as { code: unknown }).code === code;
+}
+
+export function isWalletLocked(err: unknown): boolean {
+  return isConnectErrorCode(err, ERROR_CODES.WALLET_LOCKED);
+}
+
+export function describeError(err: unknown): string {
+  if (isConnectErrorCode(err, ERROR_CODES.USER_REJECTED) || isConnectErrorCode(err, ERROR_CODES.INTENT_CANCELLED)) {
+    return 'You declined the signature request in your wallet.';
+  }
+  if (isWalletLocked(err)) {
+    return 'Your wallet is locked. Unlock it and press Sign in again — you are still connected, so no re-approval is needed.';
+  }
+  if (err instanceof Error) return err.message;
+  return 'Something went wrong.';
+}

--- a/bot/package-lock.json
+++ b/bot/package-lock.json
@@ -8,7 +8,7 @@
       "name": "sphere-connect-bot-example",
       "version": "0.0.0",
       "dependencies": {
-        "@unicitylabs/sphere-sdk": "0.12.0",
+        "@unicitylabs/sphere-sdk": "0.13.0",
         "dotenv": "^17.4.2",
         "ws": "^8.21.1"
       },
@@ -1137,9 +1137,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.12.0.tgz",
-      "integrity": "sha512-y3t64uac9cjKLmhgbVav5nCfz5iyovJ9YofSKeTr+Zl6dsp9rshsuJXPtMJELu1Sze8f8A7qvpu997QnD5q3Tw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.13.0.tgz",
+      "integrity": "sha512-uK7/xplYUNwsQ+tKJDDVClWXYxz9x7gKP8aVoSbJAbrGshG1XsG7D260AUDfIvG+pSONRfwX42ga3lW3TT/dmw==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/bot/package.json
+++ b/bot/package.json
@@ -11,7 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@unicitylabs/sphere-sdk": "0.12.0",
+    "@unicitylabs/sphere-sdk": "0.13.0",
     "dotenv": "^17.4.2",
     "ws": "^8.21.1"
   },

--- a/browser/CONNECT.md
+++ b/browser/CONNECT.md
@@ -115,7 +115,11 @@ await wallet.intent('send', { to: '@alice', amount: '1000000000000000000', coinI
   isConnected: boolean;
   isConnecting: boolean;     // true while user-triggered connect is in progress
   isAutoConnecting: boolean; // true during silent check on page load
-  isWalletLocked: boolean;   // true when wallet sends LOCKED event (extension/iframe only)
+  isWalletLocked: boolean;   // wallet:locked received, or the handshake answered locked: true —
+                             // THE SESSION IS STILL ALIVE
+  walletChanged: boolean;    // the wallet that came back from a lock has a different pubkey
+  unlockEpoch: number;       // bumps on each unlock that returned the SAME wallet
+  walletProtocol: string | null; // Connect version the WALLET reported ('2.1' | '2.0' | null)
   identity: PublicIdentity | null;
   permissions: PermissionScope[];
   error: string | null;
@@ -202,7 +206,9 @@ const unsub = wallet.on('transfer:incoming', (data) => {
 return () => unsub();
 ```
 
-Available events: auto-pushed `wallet:locked` and `identity:changed`, plus subscribable `transfer:incoming`, `transfer:confirmed`, `transfer:failed`. The full set is larger — see EventLogPanel for the complete list.
+Available events: auto-pushed `wallet:locked`, `wallet:unlocked`, `wallet:disconnected` and `identity:changed`, plus subscribable `transfer:incoming`, `transfer:confirmed`, `transfer:failed`. The full set is larger — see EventLogPanel for the complete list.
+
+The four events in `AUTO_PUSHED_EVENTS` — `wallet:locked`, `wallet:unlocked`, `wallet:disconnected`, `identity:changed` — are pushed by `ConnectHost` unconditionally. Never route them through `sphere_subscribe`: `Sphere.on()` accepts any string and would silently never emit, so the subscribe would succeed and deliver nothing forever. See [Wallet Lock Handling](#wallet-lock-handling-wallet_eventslocked) below.
 
 ### Auto-pushed wallet events
 
@@ -231,58 +237,166 @@ When using the popup (P3):
 
 ## Wallet Lock Handling (`WALLET_EVENTS.LOCKED`)
 
-When the wallet user logs out or locks the wallet, the `ConnectHost` pushes a `wallet:locked` event to all connected dApps. This is an auto-pushed event — no `sphere_subscribe` call is needed.
+**A lock is a state, not a disconnect.** When the user locks the wallet, `ConnectHost.setLocked()`
+pushes `wallet:locked` and keeps the session, the granted permissions and the transport alive.
+There is no reconnect and no re-approval, in **any** transport mode — popup included.
 
-The correct response depends on the connection mode:
+### What is served while locked, and what is refused
 
-### Extension / iframe mode (P1, P2)
+| While locked | Answer |
+|---|---|
+| `sphere_getIdentity` | **Served** from the wallet's frozen snapshot — the same bytes the handshake response already handed this origin. |
+| `sphere_subscribe` | **Served** `{ subscribed: true }`; the key is recorded and armed on unlock. |
+| `sphere_unsubscribe` | **Served** `{ unsubscribed: true }`. |
+| `sphere_disconnect` | **Served** — a locked dApp can always leave. |
+| everything else, and every intent | `WALLET_LOCKED (4009)` with `data: { reason: 'locked' }`, **in the same tick**. |
+| balances, tokens, history, fiat | **Never served and never cached.** A dApp with a stale balance is a dApp about to collect an unpayable spend. |
 
-Set `isWalletLocked = true` and show a "wallet locked" overlay. The transport stays alive — the extension or parent frame is still running. When the user unlocks or imports a new wallet, the host pushes `identity:changed`, which clears the locked state and updates the displayed identity.
+The host never parks a request and never waits for a human: a locked request is answered
+immediately, so your own timeout is never involved.
+
+### The three events that carry the model
+
+All auto-pushed — no `sphere_subscribe`:
+
+| Event | Meaning | What the dApp must do |
+|---|---|---|
+| `wallet:locked` | Wallet locked. **Session alive.** | Show a locked state. Do **not** disconnect, do **not** clear the saved session id. |
+| `wallet:unlocked` | Same session continues. Payload: `{ identity? }`. | Compare `identity.chainPubkey` with the one you connected as. If it matches, retry your reads. If it does not, you are looking at a **different wallet** — resume nothing. |
+| `wallet:disconnected` | The session is **gone** (logout, wallet deleted, expiry-while-locked, a different seed behind the lock screen). | Clear everything and re-handshake. |
 
 ```typescript
 import { WALLET_EVENTS } from '@unicitylabs/sphere-sdk/connect';
 
-const unsubLocked = client.on(WALLET_EVENTS.LOCKED, () => {
+client.on(WALLET_EVENTS.LOCKED, () => {
+  // Nothing is torn down here — in ANY transport mode.
   setState((s) => ({ ...s, isWalletLocked: true }));
 });
 
-const unsubIdentity = client.on(WALLET_EVENTS.IDENTITY_CHANGED, (data) => {
-  // Clears locked state and updates identity when wallet is unlocked
-  setState((s) => ({ ...s, isWalletLocked: false, identity: data as PublicIdentity }));
+client.on(WALLET_EVENTS.UNLOCKED, (data) => {
+  const next = (data as { identity?: PublicIdentity }).identity ?? null;
+  // Unlock is NOT implicitly the same wallet: the lock screen's
+  // "Forgot password -> restore from recovery phrase" installs a different seed, and the
+  // origin approval that authorises this session carries no identity binding.
+  if (!next || next.chainPubkey !== connectedIdentity.chainPubkey) {
+    setState((s) => ({ ...s, isWalletLocked: false, walletChanged: true, identity: next }));
+    return; // resume nothing against a wallet you never connected to
+  }
+  setState((s) => ({ ...s, isWalletLocked: false, unlockEpoch: s.unlockEpoch + 1 }));
+  // Nothing to re-subscribe: the host replays every suspended subscription key BEFORE it
+  // pushes this event. There is deliberately no client-side re-subscribe API.
+});
+
+client.on(WALLET_EVENTS.DISCONNECTED, () => {
+  transport.destroy();
+  sessionStorage.removeItem(SESSION_KEY);
+  setState(DISCONNECTED);
 });
 ```
 
-### Popup mode (P3)
+### Resuming onto a wallet that is already locked
 
-Fully disconnect: destroy the transport, clear the client reference, and remove the saved session from `sessionStorage`. **Do NOT close the popup window** — the user may import another wallet in the same popup and reconnect from scratch.
+A resume handshake whose `sessionId` matches **succeeds** while the wallet is locked, and the
+response carries `locked: true`. You are connected **and** locked, in one state — no refusal, no
+reconnect loop, and no consent prompt (any handshake while locked is forced silent, so an origin
+without an approval sees only the usual empty refusal and learns nothing about the lock):
 
 ```typescript
-const unsubLocked = client.on(WALLET_EVENTS.LOCKED, () => {
-  if (popupMode.current) {
-    // Popup navigated away (logout/refresh) — transport is dead, fully disconnect
-    transportRef.current?.destroy();
-    clientRef.current = null;
-    sessionStorage.removeItem(SESSION_KEY);
-    setState(DISCONNECTED);
-    // Note: do NOT close the popup — user can import another wallet there
-  } else {
-    // Extension/iframe — show locked state, wait for unlock
-    setState((s) => ({ ...s, isWalletLocked: true }));
-  }
+const result = await client.connect();           // resumeSessionId set
+if (result.locked === true) showLockedBanner();   // client.walletLocked is true too
+```
+
+### Talking to an older wallet
+
+The protocol version is `2.1` (`SPHERE_CONNECT_VERSION`). The compatibility gate compares MAJOR
+only, so a `2.0` wallet connects fine — but `wallet:locked` means the **opposite** there: the old
+(now removed) `notifyWalletLocked()` pushed it *and* revoked the session, and `wallet:unlocked`
+never arrives. `ConnectClient.walletProtocol` carries the wallet's version, captured at handshake:
+
+```typescript
+import { WALLET_EVENTS } from '@unicitylabs/sphere-sdk/connect';
+
+const minor = Number(/^\d+\.(\d+)$/.exec(client.walletProtocol ?? '')?.[1] ?? NaN);
+const gracefulLock = Number.isFinite(minor) && minor >= 1;
+
+client.on(WALLET_EVENTS.LOCKED, () => {
+  if (!gracefulLock) return teardown(); // 2.0 wallet: the session is already gone
+  setState((s) => ({ ...s, isWalletLocked: true }));
 });
 ```
 
-> **Why the difference?** In popup mode, the wallet page navigated away from `/connect` (e.g. to the logout screen), so the `PostMessageTransport` is dead — there is nothing to resume. In extension/iframe mode, the background script or parent frame stays alive and will push `identity:changed` once the wallet is unlocked.
+Treat an unknown or unparseable version as legacy. Assuming the session survives when it does not
+leaves the dApp stuck on a locked screen forever, waiting for an event the wallet cannot send.
+
+### Handling a request that fails while locked
+
+Discriminate on the numeric `.code` and, if you want detail, on `.data` — **never** on the message
+text. `'Wallet is locked'` is a documented recommendation, not a wire contract:
+
+```typescript
+import { ERROR_CODES } from '@unicitylabs/sphere-sdk/connect';
+
+try {
+  await client.query('sphere_getBalance');
+} catch (err) {
+  const code = typeof err === 'object' && err !== null && 'code' in err ? (err as { code: unknown }).code : undefined;
+  if (code === ERROR_CODES.WALLET_LOCKED) {
+    // data is { reason: 'locked' }
+    setLocked(true);            // stay connected; retry after wallet:unlocked
+  } else if (code === ERROR_CODES.NOT_CONNECTED || code === ERROR_CODES.SESSION_EXPIRED) {
+    teardown();                 // the session really is gone
+  } else {
+    surface(err);               // permission denied, user rejected, rate limited, …
+  }
+}
+```
+
+A handful of SDK failures carry no code at all — `Not connected`, `Query timeout: …`,
+`Intent timeout: …`, `Connection timeout`, `Disconnected` — so keep a **narrow** message fallback
+for exactly those. Do **not** match on `session` or `closed`: this example used to, and any typed
+refusal whose text merely mentioned a session forced a full disconnect. See
+`src/lib/connectErrors.ts`.
+
+### Who raises the unlock UI, and when
+
+The **wallet** does, from its own permanent chrome, **only after a human clicks**. A dApp request
+can never raise the password field — not a query, not an intent, not a handshake. What a locked
+request does raise is a passive badge ("N requests waiting — Unlock") via the host's notify-only
+`onLockedRequest`. Expect a locked request to fail typed and silently; expect the user to unlock in
+the wallet on their own initiative.
+
+The reason is not politeness. A forged *consent* dialog gains an attacker nothing; a forged
+*credential* dialog harvests the password that decrypts the seed. Letting a framed origin choose
+the moment a genuine password prompt appears is exactly how a user is trained that an unsolicited
+one is normal.
+
+### Retrying after unlock
+
+In this release the SDK does **not** queue or replay a request that failed with 4009 — the original
+promise rejects and retrying is the dApp's decision. This example bumps an `unlockEpoch` counter on
+each same-wallet unlock and lets **read** panels re-fetch on it
+(`src/components/queries/BalancePanel.tsx`).
+
+**Never auto-replay an intent.** It moves money, and firing it immediately after an unlock means it
+executes with no fresh user gesture, at the exact moment the wallet came back.
 
 ### Host-side requirement
 
-Wallet hosts (the Sphere web app `ConnectPage`, the extension background) **must** call `connectHost.notifyWalletLocked()` when the user logs out. This sends the `wallet:locked` event to the dApp and revokes the session. Call it **before** `destroy()` so the dApp receives a clean signal instead of getting `NOT_CONNECTED` errors on its next request.
+The wallet host must map each transition to exactly one verb:
 
 ```typescript
-// In the wallet's ConnectPage — when user logs out:
-connectHost.notifyWalletLocked();  // sends LOCKED event + revokes session
-connectHost.destroy();             // cleans up transport
+connectHost.setLocked();        // lock:        pushes wallet:locked,       session PRESERVED
+connectHost.updateSphere(s);    // unlock:      pushes wallet:unlocked,     session PRESERVED
+connectHost.revokeSession();    // logout:      pushes wallet:disconnected, session DESTROYED
+connectHost.setUnavailable();   // Sphere gone for a non-lock reason: revokes; requests answer 4001
 ```
+
+Call `setLocked()` **before** `sphere.destroy()`: the host drops its Sphere reference and freezes
+its snapshot there, and destroying first leaves in-flight requests reading a dead instance.
+
+`notifyWalletLocked()` has been **removed**, not deprecated. Its old meaning was *revoke* and its
+new meaning would have been *lock* — the opposite — so an alias would have silently inverted every
+call site. Pick a verb from the table above.
 
 ---
 
@@ -342,16 +456,17 @@ VITE_WALLET_URL=https://sphere.unicity.network  # wallet URL for P3 popup mode
 ## Error Handling
 
 ```typescript
+import { ERROR_CODES } from '@unicitylabs/sphere-sdk/connect';
+
 try {
   await wallet.connect();
 } catch (err) {
-  if (err.message.includes('Popup blocked')) {
-    // User needs to allow popups
-  } else if (err.message.includes('Connection timeout')) {
-    // Wallet did not respond in time
-  } else {
-    // User rejected or other error
-  }
+  const code = typeof err === 'object' && err !== null && 'code' in err ? (err as { code: unknown }).code : undefined;
+  if (code === ERROR_CODES.WALLET_LOCKED)              { /* an unapprovable resume while locked */ }
+  else if (code === ERROR_CODES.INCOMPATIBLE_NETWORK)  { /* dApp targets another network */ }
+  else if (code === ERROR_CODES.USER_REJECTED)         { /* user declined */ }
+  else if (err instanceof Error && err.message.includes('Popup blocked')) { /* allow popups */ }
+  else { /* transport failure */ }
 }
 ```
 

--- a/browser/CONNECT.md
+++ b/browser/CONNECT.md
@@ -400,6 +400,41 @@ call site. Pick a verb from the table above.
 
 ---
 
+## Choosing a transport: how long does the session need to live?
+
+The three transports are not interchangeable. Pick by session lifetime, not by convenience.
+
+**Popup (P3) — for a SHORT, bounded flow.** Connect, get a signature or a JWT, done. Everything
+about the popup is fragile for anything longer:
+
+- closing it is a real **disconnect** — the wallet revokes the session on `beforeunload` and
+  pushes `wallet:disconnected`. There is no "reopen and resume": a fresh window means a fresh
+  host with no session.
+- reloading it **re-locks** the wallet. The password is memory-only by design, so a reload
+  leaves nothing to decrypt the mnemonic with.
+- it cold-starts **locked** even when the user has Sphere unlocked in another tab. A separate
+  window is a separate JS context with its own memory; only the lock signal crosses windows
+  (via `BroadcastChannel`), never the password.
+- it does not scale to several dApps. Each dApp opens its own wallet window, so two connected
+  apps mean two windows and two password prompts.
+
+**Iframe (P1) — for a LONG-LIVED session.** The dApp runs inside Sphere, so one wallet window
+serves every framed app: one host per app, one unlock for all of them, and the wallet's own
+chrome carries the passive "N requests blocked — Unlock" badge. This is where a
+session-preserving lock actually pays off — the host outlives both the lock and a reload of the
+framed page.
+
+**Extension (P2)** sits in between: the host lives in the extension, so it survives the dApp
+page, but the user still unlocks in the extension's own surface.
+
+A locked wallet serves only `sphere_getIdentity` (from a frozen snapshot), `sphere_subscribe`,
+`sphere_unsubscribe` and `sphere_disconnect`. Balances, assets, tokens, fiat balance and history
+are never served and never cached — a stale balance is a dApp about to offer an unpayable spend.
+So a dApp must **stop issuing reads while `isWalletLocked`** and resume on `unlockEpoch`, rather
+than polling into refusals: every refusal increments the wallet's blocked-request badge.
+
+---
+
 ## Popup Mode (P3) — Session Resume
 
 When no extension is installed, the dApp opens a Sphere popup window. **The popup must stay open** for the connection to work — closing it destroys the transport and disconnects.

--- a/browser/CONNECT.md
+++ b/browser/CONNECT.md
@@ -523,6 +523,44 @@ try {
 }
 ```
 
+### Spending: the one code you must not retry on
+
+`INTENT_OUTCOME_UNKNOWN` (4201) means the wallet took your intent and the answer was lost — a
+host deadline, a lock, a logout. **The money may or may not have moved.** It is the only error
+where the natural reaction, re-enabling the button, is the wrong one.
+
+```typescript
+import { ERROR_CODES } from '@unicitylabs/sphere-sdk/connect';
+import { classifyRequestError } from './lib/connectErrors';
+
+try {
+  await wallet.intent(INTENT_ACTIONS.SEND, { to, amount, coinId });
+} catch (err) {
+  switch (classifyRequestError(err)) {
+    case 'outcome-unknown':
+      // Do NOT offer a retry. Reconcile first — poll the recipient, your backend, the
+      // aggregator — and only then decide whether anything still needs sending.
+      showPendingReconciliation();
+      break;
+    case 'locked':
+      // 4009 — the session is alive; the wallet is just locked. Safe to retry after unlock.
+      setWalletLocked(true);
+      break;
+    case 'teardown':
+      clearSession();
+      break;
+    default:
+      // A specific, truthful refusal: USER_REJECTED, INSUFFICIENT_BALANCE, TRANSFER_FAILED…
+      showError(err);
+  }
+}
+```
+
+`USER_REJECTED` (4003) is different and IS retryable: the user declined before anything was
+submitted. The wallet is responsible for never reporting a cancel once a transfer is on the
+wire, and the host downgrades `WALLET_LOCKED` / `NOT_CONNECTED` to 4201 if a wallet answers an
+accepted intent with them.
+
 ---
 
 ## Running the Example

--- a/browser/CONNECT.md
+++ b/browser/CONNECT.md
@@ -424,11 +424,23 @@ chrome carries the passive "N requests blocked — Unlock" badge. This is where 
 session-preserving lock actually pays off — the host outlives both the lock and a reload of the
 framed page.
 
-A locked wallet serves only `sphere_getIdentity` (from a frozen snapshot), `sphere_subscribe`,
-`sphere_unsubscribe` and `sphere_disconnect`. Balances, assets, tokens, fiat balance and history
-are never served and never cached — a stale balance is a dApp about to offer an unpayable spend.
-So a dApp must **stop issuing reads while `isWalletLocked`** and resume on `unlockEpoch`, rather
-than polling into refusals: every refusal increments the wallet's blocked-request badge.
+A locked wallet that HOLDS your session serves four of the sixteen `RPC_METHODS`:
+`sphere_getIdentity` (from a frozen snapshot), `sphere_subscribe`, `sphere_unsubscribe` and
+`sphere_disconnect`. The other **twelve, and every intent**, are refused `WALLET_LOCKED` (4009) —
+the five money reads, `sphere_resolve`, **all four DM reads** (`getConversations`, `getMessages`,
+`getDMUnreadCount`, `markAsRead`) and both invoice reads. Nothing is cached, and **messaging does
+not keep working while locked**. So a dApp must **stop issuing reads while `isWalletLocked`** and
+resume on `unlockEpoch`, rather than polling into refusals: every refusal increments the wallet's
+blocked-request badge.
+
+A wallet that **cold-starts locked** behaves differently, and it is the common path — the
+password is memory-only, so a wallet-page reload or a fresh popup lands there. Such a host holds
+no session, so the HANDSHAKE itself is refused with an errorless empty response: `connect()`
+rejects with a bare "Connection rejected by wallet" and **no code at all**. Do not write
+`if (err.code === ERROR_CODES.WALLET_LOCKED)` expecting to catch this — there is nothing to
+match. The silence is deliberate (the refusal must reveal nothing about the wallet to an origin
+holding no approval), so treat a rejection you did not expect as "not ready yet": stay parked and
+let the next `HOST_READY` retry for you, which is what `useWalletConnect` does.
 
 When a request the USER just triggered is refused with 4009, raise the wallet window for them —
 `useWalletConnect` does this by sampling `navigator.userActivation.isActive` synchronously at the

--- a/browser/CONNECT.md
+++ b/browser/CONNECT.md
@@ -424,9 +424,6 @@ chrome carries the passive "N requests blocked — Unlock" badge. This is where 
 session-preserving lock actually pays off — the host outlives both the lock and a reload of the
 framed page.
 
-**Extension (P2)** sits in between: the host lives in the extension, so it survives the dApp
-page, but the user still unlocks in the extension's own surface.
-
 A locked wallet serves only `sphere_getIdentity` (from a frozen snapshot), `sphere_subscribe`,
 `sphere_unsubscribe` and `sphere_disconnect`. Balances, assets, tokens, fiat balance and history
 are never served and never cached — a stale balance is a dApp about to offer an unpayable spend.

--- a/browser/CONNECT.md
+++ b/browser/CONNECT.md
@@ -430,6 +430,15 @@ are never served and never cached — a stale balance is a dApp about to offer a
 So a dApp must **stop issuing reads while `isWalletLocked`** and resume on `unlockEpoch`, rather
 than polling into refusals: every refusal increments the wallet's blocked-request badge.
 
+When a request the USER just triggered is refused with 4009, raise the wallet window for them —
+`useWalletConnect` does this by sampling `navigator.userActivation.isActive` synchronously at the
+call site, before any await. That flag is the browser's own transient-activation signal, so it
+separates "the user pressed Fetch Balance" from "a poller ran": a background request never steals
+focus. The banner also carries an explicit button, for browsers without the flag and for a gesture
+that has already expired. Note that a CLOSED popup is not recoverable — the wallet revokes the
+session on `beforeunload` and a fresh window cold-starts locked, so offer a reconnect, not a
+restore.
+
 ---
 
 ## Popup Mode (P3) — Session Resume

--- a/browser/README.md
+++ b/browser/README.md
@@ -59,7 +59,8 @@ each panel drives one query / intent / event.
 > `deliveryPending: true` and **no `transferId`** — see the Send panel; never
 > re-send that (it would pay twice).
 
-**Events** (real-time push): auto-pushed `wallet:locked` · `identity:changed`; subscribable `transfer:incoming` · `transfer:confirmed` · `transfer:failed` · and more.
+```
+**Events** (real-time push): auto-pushed `wallet:locked` · `wallet:unlocked` · `wallet:disconnected` · `identity:changed`; subscribable `transfer:incoming` · `transfer:confirmed` · `transfer:failed` · and more. A lock does **not** disconnect — see [CONNECT.md](CONNECT.md#wallet-lock-handling-wallet_eventslocked).
 
 ## How the connection is made
 

--- a/browser/package-lock.json
+++ b/browser/package-lock.json
@@ -14,7 +14,7 @@
         "@tailwindcss/vite": "^4.1.16",
         "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-table": "^8.21.3",
-        "@unicitylabs/sphere-sdk": "file:../../sphere-sdk",
+        "@unicitylabs/sphere-sdk": "0.13.0",
         "@unicitylabs/sphere-ui": "^0.1.34",
         "lucide-react": "^0.400.0",
         "react": "^19.1.1",
@@ -32,77 +32,6 @@
         "typescript": "~5.6.0",
         "vite": "^7.1.7",
         "vitest": "^4.1.10"
-      }
-    },
-    "../../sphere-sdk": {
-      "name": "@unicitylabs/sphere-sdk",
-      "version": "0.12.0",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/ciphers": "^2.2.0",
-        "@noble/curves": "^2.0.1",
-        "@noble/hashes": "^2.0.1",
-        "@unicitylabs/nostr-js-sdk": "^0.6.0",
-        "@unicitylabs/state-transition-sdk": "2.0.1",
-        "bip39": "^3.1.0",
-        "buffer": "^6.0.3",
-        "canonicalize": "^3.0.0",
-        "crypto-js": "^4.2.0"
-      },
-      "devDependencies": {
-        "@eslint/js": "^9.39.2",
-        "@libp2p/bootstrap": "^12.0.11",
-        "@libp2p/crypto": "^5.1.13",
-        "@libp2p/interface": "^3.1.0",
-        "@libp2p/peer-id": "^6.0.4",
-        "@types/crypto-js": "^4.2.2",
-        "@types/node": "^22.0.0",
-        "@types/ws": "^8.18.1",
-        "@typescript-eslint/eslint-plugin": "^8.54.0",
-        "@typescript-eslint/parser": "^8.54.0",
-        "eslint": "^9.39.2",
-        "fake-indexeddb": "^6.2.5",
-        "multiformats": "^13.4.2",
-        "testcontainers": "^11.11.0",
-        "tsup": "^8.5.1",
-        "tsx": "^4.21.0",
-        "typescript": "~5.6.0",
-        "typescript-eslint": "^8.54.0",
-        "vitest": "^2.0.0",
-        "ws": "^8.18.1"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      },
-      "optionalDependencies": {
-        "@libp2p/crypto": "^5.1.13",
-        "@libp2p/peer-id": "^6.0.4",
-        "ipns": "^10.0.0",
-        "multiformats": "^13.4.2"
-      },
-      "peerDependencies": {
-        "@libp2p/crypto": ">=5.0.0",
-        "@libp2p/peer-id": ">=6.0.0",
-        "ipns": ">=10.0.0",
-        "multiformats": ">=13.0.0",
-        "ws": ">=8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@libp2p/crypto": {
-          "optional": true
-        },
-        "@libp2p/peer-id": {
-          "optional": true
-        },
-        "ipns": {
-          "optional": true
-        },
-        "multiformats": {
-          "optional": true
-        },
-        "ws": {
-          "optional": true
-        }
       }
     },
     "node_modules/@acemir/cssom": {
@@ -459,6 +388,13 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@chainsafe/is-ip": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.1.0.tgz",
+      "integrity": "sha512-KIjt+6IfysQ4GCv66xihEitBjvhU/bixbbbFxdJ1sqCp4uJ0wuZiYBPhksZoy4lfaF0k9cwNzY5upEW/VWdw3w==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
@@ -650,6 +586,20 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnsquery/dns-packet": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@dnsquery/dns-packet/-/dns-packet-6.1.1.tgz",
+      "integrity": "sha512-WXTuFvL3G+74SchFAtz3FgIYVOe196ycvGsMgvSH/8Goptb1qpIQtIuM4SOK9G9lhMWYpHxnXyy544ZhluFOew==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.4",
+        "utf8-codec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1157,6 +1107,195 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/crypto": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
+      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/interface": "^3.2.5",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "multiformats": "^14.0.0",
+        "protons-runtime": "^7.0.0",
+        "uint8arraylist": "^3.0.2",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/crypto/node_modules/multiformats": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/interface": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
+      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@multiformats/dns": "^1.0.6",
+        "@multiformats/multiaddr": "^13.0.3",
+        "main-event": "^1.0.1",
+        "multiformats": "^14.0.0",
+        "progress-events": "^1.1.0",
+        "uint8arraylist": "^3.0.2"
+      }
+    },
+    "node_modules/@libp2p/interface/node_modules/multiformats": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/logger": {
+      "version": "6.2.11",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.11.tgz",
+      "integrity": "sha512-zZ4m2EKyyRY2G8GAzmG/ZJm4CIqmaJucl5X7zTmGs1SXlb4Ayj4aP1vsaP/cVWadf/RuPWjgmIJP+Y/sZoE7Rg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/interface": "^3.2.5",
+        "@multiformats/multiaddr": "^13.0.3",
+        "interface-datastore": "^10.0.1",
+        "multiformats": "^14.0.0",
+        "weald": "^1.1.0"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/interface-datastore": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-10.0.1.tgz",
+      "integrity": "sha512-DYMj/Og5Cz1Qwkx6/x5KRvR8SYEX7rVAv3KKCm2NzTwWSfpNAC4PahjcYbHyoZBP6zPWrhQv5n5wE+vaDdgSAg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "abort-error": "^1.0.2",
+        "interface-store": "^8.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/interface-store": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-8.0.0.tgz",
+      "integrity": "sha512-e2+s3EEROzM+Wlas4hU3zveTUscvVMf1BOvdsJfpzFm19SoEXLVadpACjWOnM491HqGpvtfFnevyiaN8W+I6Eg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "abort-error": "^1.0.2"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/multiformats": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/peer-id": {
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.13.tgz",
+      "integrity": "sha512-A3sP3QUjunp7Wo5aGOkRsuYtGJZbLD4KPlHKObMam1fUCx+gHKnfyKeaWMQLkjeaUNETz9R6llquWyi41QzkLg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/interface": "^3.2.5",
+        "multiformats": "^14.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/peer-id/node_modules/multiformats": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@multiformats/dns": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.15.tgz",
+      "integrity": "sha512-W0zAMABtAn+3chgFcPGvllKND7M6GblMAAFcJQTy+iMmGiyFErZYPzAh2b50Y3SFf340iFV7+ckVgZkGfUyxzA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@dnsquery/dns-packet": "^6.1.1",
+        "@libp2p/interface": "^3.1.0",
+        "hashlru": "^2.3.0",
+        "p-queue": "^9.0.0",
+        "progress-events": "^1.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@multiformats/multiaddr": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-13.0.3.tgz",
+      "integrity": "sha512-mEqqJ4r3a/uuFMTpRkU316wGNIDQNhuVWpm+ebKTQeYsfv9jXbPONWM6VVnj3KGUrwfsX7GZOyp4TFqEA2SPCw==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "multiformats": "^14.0.0",
+        "uint8-varint": "^3.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/multiformats": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
@@ -1539,6 +1678,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -2082,9 +2230,110 @@
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
+    "node_modules/@unicitylabs/nostr-js-sdk": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/nostr-js-sdk/-/nostr-js-sdk-0.6.0.tgz",
+      "integrity": "sha512-l6WcCmFok9nxI1WkYsjIVu67svouA2QyB5Vb+GTNugWrbw7hUgJMA1Elj8qu3u0qojvSINL/L9eWTmXVWRzZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^1.0.0",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/base": "^1.1.9",
+        "libphonenumber-js": "^1.11.14"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "resolved": "../../sphere-sdk",
-      "link": true
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.13.0.tgz",
+      "integrity": "sha512-uK7/xplYUNwsQ+tKJDDVClWXYxz9x7gKP8aVoSbJAbrGshG1XsG7D260AUDfIvG+pSONRfwX42ga3lW3TT/dmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^2.2.0",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "@unicitylabs/nostr-js-sdk": "^0.6.0",
+        "@unicitylabs/state-transition-sdk": "2.0.1",
+        "bip39": "^3.1.0",
+        "buffer": "^6.0.3",
+        "canonicalize": "^3.0.0",
+        "crypto-js": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "@libp2p/crypto": "^5.1.13",
+        "@libp2p/peer-id": "^6.0.4",
+        "ipns": "^10.0.0",
+        "multiformats": "^13.4.2"
+      },
+      "peerDependencies": {
+        "@libp2p/crypto": ">=5.0.0",
+        "@libp2p/peer-id": ">=6.0.0",
+        "ipns": ">=10.0.0",
+        "multiformats": ">=13.0.0",
+        "ws": ">=8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@libp2p/crypto": {
+          "optional": true
+        },
+        "@libp2p/peer-id": {
+          "optional": true
+        },
+        "ipns": {
+          "optional": true
+        },
+        "multiformats": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@unicitylabs/sphere-ui": {
       "version": "0.1.34",
@@ -2109,6 +2358,20 @@
         "recharts": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@unicitylabs/state-transition-sdk": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/state-transition-sdk/-/state-transition-sdk-2.0.1.tgz",
+      "integrity": "sha512-O0pjxaL32VgHYjSM3Ei64UWBG2qwBzdQ9aIdlyhzTnPdI+kKu3h9saSMF1uV9XTfqKHsNGUpE/2dFUulNfmdmg==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "uuid": "14.0.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -2245,6 +2508,13 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abort-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/abort-error/-/abort-error-1.0.2.tgz",
+      "integrity": "sha512-lVgvB2NyPLqbXXhVmXcYFTC1x5K7CiVdPgdY7LGgFQWC8506oN01sPN3i9cl9ynuwF4iJ0TS9exnR7cZ9FuX4w==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2307,6 +2577,26 @@
         "node": ">=4"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.8",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
@@ -2328,6 +2618,27 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/bip39": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
+      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0"
+      }
+    },
+    "node_modules/bip39/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/browserslist": {
@@ -2364,6 +2675,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001779",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001779.tgz",
@@ -2384,6 +2719,28 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canonicalize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-3.0.0.tgz",
+      "integrity": "sha512-yYLfHyDMIXRyRqsKBRLX023riFLpXY2YOfdtqKXZRZy9qsfOJ9U+4F9YZL7MEzL5+ziN2x2nlBvY/Voi3EBljA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cborg": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.8.tgz",
+      "integrity": "sha512-enonPtLyeEF8M8GF/5NdjLHmRGslrwKR2LvkN+yFYQJw7mzt6iOoPvkVs3vcb3rUvltzL0QfvtM6FQ44o8nhSg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -2409,6 +2766,12 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
       "license": "MIT"
     },
     "node_modules/css-tree": {
@@ -2876,6 +3239,13 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -2917,6 +3287,26 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/immer": {
       "version": "11.1.15",
       "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.15.tgz",
@@ -2927,6 +3317,34 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/interface-datastore": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-9.0.3.tgz",
+      "integrity": "sha512-NLZa7Mp+0qn48nSwIY/C36da4uVIKzwG2tuEIpaSJArsuB2RrdyDWwkoDUyjsJ+VrMntXz38VSk9vXTx/ZUpAw==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "interface-store": "^7.0.0",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/interface-datastore/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/interface-store": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-7.0.2.tgz",
+      "integrity": "sha512-KYOPcDH+1peaPhSeoZujR5nwkVeola1EdrnrlHTIM0HRNUs9B0aTsUQMH5kTmIjaQq1BOowoUyoCamgL8IMyww==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -2934,6 +3352,68 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ipns": {
+      "version": "10.1.6",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-10.1.6.tgz",
+      "integrity": "sha512-mTACIdTBBXY5kbCo3t/M3ycNWbjajLrSXhTvjD0MEGyOUaI3uMv94JbJSHGaJ2xxRlpOrRk1ifToOsyPZiglnA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/crypto": "^5.0.0",
+        "@libp2p/interface": "^3.0.2",
+        "@libp2p/logger": "^6.0.4",
+        "cborg": "^5.1.0",
+        "interface-datastore": "^9.0.2",
+        "multiformats": "^13.2.2",
+        "protons-runtime": "^6.0.1",
+        "timestamp-nano": "^1.0.1",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/ipns/node_modules/protons-runtime": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8-varint": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.5.tgz",
+      "integrity": "sha512-jeFLbL/x30wBRnWjKE1qVBXeumG46r7XmYkpis955lTQ+blccGKFrOsSMHlxePwYB1pI7L8YPHz1t4jLxEs3nA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8arraylist": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.9.tgz",
+      "integrity": "sha512-KxWjyEFzchzik3aoQlK66oaoxIReoMo5bQRm1fcjBUZvE8xv/tyR3CTKhjh6K/faV8VaF6hd5pjr45CzbwuwkA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -3023,6 +3503,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.13.9",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.9.tgz",
+      "integrity": "sha512-VNS5vWMM7r0P66BYv+TQJATxExEgLxN+34hfHDVhDkUsGAE4cRg0shCNSLTXNKm7nIUscC7AfB51TjxEeF7msQ==",
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.31.1",
@@ -3323,6 +3809,13 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/main-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/main-event/-/main-event-1.0.4.tgz",
+      "integrity": "sha512-sKazUjIy2Jalv5lkQ446iOcrx8Q7TkaCuk6xfnzg5uUqMusMLDMPmRDmSNE2kjSVpSTJo4j1bQZusS+Ib7Bvrg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -3351,6 +3844,13 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -3405,6 +3905,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.3.tgz",
+      "integrity": "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parse5": {
@@ -3498,6 +4028,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/progress-events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.1.0.tgz",
+      "integrity": "sha512-82DVc5tI36neVB3IjdXR11ztwGuoBc98em9ijzubeZKxI47OlV2Znq6mlPqE5xPDzO2Uw98GHiQSjj2favBCRQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -3507,6 +4044,18 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/protons-runtime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-7.0.0.tgz",
+      "integrity": "sha512-r/e72006xoVND4Uvf1aIs4OQOkJaASBU3ip4DzOWAktoKAkTiOYqKoS3TYMBm8HnnYU8+h0uEzr5gIRwk/pmTg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8-varint": "^3.0.0",
+        "uint8arraylist": "^3.0.0",
+        "uint8arrays": "^6.0.0"
       }
     },
     "node_modules/punycode": {
@@ -3774,6 +4323,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -3798,6 +4360,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/timestamp-nano": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/timestamp-nano/-/timestamp-nano-1.0.1.tgz",
+      "integrity": "sha512-4oGOVZWTu5sl89PtCDnhQBSt7/vL1zVEwAfxH1p49JhTosxzVQWYBYFRFZ8nJmo0G6f824iyP/44BFAwIoKvIA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4.5.0"
       }
     },
     "node_modules/tiny-invariant": {
@@ -3916,6 +4488,44 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uint8-varint": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-3.0.0.tgz",
+      "integrity": "sha512-S4DdpXBaLwKcFo7f0bWzWfHjbZ/i3QhM842qn+ZvHjxqFCfUcEB9SQNcmI69S+zMlcmIcKxsk9Iyw77S2Kxv6Q==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arraylist": "^3.0.1",
+        "uint8arrays": "^6.1.0"
+      }
+    },
+    "node_modules/uint8arraylist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-3.0.2.tgz",
+      "integrity": "sha512-LDVoq9BQaGJzGDUovEnoX6rpKCvnY/Jbtws4ikwnBzjRbq5qBAFpBZevUEbSmMM87aO0Sp+wOZy2ZXf5yODmXQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arrays": "^6.0.0"
+      }
+    },
+    "node_modules/uint8arrays": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-6.1.1.tgz",
+      "integrity": "sha512-iz7JN0XCSZYA111lhFG2Ui9EhFvTNekqSRHw3lvMHq+dzwWy1OQftxFQREEh4rffU0oSoXdQHsk2TiHKVm4fsA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^14.0.0"
+      }
+    },
+    "node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -3954,6 +4564,26 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utf8-codec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utf8-codec/-/utf8-codec-1.0.0.tgz",
+      "integrity": "sha512-S/QSLezp3qvG4ld5PUfXiH7mCFxLKjSVZRFkB3DOjgwHuJPFDkInAXc/anf7BAbHt/D38ozDzL+QMZ6/7gsI6w==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/victory-vendor": {
@@ -4154,6 +4784,27 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/weald": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/weald/-/weald-1.1.3.tgz",
+      "integrity": "sha512-vMWtNbYuPb58NeG2+0sKA0Een4VMDwzf+3oHqh68buWRSOMUBlUeRb11LhV28czV+DUpJHRykifijZDuS9bInA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^4.0.0-nightly.202508271359",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/weald/node_modules/ms": {
+      "version": "4.0.0-nightly.202508271359",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-4.0.0-nightly.202508271359.tgz",
+      "integrity": "sha512-WC/Eo7NzFrOV/RRrTaI0fxKVbNCzEy76j2VqNV8SxDf9D69gSE2Lh0QwYvDlhiYmheBYExAvEAxVf5NoN0cj2A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/webidl-conversions": {

--- a/browser/package-lock.json
+++ b/browser/package-lock.json
@@ -22,9 +22,12 @@
         "recharts": "^3.10.0"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.1.16",
         "@types/react-dom": "^19.1.9",
         "@vitejs/plugin-react": "^5.0.4",
+        "jsdom": "^27.4.0",
         "tailwindcss": "^4.1.16",
         "typescript": "~5.6.0",
         "vite": "^7.1.7",
@@ -101,6 +104,68 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -336,6 +401,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -382,6 +457,146 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -877,6 +1092,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1635,6 +1868,61 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1957,6 +2245,49 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1987,6 +2318,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/browserslist": {
@@ -2069,6 +2410,46 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -2198,6 +2579,30 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2216,11 +2621,28 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -2230,6 +2652,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.313",
@@ -2249,6 +2678,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -2434,6 +2876,47 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/immer": {
       "version": "11.1.15",
       "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.15.tgz",
@@ -2453,6 +2936,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -2467,6 +2957,46 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -2774,6 +3304,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2782,6 +3322,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/motion-dom": {
       "version": "11.18.1",
@@ -2860,6 +3407,19 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -2916,6 +3476,28 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -2925,6 +3507,16 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react": {
@@ -3062,6 +3654,16 @@
         "redux": "^5.0.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/reselect": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
@@ -3113,6 +3715,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3156,6 +3771,13 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3226,6 +3848,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tslib": {
@@ -3475,6 +4143,53 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3491,6 +4206,45 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/browser/package-lock.json
+++ b/browser/package-lock.json
@@ -14,7 +14,7 @@
         "@tailwindcss/vite": "^4.1.16",
         "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-table": "^8.21.3",
-        "@unicitylabs/sphere-sdk": "0.12.0",
+        "@unicitylabs/sphere-sdk": "file:../../sphere-sdk",
         "@unicitylabs/sphere-ui": "^0.1.34",
         "lucide-react": "^0.400.0",
         "react": "^19.1.1",
@@ -29,6 +29,77 @@
         "typescript": "~5.6.0",
         "vite": "^7.1.7",
         "vitest": "^4.1.10"
+      }
+    },
+    "../../sphere-sdk": {
+      "name": "@unicitylabs/sphere-sdk",
+      "version": "0.12.0",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^2.2.0",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "@unicitylabs/nostr-js-sdk": "^0.6.0",
+        "@unicitylabs/state-transition-sdk": "2.0.1",
+        "bip39": "^3.1.0",
+        "buffer": "^6.0.3",
+        "canonicalize": "^3.0.0",
+        "crypto-js": "^4.2.0"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.39.2",
+        "@libp2p/bootstrap": "^12.0.11",
+        "@libp2p/crypto": "^5.1.13",
+        "@libp2p/interface": "^3.1.0",
+        "@libp2p/peer-id": "^6.0.4",
+        "@types/crypto-js": "^4.2.2",
+        "@types/node": "^22.0.0",
+        "@types/ws": "^8.18.1",
+        "@typescript-eslint/eslint-plugin": "^8.54.0",
+        "@typescript-eslint/parser": "^8.54.0",
+        "eslint": "^9.39.2",
+        "fake-indexeddb": "^6.2.5",
+        "multiformats": "^13.4.2",
+        "testcontainers": "^11.11.0",
+        "tsup": "^8.5.1",
+        "tsx": "^4.21.0",
+        "typescript": "~5.6.0",
+        "typescript-eslint": "^8.54.0",
+        "vitest": "^2.0.0",
+        "ws": "^8.18.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "@libp2p/crypto": "^5.1.13",
+        "@libp2p/peer-id": "^6.0.4",
+        "ipns": "^10.0.0",
+        "multiformats": "^13.4.2"
+      },
+      "peerDependencies": {
+        "@libp2p/crypto": ">=5.0.0",
+        "@libp2p/peer-id": ">=6.0.0",
+        "ipns": ">=10.0.0",
+        "multiformats": ">=13.0.0",
+        "ws": ">=8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@libp2p/crypto": {
+          "optional": true
+        },
+        "@libp2p/peer-id": {
+          "optional": true
+        },
+        "ipns": {
+          "optional": true
+        },
+        "multiformats": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -313,13 +384,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@chainsafe/is-ip": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.1.0.tgz",
-      "integrity": "sha512-KIjt+6IfysQ4GCv66xihEitBjvhU/bixbbbFxdJ1sqCp4uJ0wuZiYBPhksZoy4lfaF0k9cwNzY5upEW/VWdw3w==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
@@ -371,20 +435,6 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnsquery/dns-packet": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@dnsquery/dns-packet/-/dns-packet-6.1.1.tgz",
-      "integrity": "sha512-WXTuFvL3G+74SchFAtz3FgIYVOe196ycvGsMgvSH/8Goptb1qpIQtIuM4SOK9G9lhMWYpHxnXyy544ZhluFOew==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@leichtgewicht/ip-codec": "^2.0.4",
-        "utf8-codec": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -874,205 +924,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@leichtgewicht/ip-codec": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
-      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@libp2p/crypto": {
-      "version": "5.1.20",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.20.tgz",
-      "integrity": "sha512-sPz+CvDWPDb+O8xYsueXDdrV6Kf7PciNEYvcCjOR/VqM0iHwzC7aaM0xPiQqrUDj1nggswbY/E/vNZYJ4aCQaA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@libp2p/interface": "^3.2.4",
-        "@noble/curves": "^2.0.1",
-        "@noble/hashes": "^2.0.1",
-        "multiformats": "^14.0.0",
-        "protons-runtime": "^7.0.0",
-        "uint8arraylist": "^3.0.2",
-        "uint8arrays": "^6.1.1"
-      }
-    },
-    "node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/@libp2p/interface": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.4.tgz",
-      "integrity": "sha512-o/ZMbsplniVQhz0AW1CinZcfZPEfr7ttu4w7aivrFAs6xDpnJYmN3FTeEgTt93EHs+AEOcIT76V3KMFDZmIEcQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@multiformats/dns": "^1.0.6",
-        "@multiformats/multiaddr": "^13.0.3",
-        "main-event": "^1.0.1",
-        "multiformats": "^14.0.0",
-        "progress-events": "^1.1.0",
-        "uint8arraylist": "^3.0.2"
-      }
-    },
-    "node_modules/@libp2p/interface/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/@libp2p/logger": {
-      "version": "6.2.9",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.9.tgz",
-      "integrity": "sha512-hjuF81KSt9dWNPJZcdJ4SHEuygMLHrPZVTGNzCWu+2jxpJqOHWy9CJS8llLH7pgbDtlq4jJ4uuqihCR5Gjo4gA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@libp2p/interface": "^3.2.4",
-        "@multiformats/multiaddr": "^13.0.3",
-        "interface-datastore": "^10.0.1",
-        "multiformats": "^14.0.0",
-        "weald": "^1.1.0"
-      }
-    },
-    "node_modules/@libp2p/logger/node_modules/interface-datastore": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-10.0.1.tgz",
-      "integrity": "sha512-DYMj/Og5Cz1Qwkx6/x5KRvR8SYEX7rVAv3KKCm2NzTwWSfpNAC4PahjcYbHyoZBP6zPWrhQv5n5wE+vaDdgSAg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "abort-error": "^1.0.2",
-        "interface-store": "^8.0.0",
-        "uint8arrays": "^6.1.1"
-      }
-    },
-    "node_modules/@libp2p/logger/node_modules/interface-store": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-8.0.0.tgz",
-      "integrity": "sha512-e2+s3EEROzM+Wlas4hU3zveTUscvVMf1BOvdsJfpzFm19SoEXLVadpACjWOnM491HqGpvtfFnevyiaN8W+I6Eg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "abort-error": "^1.0.2"
-      }
-    },
-    "node_modules/@libp2p/logger/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/@libp2p/peer-id": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.11.tgz",
-      "integrity": "sha512-p2Sw8y12gcrmDYGTrbvGQzMhM7ypquCfQX5WdhitI0+ArTSRHHXt7ozdpUWzcq7CNaK5r2q6FIbpz9Yxywg9Hw==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@libp2p/crypto": "^5.1.20",
-        "@libp2p/interface": "^3.2.4",
-        "multiformats": "^14.0.0",
-        "uint8arrays": "^6.1.1"
-      }
-    },
-    "node_modules/@libp2p/peer-id/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/@multiformats/dns": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.13.tgz",
-      "integrity": "sha512-yr4bxtA3MbvJ+2461kYIYMsiiZj/FIqKI64hE4SdvWJUdWF9EtZLar38juf20Sf5tguXKFUruluswAO6JsjS2w==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@dnsquery/dns-packet": "^6.1.1",
-        "@libp2p/interface": "^3.1.0",
-        "hashlru": "^2.3.0",
-        "p-queue": "^9.0.0",
-        "progress-events": "^1.0.0",
-        "uint8arrays": "^5.0.2"
-      }
-    },
-    "node_modules/@multiformats/dns/node_modules/uint8arrays": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
-      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
-    },
-    "node_modules/@multiformats/multiaddr": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-13.0.3.tgz",
-      "integrity": "sha512-mEqqJ4r3a/uuFMTpRkU316wGNIDQNhuVWpm+ebKTQeYsfv9jXbPONWM6VVnj3KGUrwfsX7GZOyp4TFqEA2SPCw==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@chainsafe/is-ip": "^2.0.1",
-        "multiformats": "^14.0.0",
-        "uint8-varint": "^3.0.0",
-        "uint8arrays": "^6.1.1"
-      }
-    },
-    "node_modules/@multiformats/multiaddr/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/@noble/ciphers": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
-      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "2.2.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
@@ -1455,15 +1306,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@scure/base": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
-      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -1952,110 +1794,9 @@
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
-    "node_modules/@unicitylabs/nostr-js-sdk": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/nostr-js-sdk/-/nostr-js-sdk-0.6.0.tgz",
-      "integrity": "sha512-l6WcCmFok9nxI1WkYsjIVu67svouA2QyB5Vb+GTNugWrbw7hUgJMA1Elj8qu3u0qojvSINL/L9eWTmXVWRzZUw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/ciphers": "^1.0.0",
-        "@noble/curves": "^1.6.0",
-        "@noble/hashes": "^1.5.0",
-        "@scure/base": "^1.1.9",
-        "libphonenumber-js": "^1.11.14"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.12.0.tgz",
-      "integrity": "sha512-y3t64uac9cjKLmhgbVav5nCfz5iyovJ9YofSKeTr+Zl6dsp9rshsuJXPtMJELu1Sze8f8A7qvpu997QnD5q3Tw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/ciphers": "^2.2.0",
-        "@noble/curves": "^2.0.1",
-        "@noble/hashes": "^2.0.1",
-        "@unicitylabs/nostr-js-sdk": "^0.6.0",
-        "@unicitylabs/state-transition-sdk": "2.0.1",
-        "bip39": "^3.1.0",
-        "buffer": "^6.0.3",
-        "canonicalize": "^3.0.0",
-        "crypto-js": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      },
-      "optionalDependencies": {
-        "@libp2p/crypto": "^5.1.13",
-        "@libp2p/peer-id": "^6.0.4",
-        "ipns": "^10.0.0",
-        "multiformats": "^13.4.2"
-      },
-      "peerDependencies": {
-        "@libp2p/crypto": ">=5.0.0",
-        "@libp2p/peer-id": ">=6.0.0",
-        "ipns": ">=10.0.0",
-        "multiformats": ">=13.0.0",
-        "ws": ">=8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@libp2p/crypto": {
-          "optional": true
-        },
-        "@libp2p/peer-id": {
-          "optional": true
-        },
-        "ipns": {
-          "optional": true
-        },
-        "multiformats": {
-          "optional": true
-        },
-        "ws": {
-          "optional": true
-        }
-      }
+      "resolved": "../../sphere-sdk",
+      "link": true
     },
     "node_modules/@unicitylabs/sphere-ui": {
       "version": "0.1.34",
@@ -2080,20 +1821,6 @@
         "recharts": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@unicitylabs/state-transition-sdk": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/state-transition-sdk/-/state-transition-sdk-2.0.1.tgz",
-      "integrity": "sha512-O0pjxaL32VgHYjSM3Ei64UWBG2qwBzdQ9aIdlyhzTnPdI+kKu3h9saSMF1uV9XTfqKHsNGUpE/2dFUulNfmdmg==",
-      "license": "ISC",
-      "dependencies": {
-        "@noble/curves": "2.2.0",
-        "@noble/hashes": "2.2.0",
-        "uuid": "14.0.0"
-      },
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -2230,13 +1957,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/abort-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/abort-error/-/abort-error-1.0.2.tgz",
-      "integrity": "sha512-lVgvB2NyPLqbXXhVmXcYFTC1x5K7CiVdPgdY7LGgFQWC8506oN01sPN3i9cl9ynuwF4iJ0TS9exnR7cZ9FuX4w==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2256,26 +1976,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.8",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
@@ -2287,27 +1987,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/bip39": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
-      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
-      "license": "ISC",
-      "dependencies": {
-        "@noble/hashes": "^1.2.0"
-      }
-    },
-    "node_modules/bip39/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/browserslist": {
@@ -2344,30 +2023,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001779",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001779.tgz",
@@ -2388,28 +2043,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/canonicalize": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-3.0.0.tgz",
-      "integrity": "sha512-yYLfHyDMIXRyRqsKBRLX023riFLpXY2YOfdtqKXZRZy9qsfOJ9U+4F9YZL7MEzL5+ziN2x2nlBvY/Voi3EBljA==",
-      "license": "Apache-2.0",
-      "bin": {
-        "canonicalize": "bin/canonicalize.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/cborg": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.1.tgz",
-      "integrity": "sha512-BDbSRIp6XrQXkTc7g+DN0RB9RrDPTUfals2ecWUlt3juPLjbAvy/V72mJcXY0Ehu0Dq/3WpNCOCT68HUTbW+lw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "bin": {
-        "cborg": "lib/bin.js"
-      }
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -2435,12 +2068,6 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/crypto-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
       "license": "MIT"
     },
     "node_modules/csstype": {
@@ -2807,33 +2434,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
-    "node_modules/hashlru": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
-      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/immer": {
       "version": "11.1.15",
       "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.15.tgz",
@@ -2844,34 +2444,6 @@
         "url": "https://opencollective.com/immer"
       }
     },
-    "node_modules/interface-datastore": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-9.0.3.tgz",
-      "integrity": "sha512-NLZa7Mp+0qn48nSwIY/C36da4uVIKzwG2tuEIpaSJArsuB2RrdyDWwkoDUyjsJ+VrMntXz38VSk9vXTx/ZUpAw==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "interface-store": "^7.0.0",
-        "uint8arrays": "^5.1.0"
-      }
-    },
-    "node_modules/interface-datastore/node_modules/uint8arrays": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
-      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
-    },
-    "node_modules/interface-store": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-7.0.2.tgz",
-      "integrity": "sha512-KYOPcDH+1peaPhSeoZujR5nwkVeola1EdrnrlHTIM0HRNUs9B0aTsUQMH5kTmIjaQq1BOowoUyoCamgL8IMyww==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -2879,68 +2451,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/ipns": {
-      "version": "10.1.6",
-      "resolved": "https://registry.npmjs.org/ipns/-/ipns-10.1.6.tgz",
-      "integrity": "sha512-mTACIdTBBXY5kbCo3t/M3ycNWbjajLrSXhTvjD0MEGyOUaI3uMv94JbJSHGaJ2xxRlpOrRk1ifToOsyPZiglnA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@libp2p/crypto": "^5.0.0",
-        "@libp2p/interface": "^3.0.2",
-        "@libp2p/logger": "^6.0.4",
-        "cborg": "^5.1.0",
-        "interface-datastore": "^9.0.2",
-        "multiformats": "^13.2.2",
-        "protons-runtime": "^6.0.1",
-        "timestamp-nano": "^1.0.1",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.1.0"
-      }
-    },
-    "node_modules/ipns/node_modules/protons-runtime": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
-      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8-varint": "^2.0.4",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.1.0"
-      }
-    },
-    "node_modules/ipns/node_modules/uint8-varint": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.5.tgz",
-      "integrity": "sha512-jeFLbL/x30wBRnWjKE1qVBXeumG46r7XmYkpis955lTQ+blccGKFrOsSMHlxePwYB1pI7L8YPHz1t4jLxEs3nA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/ipns/node_modules/uint8arraylist": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.9.tgz",
-      "integrity": "sha512-KxWjyEFzchzik3aoQlK66oaoxIReoMo5bQRm1fcjBUZvE8xv/tyR3CTKhjh6K/faV8VaF6hd5pjr45CzbwuwkA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8arrays": "^5.0.1"
-      }
-    },
-    "node_modules/ipns/node_modules/uint8arrays": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
-      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "multiformats": "^13.0.0"
       }
     },
     "node_modules/jiti": {
@@ -2983,12 +2493,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/libphonenumber-js": {
-      "version": "1.13.9",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.9.tgz",
-      "integrity": "sha512-VNS5vWMM7r0P66BYv+TQJATxExEgLxN+34hfHDVhDkUsGAE4cRg0shCNSLTXNKm7nIUscC7AfB51TjxEeF7msQ==",
-      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.31.1",
@@ -3279,13 +2783,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/main-event": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/main-event/-/main-event-1.0.4.tgz",
-      "integrity": "sha512-sKazUjIy2Jalv5lkQ446iOcrx8Q7TkaCuk6xfnzg5uUqMusMLDMPmRDmSNE2kjSVpSTJo4j1bQZusS+Ib7Bvrg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
     "node_modules/motion-dom": {
       "version": "11.18.1",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
@@ -3307,13 +2804,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/multiformats": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
-      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -3368,36 +2858,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
-      }
-    },
-    "node_modules/p-queue": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
-      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "eventemitter3": "^5.0.4",
-        "p-timeout": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-timeout": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
-      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pathe": {
@@ -3456,13 +2916,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/progress-events": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.1.0.tgz",
-      "integrity": "sha512-82DVc5tI36neVB3IjdXR11ztwGuoBc98em9ijzubeZKxI47OlV2Znq6mlPqE5xPDzO2Uw98GHiQSjj2favBCRQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -3472,18 +2925,6 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/protons-runtime": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-7.0.0.tgz",
-      "integrity": "sha512-r/e72006xoVND4Uvf1aIs4OQOkJaASBU3ip4DzOWAktoKAkTiOYqKoS3TYMBm8HnnYU8+h0uEzr5gIRwk/pmTg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8-varint": "^3.0.0",
-        "uint8arraylist": "^3.0.0",
-        "uint8arrays": "^6.0.0"
       }
     },
     "node_modules/react": {
@@ -3718,19 +3159,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/supports-color": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
-      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/tailwindcss": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
@@ -3748,16 +3176,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/timestamp-nano": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/timestamp-nano/-/timestamp-nano-1.0.1.tgz",
-      "integrity": "sha512-4oGOVZWTu5sl89PtCDnhQBSt7/vL1zVEwAfxH1p49JhTosxzVQWYBYFRFZ8nJmo0G6f824iyP/44BFAwIoKvIA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 4.5.0"
       }
     },
     "node_modules/tiny-invariant": {
@@ -3830,44 +3248,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/uint8-varint": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-3.0.0.tgz",
-      "integrity": "sha512-S4DdpXBaLwKcFo7f0bWzWfHjbZ/i3QhM842qn+ZvHjxqFCfUcEB9SQNcmI69S+zMlcmIcKxsk9Iyw77S2Kxv6Q==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8arraylist": "^3.0.1",
-        "uint8arrays": "^6.1.0"
-      }
-    },
-    "node_modules/uint8arraylist": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-3.0.2.tgz",
-      "integrity": "sha512-LDVoq9BQaGJzGDUovEnoX6rpKCvnY/Jbtws4ikwnBzjRbq5qBAFpBZevUEbSmMM87aO0Sp+wOZy2ZXf5yODmXQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8arrays": "^6.0.0"
-      }
-    },
-    "node_modules/uint8arrays": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-6.1.1.tgz",
-      "integrity": "sha512-iz7JN0XCSZYA111lhFG2Ui9EhFvTNekqSRHw3lvMHq+dzwWy1OQftxFQREEh4rffU0oSoXdQHsk2TiHKVm4fsA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "multiformats": "^14.0.0"
-      }
-    },
-    "node_modules/uint8arrays/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -3906,26 +3286,6 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/utf8-codec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utf8-codec/-/utf8-codec-1.0.0.tgz",
-      "integrity": "sha512-S/QSLezp3qvG4ld5PUfXiH7mCFxLKjSVZRFkB3DOjgwHuJPFDkInAXc/anf7BAbHt/D38ozDzL+QMZ6/7gsI6w==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/victory-vendor": {
@@ -4113,27 +3473,6 @@
         "vite": {
           "optional": false
         }
-      }
-    },
-    "node_modules/weald": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/weald/-/weald-1.1.3.tgz",
-      "integrity": "sha512-vMWtNbYuPb58NeG2+0sKA0Een4VMDwzf+3oHqh68buWRSOMUBlUeRb11LhV28czV+DUpJHRykifijZDuS9bInA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "ms": "^4.0.0-nightly.202508271359",
-        "supports-color": "^10.0.0"
-      }
-    },
-    "node_modules/weald/node_modules/ms": {
-      "version": "4.0.0-nightly.202508271359",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-4.0.0-nightly.202508271359.tgz",
-      "integrity": "sha512-WC/Eo7NzFrOV/RRrTaI0fxKVbNCzEy76j2VqNV8SxDf9D69gSE2Lh0QwYvDlhiYmheBYExAvEAxVf5NoN0cj2A==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/why-is-node-running": {

--- a/browser/package.json
+++ b/browser/package.json
@@ -17,7 +17,7 @@
     "@tailwindcss/vite": "^4.1.16",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-table": "^8.21.3",
-    "@unicitylabs/sphere-sdk": "file:../../sphere-sdk",
+    "@unicitylabs/sphere-sdk": "0.13.0",
     "@unicitylabs/sphere-ui": "^0.1.34",
     "lucide-react": "^0.400.0",
     "react": "^19.1.1",

--- a/browser/package.json
+++ b/browser/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -24,9 +25,12 @@
     "recharts": "^3.10.0"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.1.16",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.4",
+    "jsdom": "^27.4.0",
     "tailwindcss": "^4.1.16",
     "typescript": "~5.6.0",
     "vite": "^7.1.7",

--- a/browser/package.json
+++ b/browser/package.json
@@ -16,7 +16,7 @@
     "@tailwindcss/vite": "^4.1.16",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-table": "^8.21.3",
-    "@unicitylabs/sphere-sdk": "0.12.0",
+    "@unicitylabs/sphere-sdk": "file:../../sphere-sdk",
     "@unicitylabs/sphere-ui": "^0.1.34",
     "lucide-react": "^0.400.0",
     "react": "^19.1.1",

--- a/browser/src/App.tsx
+++ b/browser/src/App.tsx
@@ -78,7 +78,7 @@ export default function App() {
     'receive': <ReceivePanel intent={intent} />,
     'sign-message': <SignMessagePanel intent={intent} />,
     'mint': <MintPanel intent={intent} />,
-    'chat': <ChatPanel query={query} intent={intent} on={on} walletPubkey={wallet.identity!.chainPubkey} />,
+    'chat': <ChatPanel query={query} intent={intent} on={on} walletPubkey={wallet.identity!.chainPubkey} isWalletLocked={wallet.isWalletLocked} unlockEpoch={wallet.unlockEpoch} />,
     'events': <EventLogPanel on={on} />,
     'docs': <DocsPanel />,
   };
@@ -95,6 +95,7 @@ export default function App() {
         isWalletLocked={wallet.isWalletLocked}
         walletChanged={wallet.walletChanged}
         walletProtocol={wallet.walletProtocol}
+        onFocusWallet={wallet.focusWallet}
       />
       {panels[section]}
     </PageShell>

--- a/browser/src/App.tsx
+++ b/browser/src/App.tsx
@@ -3,6 +3,7 @@ import { useWalletConnect } from './hooks/useWalletConnect';
 import { ConnectButton } from './components/ConnectButton';
 import { PageShell } from './components/layout/PageShell';
 import type { Section } from './lib/types';
+import { WalletStatusBanner } from './components/layout/WalletStatusBanner';
 
 // Query panels
 import { IdentityPanel } from './components/queries/IdentityPanel';
@@ -67,7 +68,7 @@ export default function App() {
   const panels: Record<Section, React.ReactNode> = {
     'identity': <IdentityPanel query={query} />,
     'assets': <AssetsPanel query={query} />,
-    'balance': <BalancePanel query={query} />,
+    'balance': <BalancePanel query={query} unlockEpoch={wallet.unlockEpoch} />,
     'tokens': <TokensPanel query={query} />,
     'history': <HistoryPanel query={query} />,
     'resolve': <ResolvePanel query={query} />,
@@ -86,9 +87,15 @@ export default function App() {
     <PageShell
       identity={wallet.identity!}
       onDisconnect={wallet.disconnect}
+      isWalletLocked={wallet.isWalletLocked}
       section={section}
       onSectionChange={setSection}
     >
+      <WalletStatusBanner
+        isWalletLocked={wallet.isWalletLocked}
+        walletChanged={wallet.walletChanged}
+        walletProtocol={wallet.walletProtocol}
+      />
       {panels[section]}
     </PageShell>
   );

--- a/browser/src/components/chat/ChatPanel.tsx
+++ b/browser/src/components/chat/ChatPanel.tsx
@@ -9,9 +9,18 @@ interface Props {
   intent: <T>(action: string, params: Record<string, unknown>) => Promise<T>;
   on: (event: string, handler: (data: unknown) => void) => () => void;
   walletPubkey: string;
+  /**
+   * The wallet is locked. Reads are NOT served while locked — only identity, subscribe,
+   * unsubscribe and disconnect are — so a panel that keeps fetching just collects
+   * WALLET_LOCKED (4009) refusals and drives up the wallet's "N requests blocked" badge.
+   * A dApp should render its locked state and wait, not poll.
+   */
+  isWalletLocked: boolean;
+  /** Bumps once per unlock that returned the SAME wallet — the cue to reload. */
+  unlockEpoch: number;
 }
 
-export function ChatPanel({ query, intent, on, walletPubkey }: Props) {
+export function ChatPanel({ query, intent, on, walletPubkey, isWalletLocked, unlockEpoch }: Props) {
   const [conversations, setConversations] = useState<ConversationSummary[]>([]);
   const [selectedPeer, setSelectedPeer] = useState<string | null>(null);
   const [messages, setMessages] = useState<DirectMessage[]>([]);
@@ -51,8 +60,11 @@ export function ChatPanel({ query, intent, on, walletPubkey }: Props) {
   }, [query, cacheNametag]);
 
   useEffect(() => {
+    // Never fetch behind the lock screen: the host refuses every read with 4009 and each
+    // refusal lights up the wallet's blocked-request badge. unlockEpoch brings us back.
+    if (isWalletLocked) return;
     loadConversations();
-  }, [loadConversations]);
+  }, [loadConversations, isWalletLocked, unlockEpoch]);
 
   // Load messages for selected peer
   const loadMessages = useCallback(async (peerPubkey: string) => {
@@ -151,6 +163,9 @@ export function ChatPanel({ query, intent, on, walletPubkey }: Props) {
   // Real-time incoming DMs
   useEffect(() => {
     const unsub = on('message:dm', (data) => {
+      // Belt and braces: the wallet suspends event delivery while locked and re-arms the
+      // subscriptions on unlock, but a handler that fires anyway must not issue reads.
+      if (isWalletLocked) return;
       const dm = data as DirectMessage;
       // Cache nametags from real-time messages
       if (dm.senderPubkey !== walletPubkey) cacheNametag(dm.senderPubkey, dm.senderNametag);
@@ -165,7 +180,7 @@ export function ChatPanel({ query, intent, on, walletPubkey }: Props) {
       loadConversations();
     });
     return unsub;
-  }, [on, selectedPeer, query, walletPubkey, loadConversations, cacheNametag]);
+  }, [on, selectedPeer, query, walletPubkey, loadConversations, cacheNametag, isWalletLocked]);
 
   // Auto-scroll on new messages
   useEffect(() => {

--- a/browser/src/components/events/EventLogPanel.test.ts
+++ b/browser/src/components/events/EventLogPanel.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { AUTO_PUSHED_EVENTS } from '@unicitylabs/sphere-sdk/connect';
+import { ALL_EVENTS, EVENT_COLORS } from './EventLogPanel';
+
+describe('EventLogPanel event list', () => {
+  // The host pushes these unconditionally. If the log omits one, the demo silently hides the
+  // event that carries the whole lock model — and a future auto-pushed event cannot be
+  // forgotten here either, because this asserts against the SDK's own list.
+  it('logs every event the host pushes without a subscription', () => {
+    for (const event of AUTO_PUSHED_EVENTS) {
+      expect(ALL_EVENTS).toContain(event);
+    }
+  });
+
+  it('lists no event twice', () => {
+    expect(new Set(ALL_EVENTS).size).toBe(ALL_EVENTS.length);
+  });
+
+  it('gives every listed event a badge colour', () => {
+    for (const event of ALL_EVENTS) {
+      expect(typeof EVENT_COLORS[event]).toBe('string');
+    }
+  });
+});

--- a/browser/src/components/events/EventLogPanel.tsx
+++ b/browser/src/components/events/EventLogPanel.tsx
@@ -12,7 +12,7 @@ interface Props {
   on: (event: string, handler: (data: unknown) => void) => () => void;
 }
 
-const ALL_EVENTS = [
+export const ALL_EVENTS = [
   // Transfers
   'transfer:incoming',
   'transfer:confirmed',
@@ -38,6 +38,8 @@ const ALL_EVENTS = [
   // Connection & wallet state
   'connection:changed',
   'wallet:locked',
+  'wallet:unlocked',
+  'wallet:disconnected',
   // Identity & addresses
   'identity:changed',
   'nametag:registered',
@@ -55,7 +57,7 @@ const ALL_EVENTS = [
   'groupchat:connection',
 ];
 
-const EVENT_COLORS: Record<string, string> = {
+export const EVENT_COLORS: Record<string, string> = {
   // Transfers
   'transfer:incoming': 'bg-green-500/15 text-green-400',
   'transfer:confirmed': 'bg-green-500/15 text-green-400',
@@ -80,7 +82,10 @@ const EVENT_COLORS: Record<string, string> = {
   'sync:remote-update': 'bg-white/3 text-white/55',
   // Connection & wallet state
   'connection:changed': 'bg-yellow-500/15 text-amber-400',
-  'wallet:locked': 'bg-red-500/15 text-red-400',
+  // Amber, not red: a lock is a pause, not a fatal teardown. wallet:disconnected is the red one.
+  'wallet:locked': 'bg-amber-500/15 text-amber-400',
+  'wallet:unlocked': 'bg-green-500/15 text-green-400',
+  'wallet:disconnected': 'bg-red-500/15 text-red-400',
   // Identity & addresses
   'identity:changed': 'bg-blue-500/15 text-blue-400',
   'nametag:registered': 'bg-purple-500/15 text-purple-400',

--- a/browser/src/components/layout/PageShell.tsx
+++ b/browser/src/components/layout/PageShell.tsx
@@ -5,6 +5,7 @@ import { WalletHeader } from './WalletHeader';
 interface PageShellProps {
   identity: PublicIdentity;
   onDisconnect: () => void;
+  isWalletLocked: boolean;
   section: Section;
   onSectionChange: (s: Section) => void;
   children: React.ReactNode;
@@ -61,10 +62,10 @@ function NavGroup({ title, color, items, active, onSelect }: {
   );
 }
 
-export function PageShell({ identity, onDisconnect, section, onSectionChange, children }: PageShellProps) {
+export function PageShell({ identity, onDisconnect, isWalletLocked, section, onSectionChange, children }: PageShellProps) {
   return (
     <div className="flex flex-col h-screen bg-(--bg-root)">
-      <WalletHeader identity={identity} onDisconnect={onDisconnect} />
+      <WalletHeader identity={identity} onDisconnect={onDisconnect} isWalletLocked={isWalletLocked} />
 
       {/* Mobile horizontal nav */}
       <div className="lg:hidden border-b border-white/8 bg-(--bg-surface) overflow-x-auto">

--- a/browser/src/components/layout/WalletHeader.test.tsx
+++ b/browser/src/components/layout/WalletHeader.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { PublicIdentity } from '@unicitylabs/sphere-sdk/connect';
+import { WalletHeader } from './WalletHeader';
+
+const identity: PublicIdentity = {
+  chainPubkey: '02aaaa000000000000000000000000000000000000000000000000000000000000',
+  directAddress: 'DIRECT://aaaa000000000000000000000000000000000000000000000000000000000000',
+  nametag: 'alice',
+};
+
+describe('WalletHeader', () => {
+  it('says Connected while the wallet is usable', () => {
+    render(<WalletHeader identity={identity} onDisconnect={() => {}} isWalletLocked={false} />);
+    expect(screen.getByText('Connected')).toBeTruthy();
+    expect(screen.queryByText('Locked')).toBeNull();
+  });
+
+  // The badge was hardcoded green "Connected"; under a session-preserving lock that is a lie
+  // the user acts on — every panel errors while the header insists everything is fine.
+  it('says Locked instead of Connected while the wallet is locked', () => {
+    render(<WalletHeader identity={identity} onDisconnect={() => {}} isWalletLocked />);
+    expect(screen.getByText('Locked')).toBeTruthy();
+    expect(screen.queryByText('Connected')).toBeNull();
+  });
+});

--- a/browser/src/components/layout/WalletHeader.tsx
+++ b/browser/src/components/layout/WalletHeader.tsx
@@ -6,9 +6,12 @@ import { EnvSwitch } from '../EnvSwitch';
 interface WalletHeaderProps {
   identity: PublicIdentity;
   onDisconnect: () => void;
+  /** Locked means locked-but-connected. A green "Connected" badge here would be a lie the
+   *  user acts on while every panel answers WALLET_LOCKED (4009). */
+  isWalletLocked: boolean;
 }
 
-export function WalletHeader({ identity, onDisconnect }: WalletHeaderProps) {
+export function WalletHeader({ identity, onDisconnect, isWalletLocked }: WalletHeaderProps) {
   return (
     <header className="bg-(--bg-surface) border-b border-white/8 px-4 py-3 flex items-center justify-between">
       <div className="flex items-center gap-3">
@@ -23,10 +26,17 @@ export function WalletHeader({ identity, onDisconnect }: WalletHeaderProps) {
       </div>
       <div className="flex items-center gap-3">
         <EnvSwitch />
-        <span className="inline-flex items-center gap-1.5 text-xs text-green-400">
-          <span className="w-2 h-2 rounded-full bg-green-500" />
-          Connected
-        </span>
+        {isWalletLocked ? (
+          <span className="inline-flex items-center gap-1.5 text-xs text-amber-400">
+            <span className="w-2 h-2 rounded-full bg-amber-500" />
+            Locked
+          </span>
+        ) : (
+          <span className="inline-flex items-center gap-1.5 text-xs text-green-400">
+            <span className="w-2 h-2 rounded-full bg-green-500" />
+            Connected
+          </span>
+        )}
         <Button variant="secondary" onClick={onDisconnect}>
           Disconnect
         </Button>

--- a/browser/src/components/layout/WalletStatusBanner.test.tsx
+++ b/browser/src/components/layout/WalletStatusBanner.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { WalletStatusBanner } from './WalletStatusBanner';
+
+describe('WalletStatusBanner', () => {
+  it('renders nothing while a 2.1 wallet is healthy', () => {
+    const { container } = render(
+      <WalletStatusBanner isWalletLocked={false} walletChanged={false} walletProtocol="2.1" />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('explains that a locked wallet is still connected', () => {
+    render(<WalletStatusBanner isWalletLocked walletChanged={false} walletProtocol="2.1" />);
+    expect(screen.getByText('Wallet locked')).toBeTruthy();
+    expect(screen.getByText(/WALLET_LOCKED \(4009\)/)).toBeTruthy();
+    expect(screen.queryByText('Wallet changed')).toBeNull();
+  });
+
+  it('warns when a different wallet came back from the lock', () => {
+    render(<WalletStatusBanner isWalletLocked={false} walletChanged walletProtocol="2.1" />);
+    expect(screen.getByText('Wallet changed')).toBeTruthy();
+    expect(screen.queryByText('Wallet locked')).toBeNull();
+  });
+
+  it('warns that locking a Connect 2.0 wallet ends the session', () => {
+    render(<WalletStatusBanner isWalletLocked={false} walletChanged={false} walletProtocol="2.0" />);
+    expect(screen.getByText('Legacy wallet')).toBeTruthy();
+  });
+});

--- a/browser/src/components/layout/WalletStatusBanner.test.tsx
+++ b/browser/src/components/layout/WalletStatusBanner.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { WalletStatusBanner } from './WalletStatusBanner';
 
 describe('WalletStatusBanner', () => {
@@ -26,5 +26,30 @@ describe('WalletStatusBanner', () => {
   it('warns that locking a Connect 2.0 wallet ends the session', () => {
     render(<WalletStatusBanner isWalletLocked={false} walletChanged={false} walletProtocol="2.0" />);
     expect(screen.getByText('Legacy wallet')).toBeTruthy();
+  });
+});
+
+describe('WalletStatusBanner — raising the wallet window', () => {
+  it('offers to raise the wallet window only when the caller can do it', () => {
+    const onFocusWallet = vi.fn(() => true);
+    render(
+      <WalletStatusBanner
+        isWalletLocked
+        walletChanged={false}
+        walletProtocol="2.1"
+        onFocusWallet={onFocusWallet}
+      />,
+    );
+
+    // A BUTTON, never an automatic focus grab: the wallet stays the only thing that decides
+    // when a password field appears.
+    expect(onFocusWallet).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId('focus-wallet'));
+    expect(onFocusWallet).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not offer it when there is no window to raise', () => {
+    render(<WalletStatusBanner isWalletLocked walletChanged={false} walletProtocol="2.1" />);
+    expect(screen.queryByTestId('focus-wallet')).toBeNull();
   });
 });

--- a/browser/src/components/layout/WalletStatusBanner.tsx
+++ b/browser/src/components/layout/WalletStatusBanner.tsx
@@ -5,6 +5,13 @@ interface WalletStatusBannerProps {
   isWalletLocked: boolean;
   walletChanged: boolean;
   walletProtocol: string | null;
+  /**
+   * Raise the wallet window. Wired to a BUTTON, never fired automatically: a page that
+   * grabbed focus on its own would be a nuisance, and the wallet must stay the only thing
+   * that decides when a password field appears. Returns false when there is no window to
+   * raise — the popup was closed, which is a real disconnect, not a lock.
+   */
+  onFocusWallet?: () => boolean;
 }
 
 /**
@@ -18,7 +25,12 @@ interface WalletStatusBannerProps {
  * The banner never offers to unlock. The wallet raises its own credential surface, from its own
  * chrome, after a human click — a dApp may trigger a CONSENT prompt but never a password field.
  */
-export function WalletStatusBanner({ isWalletLocked, walletChanged, walletProtocol }: WalletStatusBannerProps) {
+export function WalletStatusBanner({
+  isWalletLocked,
+  walletChanged,
+  walletProtocol,
+  onFocusWallet,
+}: WalletStatusBannerProps) {
   const legacyWallet = !supportsGracefulLock(walletProtocol);
   if (!isWalletLocked && !walletChanged && !legacyWallet) return null;
 
@@ -29,6 +41,18 @@ export function WalletStatusBanner({ isWalletLocked, walletChanged, walletProtoc
           You are still connected — the wallet kept this session. Requests fail with{' '}
           <code>WALLET_LOCKED (4009)</code> until you unlock it in the wallet window. No reconnect
           and no re-approval is needed.
+          {onFocusWallet && (
+            <div className="mt-2">
+              <button
+                type="button"
+                data-testid="focus-wallet"
+                onClick={() => onFocusWallet()}
+                className="text-xs font-medium underline underline-offset-2"
+              >
+                Bring the wallet window to the front
+              </button>
+            </div>
+          )}
         </AlertBanner>
       )}
       {walletChanged && (

--- a/browser/src/components/layout/WalletStatusBanner.tsx
+++ b/browser/src/components/layout/WalletStatusBanner.tsx
@@ -1,0 +1,50 @@
+import { AlertBanner } from '@unicitylabs/sphere-ui';
+import { supportsGracefulLock } from '../../lib/walletProtocol';
+
+interface WalletStatusBannerProps {
+  isWalletLocked: boolean;
+  walletChanged: boolean;
+  walletProtocol: string | null;
+}
+
+/**
+ * The visible half of the Connect 2.1 lock model.
+ *
+ * A locked wallet is a STATE, not a disconnect: the session, the granted permissions and the
+ * transport all survive, and every request outside the locked allow-list is answered
+ * WALLET_LOCKED (4009) until the user unlocks. Without this banner the app looks perfectly
+ * connected while every panel errors.
+ *
+ * The banner never offers to unlock. The wallet raises its own credential surface, from its own
+ * chrome, after a human click — a dApp may trigger a CONSENT prompt but never a password field.
+ */
+export function WalletStatusBanner({ isWalletLocked, walletChanged, walletProtocol }: WalletStatusBannerProps) {
+  const legacyWallet = !supportsGracefulLock(walletProtocol);
+  if (!isWalletLocked && !walletChanged && !legacyWallet) return null;
+
+  return (
+    <div className="mb-4 space-y-2">
+      {isWalletLocked && (
+        <AlertBanner type="warning" title="Wallet locked">
+          You are still connected — the wallet kept this session. Requests fail with{' '}
+          <code>WALLET_LOCKED (4009)</code> until you unlock it in the wallet window. No reconnect
+          and no re-approval is needed.
+        </AlertBanner>
+      )}
+      {walletChanged && (
+        <AlertBanner type="info" title="Wallet changed">
+          The wallet that came back from the lock has a different public key than the one this
+          session was approved for. Nothing was resumed automatically — check the identity in the
+          header before sending anything.
+        </AlertBanner>
+      )}
+      {legacyWallet && (
+        <AlertBanner type="info" title="Legacy wallet">
+          This wallet speaks Connect {walletProtocol ?? 'unknown'}, where locking also ends the
+          session — the connection will drop instead of pausing, and no <code>wallet:unlocked</code>{' '}
+          is ever sent. Update the wallet for the session-preserving lock.
+        </AlertBanner>
+      )}
+    </div>
+  );
+}

--- a/browser/src/components/queries/BalancePanel.test.tsx
+++ b/browser/src/components/queries/BalancePanel.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { RPC_METHODS } from '@unicitylabs/sphere-sdk/connect';
+import { BalancePanel } from './BalancePanel';
+
+function makeQuery() {
+  const calls: string[] = [];
+  const query = <T,>(method: string): Promise<T> => {
+    calls.push(method);
+    const result =
+      method === RPC_METHODS.GET_BALANCE
+        ? [{ coinId: 'UCT', symbol: 'UCT', totalAmount: '500000000' }]
+        : { fiatBalance: 12.5 };
+    return Promise.resolve(result as T);
+  };
+  return { query, calls };
+}
+
+describe('BalancePanel', () => {
+  it('does not fetch before any unlock has happened', () => {
+    const { query, calls } = makeQuery();
+    render(<BalancePanel query={query} unlockEpoch={0} />);
+    expect(calls).toHaveLength(0);
+  });
+
+  // The reference retry-after-unlock: a READ is safe to re-issue automatically once the host
+  // confirmed the SAME wallet came back. An intent is not, and never takes this prop.
+  it('re-fetches when the same wallet is unlocked', async () => {
+    const { query, calls } = makeQuery();
+    const { rerender } = render(<BalancePanel query={query} unlockEpoch={0} />);
+
+    rerender(<BalancePanel query={query} unlockEpoch={1} />);
+
+    await waitFor(() => expect(calls).toContain(RPC_METHODS.GET_BALANCE));
+    expect(calls).toContain(RPC_METHODS.GET_FIAT_BALANCE);
+    expect(await screen.findByText('500000000')).toBeTruthy();
+  });
+});

--- a/browser/src/components/queries/BalancePanel.tsx
+++ b/browser/src/components/queries/BalancePanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { RPC_METHODS } from '@unicitylabs/sphere-sdk/connect';
 import { Button } from '@unicitylabs/sphere-ui';
 import { ResultDisplay } from '../ui/ResultDisplay';
@@ -13,9 +13,18 @@ interface BalanceItem {
 
 interface Props {
   query: <T>(method: string, params?: Record<string, unknown>) => Promise<T>;
+  /**
+   * Bumps once per unlock that returned the SAME wallet (useWalletConnect compares the
+   * chainPubkey in the wallet:unlocked payload before bumping it).
+   *
+   * This is the reference retry-after-unlock: a READ is safe to re-issue automatically. An
+   * intent never is — it moves money and would fire with no fresh user gesture, at the exact
+   * moment the wallet came back — which is why only query panels take this prop.
+   */
+  unlockEpoch: number;
 }
 
-export function BalancePanel({ query }: Props) {
+export function BalancePanel({ query, unlockEpoch }: Props) {
   const [balances, setBalances] = useState<BalanceItem[]>([]);
   const [fiat, setFiat] = useState<number | null>(null);
   const [raw, setRaw] = useState<unknown>(null);
@@ -39,6 +48,13 @@ export function BalancePanel({ query }: Props) {
       setLoading(false);
     }
   };
+
+  useEffect(() => {
+    if (unlockEpoch === 0) return; // no unlock yet — never fetch on mount
+    void execute();
+    // Deliberately keyed on unlockEpoch alone: execute() is re-created on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [unlockEpoch]);
 
   return (
     <div className="admin-card p-5">

--- a/browser/src/hooks/useWalletConnect.test.ts
+++ b/browser/src/hooks/useWalletConnect.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { ConnectError, ERROR_CODES, HOST_READY_TYPE, RPC_METHODS, WALLET_EVENTS } from '@unicitylabs/sphere-sdk/connect';
+import { FakeConnectClient, FAKE_IDENTITY } from '../test/fakeConnectClient';
+import { useWalletConnect } from './useWalletConnect';
+
+// Hoisted so the vi.mock factories below — which run before this file's own declarations —
+// can reach it.
+const mocks = vi.hoisted(() => {
+  const transportDestroys: string[] = [];
+  return {
+    transportDestroys,
+    makeTransport: () => ({
+      send: () => {},
+      onMessage: () => () => {},
+      destroy: () => {
+        transportDestroys.push('destroy');
+      },
+    }),
+  };
+});
+
+vi.mock('@unicitylabs/sphere-sdk/connect/browser', () => ({
+  PostMessageTransport: { forClient: () => mocks.makeTransport() },
+  ExtensionTransport: { forClient: () => mocks.makeTransport() },
+}));
+
+vi.mock('@unicitylabs/sphere-sdk/connect', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@unicitylabs/sphere-sdk/connect')>();
+  const { FakeConnectClient: Fake } = await import('../test/fakeConnectClient');
+  return { ...actual, ConnectClient: Fake };
+});
+
+const SESSION_KEY_POPUP = 'sphere-connect-popup-session';
+
+type Hook = ReturnType<typeof useWalletConnect>;
+
+/** Drive the popup connect path: it opens a window, then blocks on HOST_READY. */
+async function connectPopup(result: { current: Hook }): Promise<void> {
+  await act(async () => {
+    const pending = result.current.connectViaPopup();
+    // waitForHostReady() registers its listener synchronously, before connectViaPopup()
+    // hands back its promise, so dispatching here is not a race.
+    window.dispatchEvent(new MessageEvent('message', { data: { type: HOST_READY_TYPE } }));
+    await pending;
+  });
+}
+
+async function mountAndConnect() {
+  const hook = renderHook(() => useWalletConnect());
+  await waitFor(() => expect(hook.result.current.isAutoConnecting).toBe(false));
+  await connectPopup(hook.result);
+  expect(hook.result.current.isConnected).toBe(true);
+  mocks.transportDestroys.length = 0;
+  return hook;
+}
+
+beforeEach(() => {
+  FakeConnectClient.reset();
+  mocks.transportDestroys.length = 0;
+  sessionStorage.clear();
+  vi.spyOn(window, 'open').mockReturnValue({
+    closed: false,
+    focus: () => {},
+    close: () => {},
+  } as unknown as Window);
+});
+
+describe('useWalletConnect — connect', () => {
+  it('connects through the popup and saves the session id', async () => {
+    const { result } = await mountAndConnect();
+    expect(result.current.identity?.chainPubkey).toBe(FAKE_IDENTITY.chainPubkey);
+    expect(sessionStorage.getItem(SESSION_KEY_POPUP)).toBe('session-1');
+    expect(result.current.isWalletLocked).toBe(false);
+  });
+});
+
+describe('useWalletConnect — wallet:locked', () => {
+  it('keeps the session alive when the wallet speaks Connect 2.1', async () => {
+    const { result } = await mountAndConnect();
+
+    act(() => {
+      FakeConnectClient.last.emit(WALLET_EVENTS.LOCKED, {});
+    });
+
+    expect(result.current.isWalletLocked).toBe(true);
+    expect(result.current.isConnected).toBe(true);
+    expect(result.current.identity?.chainPubkey).toBe(FAKE_IDENTITY.chainPubkey);
+    expect(sessionStorage.getItem(SESSION_KEY_POPUP)).toBe('session-1');
+    expect(mocks.transportDestroys).toHaveLength(0);
+  });
+
+  // A 2.0 wallet means the OPPOSITE by the same event name: the removed
+  // notifyWalletLocked() pushed wallet:locked AND revoked the session, and wallet:unlocked
+  // will never arrive. Staying "connected" against it would leave the dApp waiting forever
+  // on a locked screen.
+  it('tears down when the wallet still speaks Connect 2.0', async () => {
+    FakeConnectClient.nextWalletProtocol = '2.0';
+    const { result } = await mountAndConnect();
+
+    act(() => {
+      FakeConnectClient.last.emit(WALLET_EVENTS.LOCKED, {});
+    });
+
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.isWalletLocked).toBe(false);
+    expect(sessionStorage.getItem(SESSION_KEY_POPUP)).toBeNull();
+    expect(mocks.transportDestroys).toHaveLength(1);
+  });
+});
+
+describe('useWalletConnect — request failures', () => {
+  it('flags the lock instead of disconnecting when a query answers 4009', async () => {
+    const { result } = await mountAndConnect();
+    FakeConnectClient.last.queryError = new ConnectError('Wallet is locked', ERROR_CODES.WALLET_LOCKED, {
+      reason: 'locked',
+    });
+
+    let caught: unknown;
+    await act(async () => {
+      caught = await result.current.query(RPC_METHODS.GET_BALANCE).catch((e: unknown) => e);
+    });
+
+    expect((caught as ConnectError).code).toBe(ERROR_CODES.WALLET_LOCKED);
+    expect((caught as ConnectError).data).toEqual({ reason: 'locked' });
+    expect(result.current.isWalletLocked).toBe(true);
+    expect(result.current.isConnected).toBe(true);
+    expect(sessionStorage.getItem(SESSION_KEY_POPUP)).toBe('session-1');
+    expect(mocks.transportDestroys).toHaveLength(0);
+  });
+
+  it('does not disconnect on a typed refusal the session survives', async () => {
+    const { result } = await mountAndConnect();
+    FakeConnectClient.last.queryError = new ConnectError('Permission denied', ERROR_CODES.PERMISSION_DENIED);
+
+    await act(async () => {
+      await result.current.query(RPC_METHODS.GET_BALANCE).catch(() => {});
+    });
+
+    expect(result.current.isConnected).toBe(true);
+    expect(result.current.isWalletLocked).toBe(false);
+    expect(mocks.transportDestroys).toHaveLength(0);
+  });
+
+  it('preserves isWalletLocked when a codeless timeout forces a teardown', async () => {
+    const { result } = await mountAndConnect();
+    act(() => FakeConnectClient.last.emit(WALLET_EVENTS.LOCKED, {}));
+    FakeConnectClient.last.queryError = new Error('Query timeout: sphere_getBalance');
+
+    await act(async () => {
+      await result.current.query(RPC_METHODS.GET_BALANCE).catch(() => {});
+    });
+
+    expect(result.current.isConnected).toBe(false);
+    // The teardown must NOT assign the whole DISCONNECTED constant over the lock flag —
+    // the wallet is still locked and the UI must keep saying so.
+    expect(result.current.isWalletLocked).toBe(true);
+  });
+});

--- a/browser/src/hooks/useWalletConnect.test.ts
+++ b/browser/src/hooks/useWalletConnect.test.ts
@@ -421,3 +421,46 @@ describe('useWalletConnect — raising the wallet on a locked refusal', () => {
     expect(focus).not.toHaveBeenCalled();
   });
 });
+
+describe('useWalletConnect — a dApp reload must not reload the wallet', () => {
+  it('recovers the existing wallet window without navigating it', async () => {
+    // window.open(url, name) NAVIGATES a window that already has that name. Navigating the
+    // wallet reloads its page, and the password is memory-only — so a dApp reload relocked the
+    // wallet. window.open('', name) hands back the same window without touching it.
+    const opened: Array<string | undefined> = [];
+    const popup = { closed: false, focus: vi.fn(), close: () => {} };
+    vi.spyOn(window, 'open').mockImplementation((url?: string | URL) => {
+      opened.push(url === undefined ? undefined : String(url));
+      return popup as unknown as Window;
+    });
+    sessionStorage.setItem(SESSION_KEY_POPUP, 'session-1');
+
+    const hook = renderHook(() => useWalletConnect());
+    await waitFor(() => expect(hook.result.current.isAutoConnecting).toBe(false));
+
+    // The resume asked for the window by NAME with an empty url, and never navigated it.
+    expect(opened[0]).toBe('');
+    expect(opened.some((u) => u && u.includes('/connect?origin='))).toBe(false);
+    expect(hook.result.current.isConnected).toBe(true);
+  });
+
+  it('falls back to loading the wallet when there is no live window to recover', async () => {
+    const opened: string[] = [];
+    const popup = { closed: false, focus: vi.fn(), close: () => {} };
+    vi.spyOn(window, 'open').mockImplementation((url?: string | URL) => {
+      opened.push(url === undefined ? '' : String(url));
+      return popup as unknown as Window;
+    });
+    // A blank window answers nothing, so the resume handshake fails…
+    FakeConnectClient.nextConnectError = new Error('no wallet there');
+    sessionStorage.setItem(SESSION_KEY_POPUP, 'session-1');
+
+    renderHook(() => useWalletConnect());
+
+    // …so the SAME window is navigated to the wallet rather than left stray. Asserted on the
+    // navigation itself, not on the outcome: the fallback then parks in waitForHostReady, and
+    // whether it eventually connects is a different test's business.
+    await waitFor(() => expect(opened.some((u) => u.includes('/connect?origin='))).toBe(true));
+    expect(opened[0]).toBe('');
+  });
+});

--- a/browser/src/hooks/useWalletConnect.test.ts
+++ b/browser/src/hooks/useWalletConnect.test.ts
@@ -326,3 +326,31 @@ describe('useWalletConnect — a connect attempt that met a locked wallet', () =
     expect(hook.result.current.isConnected).toBe(true);
   });
 });
+
+describe('useWalletConnect — focusWallet', () => {
+  it('raises an open popup', async () => {
+    const focus = vi.fn();
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false, focus, close: () => {} } as unknown as Window);
+    const hook = renderHook(() => useWalletConnect());
+    await waitFor(() => expect(hook.result.current.isAutoConnecting).toBe(false));
+    await connectPopup(hook.result);
+    focus.mockClear();
+
+    expect(hook.result.current.focusWallet()).toBe(true);
+    expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses to pretend a CLOSED popup can be raised', async () => {
+    const popup = { closed: false, focus: vi.fn(), close: () => {} };
+    vi.spyOn(window, 'open').mockReturnValue(popup as unknown as Window);
+    const hook = renderHook(() => useWalletConnect());
+    await waitFor(() => expect(hook.result.current.isAutoConnecting).toBe(false));
+    await connectPopup(hook.result);
+
+    // Closing the popup is a real disconnect — the wallet revokes the session on
+    // beforeunload — and a fresh window would cold-start LOCKED anyway, because the password
+    // is memory-only. Reporting false lets the UI say "reconnect" instead of lying.
+    popup.closed = true;
+    expect(hook.result.current.focusWallet()).toBe(false);
+  });
+});

--- a/browser/src/hooks/useWalletConnect.test.ts
+++ b/browser/src/hooks/useWalletConnect.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { ConnectError, ERROR_CODES, HOST_READY_TYPE, RPC_METHODS, WALLET_EVENTS } from '@unicitylabs/sphere-sdk/connect';
-import { FakeConnectClient, FAKE_IDENTITY } from '../test/fakeConnectClient';
+import { FakeConnectClient, FAKE_IDENTITY, OTHER_IDENTITY } from '../test/fakeConnectClient';
 import { useWalletConnect } from './useWalletConnect';
 
 // Hoisted so the vi.mock factories below — which run before this file's own declarations —
@@ -155,5 +155,68 @@ describe('useWalletConnect — request failures', () => {
     // The teardown must NOT assign the whole DISCONNECTED constant over the lock flag —
     // the wallet is still locked and the UI must keep saying so.
     expect(result.current.isWalletLocked).toBe(true);
+  });
+});
+describe('useWalletConnect — wallet:unlocked', () => {
+  it('resumes the same session without re-subscribing when the same wallet returns', async () => {
+    const { result } = await mountAndConnect();
+    const client = FakeConnectClient.last;
+    const registrationsBeforeUnlock = client.onCalls.length;
+
+    act(() => client.emit(WALLET_EVENTS.LOCKED, {}));
+    act(() => client.emit(WALLET_EVENTS.UNLOCKED, { identity: FAKE_IDENTITY }));
+
+    expect(result.current.isWalletLocked).toBe(false);
+    expect(result.current.walletChanged).toBe(false);
+    expect(result.current.unlockEpoch).toBe(1);
+    expect(result.current.isConnected).toBe(true);
+    expect(sessionStorage.getItem(SESSION_KEY_POPUP)).toBe('session-1');
+    // The host re-arms every suspended subscription BEFORE pushing wallet:unlocked, so a dApp
+    // must send nothing here. A client-side re-subscribe would mean a dApp that never
+    // upgrades loses its event streams forever.
+    expect(client.onCalls).toHaveLength(registrationsBeforeUnlock);
+    expect(client.queries).toHaveLength(0);
+  });
+
+  // "Forgot password -> restore from recovery phrase" on the wallet's lock screen installs a
+  // DIFFERENT seed, and the origin approval that authorises this session carries no identity
+  // binding. The host's own lock-edge guard revokes instead of unlocking, but a dApp must
+  // still render honestly if it ever sees a mismatching payload.
+  it('flags a different wallet and resumes nothing against it', async () => {
+    const { result } = await mountAndConnect();
+    const client = FakeConnectClient.last;
+
+    act(() => client.emit(WALLET_EVENTS.LOCKED, {}));
+    act(() => client.emit(WALLET_EVENTS.UNLOCKED, { identity: OTHER_IDENTITY }));
+
+    expect(result.current.isWalletLocked).toBe(false);
+    expect(result.current.walletChanged).toBe(true);
+    expect(result.current.unlockEpoch).toBe(0);
+    expect(result.current.identity?.chainPubkey).toBe(OTHER_IDENTITY.chainPubkey);
+  });
+
+  it('treats an identity-less unlock payload as a changed wallet', async () => {
+    const { result } = await mountAndConnect();
+    const client = FakeConnectClient.last;
+
+    act(() => client.emit(WALLET_EVENTS.LOCKED, {}));
+    act(() => client.emit(WALLET_EVENTS.UNLOCKED, {}));
+
+    expect(result.current.walletChanged).toBe(true);
+    expect(result.current.unlockEpoch).toBe(0);
+  });
+});
+
+describe('useWalletConnect — wallet:disconnected', () => {
+  it('tears the connection down and clears the saved session', async () => {
+    const { result } = await mountAndConnect();
+
+    act(() => FakeConnectClient.last.emit(WALLET_EVENTS.DISCONNECTED, {}));
+
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.isWalletLocked).toBe(false);
+    expect(result.current.identity).toBeNull();
+    expect(sessionStorage.getItem(SESSION_KEY_POPUP)).toBeNull();
+    expect(mocks.transportDestroys).toHaveLength(1);
   });
 });

--- a/browser/src/hooks/useWalletConnect.test.ts
+++ b/browser/src/hooks/useWalletConnect.test.ts
@@ -220,3 +220,45 @@ describe('useWalletConnect — wallet:disconnected', () => {
     expect(mocks.transportDestroys).toHaveLength(1);
   });
 });
+describe('useWalletConnect — HOST_READY', () => {
+  it('does not re-handshake on the HOST_READY that belongs to its own connect', async () => {
+    await mountAndConnect();
+    expect(FakeConnectClient.instances).toHaveLength(1);
+  });
+
+  // A wallet page reload — which is exactly what a reload during a lock looks like — leaves the
+  // dApp talking to a ConnectHost that no longer exists. The replacement host re-announces
+  // HOST_READY; resume the SAME session silently, because the persisted origin approval
+  // survives the reload and the user must not be re-prompted for consent.
+  it('re-handshakes with the saved session id when the host announces HOST_READY again', async () => {
+    const { result } = await mountAndConnect();
+    FakeConnectClient.nextSessionId = 'session-2';
+
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', { data: { type: HOST_READY_TYPE } }));
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(FakeConnectClient.instances).toHaveLength(2));
+
+    expect(FakeConnectClient.last.options.resumeSessionId).toBe('session-1');
+    expect(FakeConnectClient.last.options.silent).toBe(true);
+    expect(sessionStorage.getItem(SESSION_KEY_POPUP)).toBe('session-2');
+    expect(result.current.isConnected).toBe(true);
+  });
+});
+
+describe('useWalletConnect — resume onto a locked wallet', () => {
+  // The most common entry into this feature: the wallet was already locked when the dApp
+  // resumed. Connect 2.1 makes that handshake SUCCEED and carries locked: true, so the dApp is
+  // connected AND locked in one state — no refusal, no reconnect loop, no consent prompt.
+  it('is connected and locked when the handshake response carries locked: true', async () => {
+    FakeConnectClient.nextLocked = true;
+    const { result } = await mountAndConnect();
+
+    expect(result.current.isConnected).toBe(true);
+    expect(result.current.isWalletLocked).toBe(true);
+    expect(result.current.walletProtocol).toBe('2.1');
+    expect(sessionStorage.getItem(SESSION_KEY_POPUP)).toBe('session-1');
+    expect(mocks.transportDestroys).toHaveLength(0);
+  });
+});

--- a/browser/src/hooks/useWalletConnect.test.ts
+++ b/browser/src/hooks/useWalletConnect.test.ts
@@ -354,3 +354,70 @@ describe('useWalletConnect — focusWallet', () => {
     expect(hook.result.current.focusWallet()).toBe(false);
   });
 });
+
+describe('useWalletConnect — raising the wallet on a locked refusal', () => {
+  function setActivation(isActive: boolean) {
+    Object.defineProperty(navigator, 'userActivation', {
+      value: { isActive },
+      configurable: true,
+    });
+  }
+
+  it('raises the wallet window when a HUMAN asked and the wallet answered 4009', async () => {
+    const focus = vi.fn();
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false, focus, close: () => {} } as unknown as Window);
+    const hook = renderHook(() => useWalletConnect());
+    await waitFor(() => expect(hook.result.current.isAutoConnecting).toBe(false));
+    await connectPopup(hook.result);
+    focus.mockClear();
+
+    FakeConnectClient.last.queryError = new ConnectError('Wallet is locked', ERROR_CODES.WALLET_LOCKED, {
+      reason: 'locked',
+    });
+    setActivation(true);
+    await act(async () => {
+      await hook.result.current.query(RPC_METHODS.GET_BALANCE).catch(() => {});
+    });
+
+    expect(focus).toHaveBeenCalledTimes(1);
+    expect(hook.result.current.isWalletLocked).toBe(true);
+  });
+
+  it('does NOT raise it for a background request with no user gesture', async () => {
+    const focus = vi.fn();
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false, focus, close: () => {} } as unknown as Window);
+    const hook = renderHook(() => useWalletConnect());
+    await waitFor(() => expect(hook.result.current.isAutoConnecting).toBe(false));
+    await connectPopup(hook.result);
+    focus.mockClear();
+
+    FakeConnectClient.last.queryError = new ConnectError('Wallet is locked', ERROR_CODES.WALLET_LOCKED, {
+      reason: 'locked',
+    });
+    setActivation(false);
+    await act(async () => {
+      await hook.result.current.query(RPC_METHODS.GET_BALANCE).catch(() => {});
+    });
+
+    // A poller or a subscription callback must never steal focus.
+    expect(focus).not.toHaveBeenCalled();
+    expect(hook.result.current.isWalletLocked).toBe(true);
+  });
+
+  it('does not raise it for a refusal that is not a lock', async () => {
+    const focus = vi.fn();
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false, focus, close: () => {} } as unknown as Window);
+    const hook = renderHook(() => useWalletConnect());
+    await waitFor(() => expect(hook.result.current.isAutoConnecting).toBe(false));
+    await connectPopup(hook.result);
+    focus.mockClear();
+
+    FakeConnectClient.last.queryError = new ConnectError('Nope', ERROR_CODES.PERMISSION_DENIED);
+    setActivation(true);
+    await act(async () => {
+      await hook.result.current.query(RPC_METHODS.GET_BALANCE).catch(() => {});
+    });
+
+    expect(focus).not.toHaveBeenCalled();
+  });
+});

--- a/browser/src/hooks/useWalletConnect.test.ts
+++ b/browser/src/hooks/useWalletConnect.test.ts
@@ -262,3 +262,67 @@ describe('useWalletConnect — resume onto a locked wallet', () => {
     expect(mocks.transportDestroys).toHaveLength(0);
   });
 });
+
+describe('useWalletConnect — a connect attempt that met a locked wallet', () => {
+  /**
+   * Drives a popup attempt that FAILS while the popup stays open — the shape of every
+   * failure against a wallet that cannot serve yet. The window mock reports `closed: false`
+   * throughout, which is what the real popup does: a failed attempt is the one path that
+   * does not close it.
+   */
+  async function failedAttempt(hook: { result: { current: Hook } }) {
+    FakeConnectClient.nextConnectError = new Error('Connection rejected by wallet');
+    await act(async () => {
+      const pending = hook.result.current.connectViaPopup();
+      window.dispatchEvent(new MessageEvent('message', { data: { type: HOST_READY_TYPE } }));
+      await pending;
+    });
+    expect(hook.result.current.isConnected).toBe(false);
+    FakeConnectClient.nextConnectError = null;
+  }
+
+  it('retries itself when the wallet announces it can serve, with no second click', async () => {
+    const hook = renderHook(() => useWalletConnect());
+    await waitFor(() => expect(hook.result.current.isAutoConnecting).toBe(false));
+    await failedAttempt(hook);
+
+    // The human unlocks; ConnectPage announces on the locked -> live re-arm. The listener is
+    // armed even though we are NOT connected — gating it on isConnected is what swallowed
+    // this and left the user clicking Connect at a wallet that was already ready.
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', { data: { type: HOST_READY_TYPE } }));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(hook.result.current.isConnected).toBe(true));
+    expect(hook.result.current.identity?.chainPubkey).toBe(FAKE_IDENTITY.chainPubkey);
+  });
+
+  it('does not block on HOST_READY when the popup is already open', async () => {
+    const hook = renderHook(() => useWalletConnect());
+    await waitFor(() => expect(hook.result.current.isAutoConnecting).toBe(false));
+    await failedAttempt(hook);
+
+    // The user unlocks and clicks Connect again. That window has already booted and already
+    // announced, so nothing will announce a second time — waiting would hang for the full
+    // timeout, which is the reported bug. No readiness bit is remembered either: readiness
+    // is not monotonic, so a remembered bit would go stale with nothing to clear it.
+    await act(async () => {
+      await hook.result.current.connectViaPopup();
+    });
+
+    expect(hook.result.current.isConnected).toBe(true);
+  });
+
+  it('ignores the announcement that belongs to an attempt already in flight', async () => {
+    const hook = renderHook(() => useWalletConnect());
+    await waitFor(() => expect(hook.result.current.isAutoConnecting).toBe(false));
+
+    await connectPopup(hook.result);
+
+    // One client: the attempt consumed its own announcement. A listener that also acted on it
+    // would build a second client for the same handshake.
+    expect(FakeConnectClient.instances).toHaveLength(1);
+    expect(hook.result.current.isConnected).toBe(true);
+  });
+});

--- a/browser/src/hooks/useWalletConnect.ts
+++ b/browser/src/hooks/useWalletConnect.ts
@@ -14,6 +14,13 @@ export interface WalletConnectState {
    *  transport are all ALIVE — requests are answered WALLET_LOCKED (4009) until the host
    *  pushes wallet:unlocked. Against a 2.0 wallet the connection is torn down instead. */
   isWalletLocked: boolean;
+  /** A lock ended with a DIFFERENT wallet than this session was approved for. Unlock is not
+   *  implicitly the same wallet: the lock screen's "restore from recovery phrase" installs
+   *  another seed, and origin approvals carry no identity binding. */
+  walletChanged: boolean;
+  /** Bumps once per unlock that returned the SAME wallet. Read panels use it as a refetch
+   *  trigger — the reference retry-after-unlock. Never used to replay an intent. */
+  unlockEpoch: number;
   identity: PublicIdentity | null;
   permissions: readonly PermissionScope[];
   error: string | null;
@@ -33,11 +40,13 @@ export interface UseWalletConnect extends WalletConnectState {
   extensionInstalled: boolean;
 }
 
-// Reusable disconnected state to avoid repeating isWalletLocked everywhere
+// Reusable disconnected state so no call site has to remember every flag
 const DISCONNECTED: WalletConnectState = {
   isConnected: false,
   isConnecting: false,
   isWalletLocked: false,
+  walletChanged: false,
+  unlockEpoch: 0,
   identity: null,
   permissions: [],
   error: null,
@@ -80,6 +89,12 @@ export function useWalletConnect(): UseWalletConnect {
   const transportRef = useRef<ConnectTransport | null>(null);
   const popupRef = useRef<Window | null>(null);
   const popupMode = useRef(false);
+  // Mirrors state.identity so the auto-pushed event handlers — registered once per connection —
+  // compare against the CURRENT identity instead of a stale closure copy.
+  const identityRef = useRef<PublicIdentity | null>(null);
+  useEffect(() => {
+    identityRef.current = state.identity;
+  }, [state.identity]);
 
   const dappMeta = {
     name: 'Connect Demo',
@@ -354,14 +369,50 @@ export function useWalletConnect(): UseWalletConnect {
       setState((s) => ({ ...s, isWalletLocked: true }));
     });
 
+    // wallet:unlocked — the SAME session continues: no re-handshake, no re-approval, and no
+    // re-subscribe (the host replays every suspended subscription key BEFORE it pushes this).
+    // The payload carries the wallet's identity at unlock time, and checking it is not
+    // optional: the host's lock-edge guard is authoritative, but a dApp must render honestly.
+    const unsubUnlocked = client.on(WALLET_EVENTS.UNLOCKED, (data) => {
+      const next = (data as { identity?: PublicIdentity } | undefined)?.identity ?? null;
+      const previous = identityRef.current;
+      const sameWallet = !!next && !!previous && next.chainPubkey === previous.chainPubkey;
+
+      if (!sameWallet) {
+        // A different seed came back (or none was reported). Resume NOTHING against it — the
+        // origin approval that authorises this session says nothing about which wallet it is.
+        setState((s) => ({ ...s, isWalletLocked: false, walletChanged: true, identity: next ?? s.identity }));
+        return;
+      }
+
+      setState((s) => ({ ...s, isWalletLocked: false, walletChanged: false, unlockEpoch: s.unlockEpoch + 1 }));
+    });
+
+    // wallet:disconnected — logout, wallet deleted, a session that expired while locked, or a
+    // different seed behind the lock screen. Unlike a lock this really is a teardown: nothing
+    // is resumable without a fresh handshake.
+    const unsubDisconnected = client.on(WALLET_EVENTS.DISCONNECTED, () => {
+      transportRef.current?.destroy();
+      clientRef.current = null;
+      transportRef.current = null;
+      popupRef.current = null; // do NOT close the popup — the user may onboard a new wallet there
+      popupMode.current = false;
+      sessionStorage.removeItem(SESSION_KEY_POPUP);
+      setState(DISCONNECTED);
+    });
+
     // identity:changed — auto-pushed by ConnectHost (MetaMask accountsChanged pattern),
     // no sphere_subscribe needed. Update displayed identity when wallet switches address.
+    // identity:changed — the user switched address inside an UNLOCKED wallet. Not a lock event:
+    // it clears both flags because the wallet is demonstrably usable and freshly identified.
     const unsubIdentity = client.on(WALLET_EVENTS.IDENTITY_CHANGED, (data) => {
-      setState((s) => ({ ...s, isWalletLocked: false, identity: data as PublicIdentity }));
+      setState((s) => ({ ...s, isWalletLocked: false, walletChanged: false, identity: data as PublicIdentity }));
     });
 
     return () => {
       unsubLocked();
+      unsubUnlocked();
+      unsubDisconnected();
       unsubIdentity();
     };
   }, [state.isConnected]);

--- a/browser/src/hooks/useWalletConnect.ts
+++ b/browser/src/hooks/useWalletConnect.ts
@@ -4,10 +4,15 @@ import { PostMessageTransport, ExtensionTransport } from '@unicitylabs/sphere-sd
 import type { ConnectTransport, PublicIdentity, RpcMethod, IntentAction } from '@unicitylabs/sphere-sdk/connect';
 import type { PermissionScope } from '@unicitylabs/sphere-sdk/connect';
 import { isInIframe, hasExtension } from '../lib/detection';
+import { classifyRequestError } from '../lib/connectErrors';
+import { supportsGracefulLock } from '../lib/walletProtocol';
 
 export interface WalletConnectState {
   isConnected: boolean;
   isConnecting: boolean;
+  /** The wallet is locked. Under Connect >= 2.1 the session, the granted permissions and the
+   *  transport are all ALIVE — requests are answered WALLET_LOCKED (4009) until the host
+   *  pushes wallet:unlocked. Against a 2.0 wallet the connection is torn down instead. */
   isWalletLocked: boolean;
   identity: PublicIdentity | null;
   permissions: readonly PermissionScope[];
@@ -69,14 +74,7 @@ export function useWalletConnect(): UseWalletConnect {
 
   const [isAutoConnecting, setIsAutoConnecting] = useState(willSilentCheck);
 
-  const [state, setState] = useState<WalletConnectState>({
-    isConnected: false,
-    isConnecting: false,
-    isWalletLocked: false,
-    identity: null,
-    permissions: [],
-    error: null,
-  });
+  const [state, setState] = useState<WalletConnectState>(DISCONNECTED);
 
   const clientRef = useRef<ConnectClient | null>(null);
   const transportRef = useRef<ConnectTransport | null>(null);
@@ -251,19 +249,30 @@ export function useWalletConnect(): UseWalletConnect {
     setState(DISCONNECTED);
   }, []);
 
-  // Auto-disconnect on transport/session errors (popup closed, refreshed, logged out)
+  // Decide what a failed request means, by ERROR CODE (src/lib/connectErrors.ts).
+  //   locked   → the session is ALIVE. Flag the lock, change nothing else, rethrow.
+  //   teardown → the connection is genuinely gone. Drop everything.
+  //   other    → a typed refusal the session survives. Surface it untouched.
   const handleRequestError = useCallback((err: unknown) => {
-    const msg = err instanceof Error ? err.message : String(err);
-    // Transport dead or session revoked — fully disconnect
-    if (/not.connected|timeout|transport|closed|session/i.test(msg)) {
+    const kind = classifyRequestError(err);
+
+    if (kind === 'teardown') {
       transportRef.current?.destroy();
       clientRef.current = null;
       transportRef.current = null;
       popupRef.current = null;
       popupMode.current = false;
       sessionStorage.removeItem(SESSION_KEY_POPUP);
-      setState(DISCONNECTED);
+      // Preserve isWalletLocked: a codeless timeout raised WHILE the wallet is locked must not
+      // erase the lock by assigning the whole DISCONNECTED constant over it.
+      setState((s) => ({ ...DISCONNECTED, isWalletLocked: s.isWalletLocked }));
+    } else if (kind === 'locked') {
+      // WALLET_LOCKED (4009). Do NOT disconnect — the host preserved this session and will push
+      // wallet:unlocked on it. The caller's promise still rejects: in Release 1 retrying is the
+      // dApp's decision (Task 5's unlockEpoch), never a silent replay by this layer.
+      setState((s) => ({ ...s, isWalletLocked: true }));
     }
+
     throw err;
   }, []);
 
@@ -323,21 +332,26 @@ export function useWalletConnect(): UseWalletConnect {
     if (!state.isConnected || !clientRef.current) return;
     const client = clientRef.current;
 
-    // wallet:locked — pushed automatically by ConnectHost, no sphere_subscribe needed.
-    // Popup mode: fully disconnect — popup navigated away (logout/refresh), no way to resume.
-    // Extension/iframe mode: show locked state, let user unlock and continue (MetaMask pattern).
+    // wallet:locked — under Connect >= 2.1 this is a STATE, not a teardown: the session, the
+    // granted permissions and the transport all survive, in EVERY transport mode. Tearing down
+    // here orphans a host-side session that now outlives the lock, and the next silent
+    // autoConnect reconnects with no prompt at all.
+    //
+    // A 2.0 wallet means the opposite by the same event name — the removed
+    // notifyWalletLocked() pushed it AND revoked the session, so wallet:unlocked will never
+    // arrive and there is nothing to wait for. ConnectClient.walletProtocol tells them apart.
     const unsubLocked = client.on(WALLET_EVENTS.LOCKED, () => {
-      if (popupMode.current) {
+      if (!supportsGracefulLock(client.walletProtocol)) {
         transportRef.current?.destroy();
         clientRef.current = null;
         transportRef.current = null;
-        popupRef.current = null;
+        popupRef.current = null; // do NOT close the popup — the user may onboard another wallet there
         popupMode.current = false;
         sessionStorage.removeItem(SESSION_KEY_POPUP);
         setState(DISCONNECTED);
-      } else {
-        setState((s) => ({ ...s, isWalletLocked: true }));
+        return;
       }
+      setState((s) => ({ ...s, isWalletLocked: true }));
     });
 
     // identity:changed — auto-pushed by ConnectHost (MetaMask accountsChanged pattern),

--- a/browser/src/hooks/useWalletConnect.ts
+++ b/browser/src/hooks/useWalletConnect.ts
@@ -21,6 +21,9 @@ export interface WalletConnectState {
   /** Bumps once per unlock that returned the SAME wallet. Read panels use it as a refetch
    *  trigger — the reference retry-after-unlock. Never used to replay an intent. */
   unlockEpoch: number;
+  /** Connect protocol version the WALLET reported at handshake ('2.1', '2.0', …), or null.
+   *  Decides what wallet:locked means — see src/lib/walletProtocol.ts. */
+  walletProtocol: string | null;
   identity: PublicIdentity | null;
   permissions: readonly PermissionScope[];
   error: string | null;
@@ -47,6 +50,7 @@ const DISCONNECTED: WalletConnectState = {
   isWalletLocked: false,
   walletChanged: false,
   unlockEpoch: 0,
+  walletProtocol: null,
   identity: null,
   permissions: [],
   error: null,
@@ -56,6 +60,12 @@ const WALLET_URL = import.meta.env.VITE_WALLET_URL || 'https://sphere.unicity.ne
 
 // sessionStorage key for popup session resume (P3 only)
 const SESSION_KEY_POPUP = 'sphere-connect-popup-session';
+
+const DAPP_META = {
+  name: 'Connect Demo',
+  description: 'Sphere Connect browser example',
+  url: location.origin,
+} as const;
 
 /** Wait for the wallet popup to signal it's ready */
 function waitForHostReady(timeoutMs = HOST_READY_TIMEOUT): Promise<void> {
@@ -96,17 +106,87 @@ export function useWalletConnect(): UseWalletConnect {
     identityRef.current = state.identity;
   }, [state.identity]);
 
-  const dappMeta = {
-    name: 'Connect Demo',
-    description: 'Sphere Connect browser example',
-    url: location.origin,
-  } as const;
+  const makeClient = useCallback(
+    (transport: ConnectTransport, extra: { resumeSessionId?: string; silent?: boolean } = {}): ConnectClient =>
+      new ConnectClient({ transport, dapp: DAPP_META, network: SPHERE_NETWORKS.testnet2, ...extra }),
+    [],
+  );
 
-  const makeClient = (
-    transport: ConnectTransport,
-    extra: { resumeSessionId?: string; silent?: boolean } = {},
-  ): ConnectClient =>
-    new ConnectClient({ transport, dapp: dappMeta, network: SPHERE_NETWORKS.testnet2, ...extra });
+  /**
+   * Handshake on `transport` and publish the result. The single place a session is created —
+   * seven call sites used to repeat this block, which is why the wallet's protocol version and
+   * the new ConnectResult.locked had nowhere to be recorded.
+   *
+   * `result.locked === true` means the wallet was LOCKED when we resumed and the session is
+   * nevertheless alive: connected AND locked, in one state. That is a success, not a refusal.
+   */
+  const handshake = useCallback(
+    async (transport: ConnectTransport, extra: { resumeSessionId?: string; silent?: boolean } = {}) => {
+      const client = makeClient(transport, extra);
+      clientRef.current = client;
+      const result = await client.connect();
+      if (popupMode.current) sessionStorage.setItem(SESSION_KEY_POPUP, result.sessionId);
+      setState({
+        ...DISCONNECTED,
+        isConnected: true,
+        isWalletLocked: result.locked === true,
+        identity: result.identity,
+        permissions: result.permissions,
+        walletProtocol: client.walletProtocol,
+      });
+      return result;
+    },
+    [makeClient],
+  );
+
+  const rehandshaking = useRef(false);
+
+  /**
+   * The wallet host announced HOST_READY while we already believed we were connected — the
+   * wallet page reloaded (a reload during a lock does exactly this) and the old ConnectHost is
+   * gone. Rebuild the transport and resume the SAME session id silently: the persisted origin
+   * approval survives a reload, so the user must not see a consent prompt for it. If the
+   * wallet is still locked, the resume succeeds with locked: true.
+   *
+   * Extension mode never receives HOST_READY — only the PostMessage host sends it — so this is
+   * a no-op there by construction.
+   */
+  const rehandshake = useCallback(async () => {
+    if (rehandshaking.current) return;
+    rehandshaking.current = true;
+    try {
+      const wasPopup = popupMode.current;
+      if (!wasPopup && !isInIframe()) return;
+      if (wasPopup && (!popupRef.current || popupRef.current.closed)) return;
+
+      transportRef.current?.destroy();
+      const transport = wasPopup
+        ? PostMessageTransport.forClient({ target: popupRef.current!, targetOrigin: WALLET_URL })
+        : PostMessageTransport.forClient();
+      transportRef.current = transport;
+
+      const resumeSessionId = wasPopup ? sessionStorage.getItem(SESSION_KEY_POPUP) ?? undefined : undefined;
+      await handshake(transport, { resumeSessionId, silent: true });
+    } catch {
+      // The host came back without a resumable session — leave the state alone; the user
+      // reconnects explicitly. Never surface an error for a background re-handshake.
+    } finally {
+      rehandshaking.current = false;
+    }
+  }, [handshake]);
+
+  // Permanent HOST_READY listener, replacing the one-shot mount listener. It is only armed once
+  // we believe we are connected: a HOST_READY arriving before that belongs to the connect path
+  // itself (waitForHostReady), not to a host restart.
+  useEffect(() => {
+    if (!state.isConnected) return;
+    const handler = (event: MessageEvent) => {
+      if (event.data?.type !== HOST_READY_TYPE) return;
+      void rehandshake();
+    };
+    window.addEventListener('message', handler);
+    return () => window.removeEventListener('message', handler);
+  }, [state.isConnected, rehandshake]);
 
   /**
    * Open (or re-open) popup, create fresh transport + client, do handshake.
@@ -137,16 +217,10 @@ export function useWalletConnect(): UseWalletConnect {
     await waitForHostReady();
 
     const resumeSessionId = sessionStorage.getItem(SESSION_KEY_POPUP) ?? undefined;
-    const client = makeClient(transport, { resumeSessionId });
-    clientRef.current = client;
+    await handshake(transport, { resumeSessionId });
 
-    const result = await client.connect();
-    sessionStorage.setItem(SESSION_KEY_POPUP, result.sessionId);
-
-    setState({ ...DISCONNECTED, isConnected: true, identity: result.identity, permissions: result.permissions });
-
-    return client;
-  }, [dappMeta]);
+    return clientRef.current!;
+  }, [handshake]);
 
   /**
    * Ensure we have a working client.
@@ -182,14 +256,11 @@ export function useWalletConnect(): UseWalletConnect {
       popupMode.current = false;
       const transport = ExtensionTransport.forClient();
       transportRef.current = transport;
-      const client = makeClient(transport);
-      clientRef.current = client;
-      const result = await client.connect();
-      setState({ ...DISCONNECTED, isConnected: true, identity: result.identity, permissions: result.permissions });
+      await handshake(transport);
     } catch (err) {
       setState((s) => ({ ...s, isConnecting: false, error: err instanceof Error ? err.message : 'Connection failed' }));
     }
-  }, [dappMeta]);
+  }, [handshake]);
 
   const connectViaPopup = useCallback(async () => {
     setState((s) => ({ ...s, isConnecting: true, error: null }));
@@ -201,10 +272,7 @@ export function useWalletConnect(): UseWalletConnect {
         popupMode.current = false;
         const transport = PostMessageTransport.forClient();
         transportRef.current = transport;
-        const client = makeClient(transport);
-        clientRef.current = client;
-        const result = await client.connect();
-        setState({ ...DISCONNECTED, isConnected: true, identity: result.identity, permissions: result.permissions });
+        await handshake(transport);
       } else {
         // Outside iframe — open popup window
         popupMode.current = true;
@@ -213,7 +281,7 @@ export function useWalletConnect(): UseWalletConnect {
     } catch (err) {
       setState((s) => ({ ...s, isConnecting: false, error: err instanceof Error ? err.message : 'Connection failed' }));
     }
-  }, [openPopupAndConnect, dappMeta]);
+  }, [openPopupAndConnect, handshake]);
 
   const connect = useCallback(async () => {
     setState((s) => ({ ...s, isConnecting: true, error: null }));
@@ -227,11 +295,7 @@ export function useWalletConnect(): UseWalletConnect {
         const transport = PostMessageTransport.forClient();
         transportRef.current = transport;
 
-        const client = makeClient(transport);
-        clientRef.current = client;
-
-        const result = await client.connect();
-        setState({ ...DISCONNECTED, isConnected: true, identity: result.identity, permissions: result.permissions });
+        await handshake(transport);
       } else if (hasExtension()) {
         await connectViaExtension();
       } else {
@@ -244,7 +308,7 @@ export function useWalletConnect(): UseWalletConnect {
         error: err instanceof Error ? err.message : 'Connection failed',
       }));
     }
-  }, [openPopupAndConnect, dappMeta]);
+  }, [connectViaExtension, connectViaPopup, handshake]);
 
   const disconnect = useCallback(async () => {
     try {
@@ -445,11 +509,8 @@ export function useWalletConnect(): UseWalletConnect {
         popupMode.current = false;
         const transport = PostMessageTransport.forClient();
         transportRef.current = transport;
-        const client = makeClient(transport, { silent: true });
-        clientRef.current = client;
         try {
-          const result = await client.connect();
-          setState({ ...DISCONNECTED, isConnected: true, identity: result.identity, permissions: result.permissions });
+          await handshake(transport, { silent: true });
         } catch {
           // Parent rejected (origin not approved yet) — clean up, show Connect button
           transportRef.current?.destroy();
@@ -467,12 +528,8 @@ export function useWalletConnect(): UseWalletConnect {
         const transport = ExtensionTransport.forClient();
         transportRef.current = transport;
 
-        const client = makeClient(transport, { silent: true });
-        clientRef.current = client;
-
         try {
-          const result = await client.connect();
-          setState({ ...DISCONNECTED, isConnected: true, identity: result.identity, permissions: result.permissions });
+          await handshake(transport, { silent: true });
         } catch {
           // Origin not approved — clean up and show Connect button (no error message)
           transportRef.current?.destroy();
@@ -508,11 +565,7 @@ export function useWalletConnect(): UseWalletConnect {
 
           await waitForHostReady(5000);
 
-          const client = makeClient(transport, { resumeSessionId: savedSession, silent: true });
-          clientRef.current = client;
-          const result = await client.connect();
-          sessionStorage.setItem(SESSION_KEY_POPUP, result.sessionId);
-          setState({ ...DISCONNECTED, isConnected: true, identity: result.identity, permissions: result.permissions });
+          await handshake(transport, { resumeSessionId: savedSession, silent: true });
         };
         resumePopup()
           .catch(() => {

--- a/browser/src/hooks/useWalletConnect.ts
+++ b/browser/src/hooks/useWalletConnect.ts
@@ -69,6 +69,22 @@ const DAPP_META = {
   url: location.origin,
 } as const;
 
+/**
+ * Is there a live user gesture behind the call happening right now?
+ *
+ * `navigator.userActivation.isActive` is the browser's own transient-activation flag: true for
+ * a short window after a real click/keypress, false for anything a timer or a subscription
+ * callback started. It is what separates "the user pressed Fetch Balance" from "a poller ran",
+ * so it decides whether we may raise the wallet window. Absent (non-Chromium) -> treated as
+ * NOT user-initiated, because guessing wrong in that direction only costs a window raise,
+ * while guessing wrong the other way lets a background timer steal focus.
+ */
+function isUserInitiated(): boolean {
+  const activation = (navigator as Navigator & { userActivation?: { isActive: boolean } })
+    .userActivation;
+  return activation?.isActive ?? false;
+}
+
 /** Wait for the wallet popup to signal it's ready */
 function waitForHostReady(timeoutMs = HOST_READY_TIMEOUT): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -431,30 +447,6 @@ export function useWalletConnect(): UseWalletConnect {
     throw err;
   }, []);
 
-  const query = useCallback(
-    async <T = unknown>(method: RpcMethod | string, params?: Record<string, unknown>): Promise<T> => {
-      const client = await ensureClient();
-      try {
-        return await client.query<T>(method, params);
-      } catch (err) {
-        return handleRequestError(err) as never;
-      }
-    },
-    [ensureClient, handleRequestError],
-  );
-
-  const intent = useCallback(
-    async <T = unknown>(action: IntentAction | string, params: Record<string, unknown>): Promise<T> => {
-      const client = await ensureClient();
-      try {
-        return await client.intent<T>(action, params);
-      } catch (err) {
-        return handleRequestError(err) as never;
-      }
-    },
-    [ensureClient, handleRequestError],
-  );
-
   /**
    * Bring the wallet window to the front. Returns false when there is nothing to raise.
    *
@@ -472,6 +464,54 @@ export function useWalletConnect(): UseWalletConnect {
     popup.focus();
     return true;
   }, []);
+
+  /**
+   * Raise the wallet window when a request was refused BECAUSE the wallet is locked and a
+   * human is the one who asked. `userAsked` is sampled synchronously at the call site, before
+   * any await, so a background poller can never trigger this — only a live gesture can.
+   *
+   * This is the difference between a helpful reaction and a hostile one: raising the window
+   * the user just asked to talk to is what a wallet integration should do, whereas a page
+   * that grabs focus on a timer is a nuisance and an aid to clickjacking. The wallet still
+   * decides everything that happens next — it raises its own password field, we only make the
+   * window visible.
+   */
+  const raiseWalletIfUserAsked = useCallback((err: unknown, userAsked: boolean): void => {
+    if (!userAsked) return;
+    if (classifyRequestError(err) !== 'locked') return;
+    focusWallet();
+  }, [focusWallet]);
+
+  const query = useCallback(
+    async <T = unknown>(method: RpcMethod | string, params?: Record<string, unknown>): Promise<T> => {
+      // Sampled SYNCHRONOUSLY, before any await: this is the only moment at which the user's
+      // gesture is still live. See raiseWalletIfUserAsked.
+      const userAsked = isUserInitiated();
+      const client = await ensureClient();
+      try {
+        return await client.query<T>(method, params);
+      } catch (err) {
+        raiseWalletIfUserAsked(err, userAsked);
+        return handleRequestError(err) as never;
+      }
+    },
+    [ensureClient, handleRequestError, raiseWalletIfUserAsked],
+  );
+
+  const intent = useCallback(
+    async <T = unknown>(action: IntentAction | string, params: Record<string, unknown>): Promise<T> => {
+      const userAsked = isUserInitiated();
+      const client = await ensureClient();
+      try {
+        return await client.intent<T>(action, params);
+      } catch (err) {
+        raiseWalletIfUserAsked(err, userAsked);
+        return handleRequestError(err) as never;
+      }
+    },
+    [ensureClient, handleRequestError, raiseWalletIfUserAsked],
+  );
+
 
   const on = useCallback((event: string, handler: (data: unknown) => void): (() => void) => {
     if (!clientRef.current) throw new Error('Not connected');

--- a/browser/src/hooks/useWalletConnect.ts
+++ b/browser/src/hooks/useWalletConnect.ts
@@ -41,6 +41,8 @@ export interface UseWalletConnect extends WalletConnectState {
   isAutoConnecting: boolean;
   /** True if the Sphere browser extension is detected. */
   extensionInstalled: boolean;
+  /** Raise the wallet window (popup mode only). Returns false when there is none to raise. */
+  focusWallet: () => boolean;
 }
 
 // Reusable disconnected state so no call site has to remember every flag
@@ -453,6 +455,24 @@ export function useWalletConnect(): UseWalletConnect {
     [ensureClient, handleRequestError],
   );
 
+  /**
+   * Bring the wallet window to the front. Returns false when there is nothing to raise.
+   *
+   * Call this ONLY from a user gesture — a button, never a failed background request. A page
+   * that yanked focus on its own would be a nuisance at best and a clickjacking aid at worst.
+   *
+   * It deliberately does NOT reopen a CLOSED popup. Closing the popup is a real disconnect:
+   * the wallet revokes the session on beforeunload and pushes wallet:disconnected, and a
+   * fresh window would cold-start LOCKED anyway because the password is memory-only. Offering
+   * to "restore" it would be a lie — the honest move is to reconnect explicitly.
+   */
+  const focusWallet = useCallback((): boolean => {
+    const popup = popupRef.current;
+    if (!popupMode.current || !popup || popup.closed) return false;
+    popup.focus();
+    return true;
+  }, []);
+
   const on = useCallback((event: string, handler: (data: unknown) => void): (() => void) => {
     if (!clientRef.current) throw new Error('Not connected');
     return clientRef.current.on(event, handler);
@@ -669,5 +689,6 @@ export function useWalletConnect(): UseWalletConnect {
     on,
     isAutoConnecting,
     extensionInstalled: hasExtension(),
+    focusWallet,
   };
 }

--- a/browser/src/hooks/useWalletConnect.ts
+++ b/browser/src/hooks/useWalletConnect.ts
@@ -63,6 +63,29 @@ const WALLET_URL = import.meta.env.VITE_WALLET_URL || 'https://sphere.unicity.ne
 // sessionStorage key for popup session resume (P3 only)
 const SESSION_KEY_POPUP = 'sphere-connect-popup-session';
 
+/**
+ * The popup's window NAME. `window.open(url, name)` does not merely return an existing window
+ * with that name — it NAVIGATES it to `url`. Navigating the wallet reloads its page, and the
+ * password is memory-only, so that RELOCKS the wallet. Reloading the dApp was enough to trigger
+ * it: the fresh JS context has lost its window handle, so the reconnect called window.open with
+ * a URL and re-navigated a perfectly good wallet window.
+ *
+ * `window.open('', name)` returns the existing window WITHOUT navigating it — that is how a
+ * handle is recovered. When no such window exists it yields a blank one instead, which is then
+ * navigated properly.
+ */
+const POPUP_NAME = 'sphere-wallet';
+const POPUP_FEATURES = 'width=420,height=650';
+
+function walletConnectUrl(): string {
+  return WALLET_URL + '/connect?origin=' + encodeURIComponent(location.origin);
+}
+
+/** A saved session id means a wallet window was serving us — worth trying to recover. */
+function popupSessionId(): string | null {
+  return typeof sessionStorage === 'undefined' ? null : sessionStorage.getItem(SESSION_KEY_POPUP);
+}
+
 const DAPP_META = {
   name: 'Connect Demo',
   description: 'Sphere Connect browser example',
@@ -272,16 +295,21 @@ export function useWalletConnect(): UseWalletConnect {
     // Whether THIS call created the window decides whether we wait for HOST_READY.
     let openedFreshWindow = false;
     if (!popupRef.current || popupRef.current.closed) {
-      const popup = window.open(
-        WALLET_URL + '/connect?origin=' + encodeURIComponent(location.origin),
-        'sphere-wallet',
-        'width=420,height=650',
-      );
-      if (!popup) {
-        throw new Error('Popup blocked. Please allow popups for this site.');
+      // Recover a handle to an already-open wallet window WITHOUT navigating it — see
+      // POPUP_NAME. Only if there is nothing to recover do we navigate, which is what actually
+      // loads (or reloads) the wallet page.
+      const existing = window.open('', POPUP_NAME, POPUP_FEATURES);
+      const looksReusable = !!existing && !existing.closed && !!popupSessionId();
+      if (looksReusable) {
+        popupRef.current = existing;
+      } else {
+        const popup = window.open(walletConnectUrl(), POPUP_NAME, POPUP_FEATURES);
+        if (!popup) {
+          throw new Error('Popup blocked. Please allow popups for this site.');
+        }
+        popupRef.current = popup;
+        openedFreshWindow = true;
       }
-      popupRef.current = popup;
-      openedFreshWindow = true;
     } else {
       popupRef.current.focus();
     }
@@ -680,25 +708,46 @@ export function useWalletConnect(): UseWalletConnect {
       if (savedSession) {
         popupMode.current = true;
         const resumePopup = async () => {
-          if (!popupRef.current || popupRef.current.closed) {
-            const popup = window.open(
-              WALLET_URL + '/connect?origin=' + encodeURIComponent(location.origin),
-              'sphere-wallet',
-              'width=420,height=650',
-            );
-            if (!popup) throw new Error('Popup blocked');
-            popupRef.current = popup;
+          // THIS is the path a dApp page reload takes, and it must not navigate the wallet
+          // window: navigating reloads the wallet page, and the memory-only password dies with
+          // it, so merely reloading the dApp relocked the wallet. Recover the handle instead.
+          const existing =
+            popupRef.current && !popupRef.current.closed
+              ? popupRef.current
+              : window.open('', POPUP_NAME, POPUP_FEATURES);
+
+          if (existing && !existing.closed) {
+            popupRef.current = existing;
+            transportRef.current?.destroy();
+            const transport = PostMessageTransport.forClient({
+              target: existing,
+              targetOrigin: WALLET_URL,
+            });
+            transportRef.current = transport;
+            try {
+              // No waitForHostReady: a host that is already live announced once, when it came
+              // up, and does not announce again. Just resume — a live wallet answers at once.
+              await handshake(transport, { resumeSessionId: savedSession, silent: true });
+              return;
+            } catch {
+              // Either that window is not a live wallet (window.open('') hands back a blank one
+              // when the name is free) or the session is gone. Fall through and load the wallet
+              // into the very same window rather than leaving a stray blank popup behind.
+            }
           }
+
+          const popup = window.open(walletConnectUrl(), POPUP_NAME, POPUP_FEATURES);
+          if (!popup) throw new Error('Popup blocked');
+          popupRef.current = popup;
 
           transportRef.current?.destroy();
           const transport = PostMessageTransport.forClient({
-            target: popupRef.current,
+            target: popup,
             targetOrigin: WALLET_URL,
           });
           transportRef.current = transport;
 
           await waitForHostReady(5000);
-
           await handshake(transport, { resumeSessionId: savedSession, silent: true });
         };
         resumePopup()

--- a/browser/src/hooks/useWalletConnect.ts
+++ b/browser/src/hooks/useWalletConnect.ts
@@ -105,6 +105,18 @@ export function useWalletConnect(): UseWalletConnect {
   useEffect(() => {
     identityRef.current = state.identity;
   }, [state.identity]);
+  // Mirrors state.isConnected for the always-armed HOST_READY listener, which is registered
+  // once and must not be torn down and rebuilt every time the connection state flips.
+  const isConnectedRef = useRef(false);
+  useEffect(() => {
+    isConnectedRef.current = state.isConnected;
+  }, [state.isConnected]);
+  // True while a popup connect attempt is running. The attempt CONSUMES the announcement
+  // itself (waitForHostReady), so the listener must stand aside or it would race the attempt
+  // and build a second client for the same handshake. Written SYNCHRONOUSLY rather than
+  // mirrored from state through an effect: the announcement can arrive in the same tick the
+  // attempt starts, long before React has flushed anything.
+  const attemptInFlightRef = useRef(false);
 
   const makeClient = useCallback(
     (transport: ConnectTransport, extra: { resumeSessionId?: string; silent?: boolean } = {}): ConnectClient =>
@@ -175,24 +187,72 @@ export function useWalletConnect(): UseWalletConnect {
     }
   }, [handshake]);
 
-  // Permanent HOST_READY listener, replacing the one-shot mount listener. It is only armed once
-  // we believe we are connected: a HOST_READY arriving before that belongs to the connect path
-  // itself (waitForHostReady), not to a host restart.
+  /**
+   * A connect attempt failed while the wallet was locked, and the wallet has just announced
+   * that it can serve again. Retry it — the user already asked to connect; making them press
+   * Connect a second time for a wallet that is now ready is the bug this closes.
+   *
+   * Silent is deliberately NOT set: if this origin has no approval yet the user must still
+   * see the consent prompt. What is skipped is only the second CLICK, never the consent.
+   */
+  const retryAfterUnlock = useCallback(async () => {
+    if (rehandshaking.current) return;
+    rehandshaking.current = true;
+    try {
+      const popup = popupRef.current;
+      if (!popup || popup.closed) return;
+      transportRef.current?.destroy();
+      const transport = PostMessageTransport.forClient({ target: popup, targetOrigin: WALLET_URL });
+      transportRef.current = transport;
+      const resumeSessionId = sessionStorage.getItem(SESSION_KEY_POPUP) ?? undefined;
+      await handshake(transport, { resumeSessionId });
+    } catch {
+      // Still not ready, or the user declined. Leave the state alone — the next announcement
+      // (or an explicit click) tries again.
+    } finally {
+      rehandshaking.current = false;
+    }
+  }, [handshake]);
+
+  // Permanent HOST_READY listener, replacing the one-shot mount listener. ALWAYS armed —
+  // never gated on isConnected.
+  //
+  // The wallet announces HOST_READY at each moment its host becomes able to complete a
+  // handshake, and a wallet that cold-starts LOCKED announces nothing until a human unlocks
+  // it. That announcement is therefore the signal that a connect attempt which failed while
+  // the wallet was locked can now succeed. Gating this listener on isConnected swallowed it:
+  // the attempt had already failed, so nothing was listening, and the user was left pressing
+  // Connect against a wallet that was ready — the reported bug.
+  //
+  //   connected     -> the wallet page restarted; resume the SAME session silently.
+  //   not connected -> a previous attempt failed against a locked wallet; the unlock is our
+  //                    cue to retry it, with no second click.
   useEffect(() => {
-    if (!state.isConnected) return;
     const handler = (event: MessageEvent) => {
       if (event.data?.type !== HOST_READY_TYPE) return;
-      void rehandshake();
+      // An attempt in flight is already waiting for exactly this message.
+      if (attemptInFlightRef.current) return;
+      if (isConnectedRef.current) {
+        void rehandshake();
+        return;
+      }
+      // Only for a popup we still hold: an announcement can only come from a host we opened.
+      if (!popupMode.current || !popupRef.current || popupRef.current.closed) return;
+      void retryAfterUnlock();
     };
     window.addEventListener('message', handler);
     return () => window.removeEventListener('message', handler);
-  }, [state.isConnected, rehandshake]);
+  }, [rehandshake, retryAfterUnlock]);
 
   /**
    * Open (or re-open) popup, create fresh transport + client, do handshake.
    * Wallet remembers approved origin so re-connect skips the approval modal.
    */
   const openPopupAndConnect = useCallback(async (): Promise<ConnectClient> => {
+    attemptInFlightRef.current = true;
+    try {
+    // Whether THIS call created the window decides whether we wait for HOST_READY.
+    let openedFreshWindow = false;
     if (!popupRef.current || popupRef.current.closed) {
       const popup = window.open(
         WALLET_URL + '/connect?origin=' + encodeURIComponent(location.origin),
@@ -203,6 +263,7 @@ export function useWalletConnect(): UseWalletConnect {
         throw new Error('Popup blocked. Please allow popups for this site.');
       }
       popupRef.current = popup;
+      openedFreshWindow = true;
     } else {
       popupRef.current.focus();
     }
@@ -214,12 +275,25 @@ export function useWalletConnect(): UseWalletConnect {
     });
     transportRef.current = transport;
 
-    await waitForHostReady();
+    // HOST_READY is announced ONCE per host, at the moment that host becomes able to serve a
+    // handshake. It is the right thing to wait for while a wallet page is still booting — and
+    // the wrong thing to wait for against a window that has already booted and already
+    // announced, which is why a second Connect used to hang for the full timeout.
+    //
+    // Deliberately NOT remembered as a "host is ready" flag: readiness is not monotonic (a
+    // wallet can lock again with no wire signal at all), so a remembered bit goes stale with
+    // nothing to clear it. Instead the handshake is simply attempted; a host that cannot
+    // serve refuses it promptly, and the always-armed listener above retries when the wallet
+    // announces it can.
+    if (openedFreshWindow) await waitForHostReady();
 
     const resumeSessionId = sessionStorage.getItem(SESSION_KEY_POPUP) ?? undefined;
     await handshake(transport, { resumeSessionId });
 
     return clientRef.current!;
+    } finally {
+      attemptInFlightRef.current = false;
+    }
   }, [handshake]);
 
   /**

--- a/browser/src/lib/connectErrors.test.ts
+++ b/browser/src/lib/connectErrors.test.ts
@@ -85,3 +85,18 @@ describe('lockedData', () => {
     expect(lockedData(new Error('boom'))).toBeUndefined();
   });
 });
+
+describe('INTENT_OUTCOME_UNKNOWN is its own kind', () => {
+  it('is not lumped in with ordinary refusals', () => {
+    const err = new ConnectError('unknown', ERROR_CODES.INTENT_OUTCOME_UNKNOWN);
+
+    // 'other' would be read by a panel as "it failed, let them press Send again" — which is
+    // the one reaction this code exists to forbid, because the transfer may have gone through.
+    expect(classifyRequestError(err)).toBe('outcome-unknown');
+  });
+
+  it('does not tear the connection down — the session is fine, only the answer was lost', () => {
+    const err = new ConnectError('unknown', ERROR_CODES.INTENT_OUTCOME_UNKNOWN);
+    expect(classifyRequestError(err)).not.toBe('teardown');
+  });
+});

--- a/browser/src/lib/connectErrors.test.ts
+++ b/browser/src/lib/connectErrors.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { ConnectError, ERROR_CODES } from '@unicitylabs/sphere-sdk/connect';
+import { classifyRequestError, connectErrorCode, lockedData } from './connectErrors';
+
+/** Exactly what ConnectHost sends on a 4009 in Release 1. */
+const locked = () => new ConnectError('Wallet is locked', ERROR_CODES.WALLET_LOCKED, { reason: 'locked' });
+
+describe('classifyRequestError', () => {
+  it('treats WALLET_LOCKED as a lock, never as a teardown', () => {
+    expect(classifyRequestError(locked())).toBe('locked');
+  });
+
+  it('treats a dead session as a teardown', () => {
+    expect(classifyRequestError(new ConnectError('Not connected', ERROR_CODES.NOT_CONNECTED))).toBe('teardown');
+    expect(classifyRequestError(new ConnectError('Session expired', ERROR_CODES.SESSION_EXPIRED))).toBe('teardown');
+  });
+
+  it('leaves typed refusals that keep the session alive alone', () => {
+    const survivable = [
+      ERROR_CODES.PERMISSION_DENIED,
+      ERROR_CODES.USER_REJECTED,
+      ERROR_CODES.RATE_LIMITED,
+      ERROR_CODES.INTENT_CANCELLED,
+      ERROR_CODES.INCOMPATIBLE_NETWORK,
+      ERROR_CODES.INSUFFICIENT_BALANCE,
+      ERROR_CODES.INTERNAL_ERROR,
+    ];
+    for (const code of survivable) {
+      expect(classifyRequestError(new ConnectError('refused', code))).toBe('other');
+    }
+  });
+
+  // CANARY for the regex this replaces (/not.connected|timeout|transport|closed|session/i):
+  // a coded refusal whose text merely MENTIONS a session used to force a full disconnect.
+  it('lets the code win over the message text', () => {
+    const err = new ConnectError('No active session for this method', ERROR_CODES.PERMISSION_DENIED);
+    expect(classifyRequestError(err)).toBe('other');
+  });
+
+  // 'Wallet is locked' is a documented recommendation, NOT a wire contract. A wallet that
+  // words it differently must still be classified as locked, on the code alone.
+  it('does not depend on the refusal text', () => {
+    expect(classifyRequestError(new ConnectError('Gesperrt', ERROR_CODES.WALLET_LOCKED, { reason: 'locked' }))).toBe('locked');
+  });
+
+  it('falls back to message text for the SDK errors that carry no code at all', () => {
+    // SphereError('Not connected', …) — ConnectClient.query/intent before a handshake.
+    // SphereError.code is a STRING, so these never reach the coded branch.
+    expect(classifyRequestError(new Error('Not connected'))).toBe('teardown');
+    expect(classifyRequestError(new Error('Query timeout: sphere_getBalance'))).toBe('teardown');
+    expect(classifyRequestError(new Error('Intent timeout: send'))).toBe('teardown');
+    expect(classifyRequestError(new Error('Connection timeout'))).toBe('teardown');
+    expect(classifyRequestError(new Error('Disconnected'))).toBe('teardown');
+    expect(classifyRequestError(new Error('Wallet popup was closed'))).toBe('teardown');
+  });
+
+  it('does not tear down on an unknown codeless failure', () => {
+    expect(classifyRequestError(new Error('Something exploded'))).toBe('other');
+    expect(classifyRequestError(null)).toBe('other');
+    expect(classifyRequestError('boom')).toBe('other');
+  });
+});
+
+describe('connectErrorCode', () => {
+  it('reads a numeric code off a duck-typed error', () => {
+    expect(connectErrorCode(locked())).toBe(4009);
+    expect(connectErrorCode({ code: 4009 })).toBe(4009);
+  });
+
+  it('ignores non-numeric codes — SphereError.code is a string', () => {
+    expect(connectErrorCode(new Error('x'))).toBeUndefined();
+    expect(connectErrorCode({ code: 'NOT_INITIALIZED' })).toBeUndefined();
+    expect(connectErrorCode(null)).toBeUndefined();
+  });
+});
+
+describe('lockedData', () => {
+  it('reads the WalletLockedData the host attaches to every 4009', () => {
+    expect(lockedData(locked())).toEqual({ reason: 'locked' });
+  });
+
+  it('returns undefined when the error is not a 4009 or carries no data', () => {
+    expect(lockedData(new ConnectError('Wallet is locked', ERROR_CODES.WALLET_LOCKED))).toBeUndefined();
+    expect(lockedData(new ConnectError('Not connected', ERROR_CODES.NOT_CONNECTED, { reason: 'locked' }))).toBeUndefined();
+    expect(lockedData(new Error('boom'))).toBeUndefined();
+  });
+});

--- a/browser/src/lib/connectErrors.ts
+++ b/browser/src/lib/connectErrors.ts
@@ -19,6 +19,16 @@ export type RequestErrorKind =
   | 'locked'
   /** The connection is genuinely gone. Drop client, transport and saved session id. */
   | 'teardown'
+  /**
+   * INTENT_OUTCOME_UNKNOWN (4201). The wallet took the intent and the answer was lost — a host
+   * deadline, a lock, a logout. **The money may or may not have moved.**
+   *
+   * Kept apart from 'other' precisely so a UI cannot treat it as an ordinary refusal: the
+   * natural reaction to "failed" is to re-enable the button, and that is the one thing that
+   * must not happen here. Reconcile out of band — poll the recipient, your backend, the
+   * aggregator — and only then decide.
+   */
+  | 'outcome-unknown'
   /** A typed refusal the session survives (permission, rejection, rate limit, …). Surface it. */
   | 'other';
 
@@ -64,6 +74,7 @@ export function classifyRequestError(err: unknown): RequestErrorKind {
   if (code !== undefined) {
     // A coded error is authoritative — never second-guess it with the message text.
     if (code === ERROR_CODES.WALLET_LOCKED) return 'locked';
+    if (code === ERROR_CODES.INTENT_OUTCOME_UNKNOWN) return 'outcome-unknown';
     if (code === ERROR_CODES.NOT_CONNECTED || code === ERROR_CODES.SESSION_EXPIRED) return 'teardown';
     return 'other';
   }

--- a/browser/src/lib/connectErrors.ts
+++ b/browser/src/lib/connectErrors.ts
@@ -1,0 +1,73 @@
+/**
+ * Failure classification for Connect requests.
+ *
+ * Connect 2.1 makes this load-bearing. A locked wallet keeps the session, the granted
+ * permissions and the transport alive and answers WALLET_LOCKED (4009); a dApp that tears
+ * down on it orphans a host-side session that now survives, and the next silent autoConnect
+ * reconnects with no prompt.
+ *
+ * Discriminate on the numeric `.code` — duck-typed, not `instanceof ConnectError`, which the
+ * SDK's own client flags as unsafe across bundle copies. The refusal TEXT is never consulted
+ * for a coded error: 'Wallet is locked' is a documented recommendation, not a wire contract.
+ * Message text is used ONLY for the failures the SDK raises with no code at all.
+ */
+import { ERROR_CODES } from '@unicitylabs/sphere-sdk/connect';
+import type { WalletLockedData } from '@unicitylabs/sphere-sdk/connect';
+
+export type RequestErrorKind =
+  /** WALLET_LOCKED (4009). Session alive. Show the lock, keep everything, let the caller retry. */
+  | 'locked'
+  /** The connection is genuinely gone. Drop client, transport and saved session id. */
+  | 'teardown'
+  /** A typed refusal the session survives (permission, rejection, rate limit, …). Surface it. */
+  | 'other';
+
+/** The numeric Connect error code carried by `err`, or undefined when it has none. */
+export function connectErrorCode(err: unknown): number | undefined {
+  if (typeof err !== 'object' || err === null || !('code' in err)) return undefined;
+  const code = (err as { code: unknown }).code;
+  return typeof code === 'number' ? code : undefined;
+}
+
+/**
+ * The structured `data` the host attaches to every 4009 refusal.
+ *
+ * `SphereRpcError.data?` already existed and ConnectClient already forwards it into
+ * ConnectError, so this is free. Release 1 always sends exactly `{ reason: 'locked' }`;
+ * Release 2 adds `unlockSurface`, which is what feeds ConnectClientConfig.onWalletAttention.
+ */
+export function lockedData(err: unknown): WalletLockedData | undefined {
+  if (connectErrorCode(err) !== ERROR_CODES.WALLET_LOCKED) return undefined;
+  const data = (err as { data?: unknown }).data;
+  if (typeof data !== 'object' || data === null) return undefined;
+  return (data as { reason?: unknown }).reason === 'locked' ? (data as WalletLockedData) : undefined;
+}
+
+/**
+ * Codeless SDK failures that really do mean "the connection is gone":
+ *   'Not connected'            — SphereError from ConnectClient.query/intent before a handshake
+ *   'Query timeout: <method>'  — ConnectClient.query timer
+ *   'Intent timeout: <action>' — ConnectClient.intent timer
+ *   'Connection timeout'       — ConnectClient.connect timer
+ *   'Disconnected'             — ConnectClient.cleanup() rejecting in-flight requests
+ *   'Wallet popup was closed'  — this example's own ensureClient()
+ *
+ * Deliberately contains neither "session" nor a bare "closed": the regex this replaces matched
+ * both, so any typed refusal that merely mentioned a session forced a full disconnect.
+ */
+const CODELESS_TEARDOWN =
+  /\b(not connected|disconnected|connection timeout|query timeout|intent timeout|popup was closed)\b/i;
+
+export function classifyRequestError(err: unknown): RequestErrorKind {
+  const code = connectErrorCode(err);
+
+  if (code !== undefined) {
+    // A coded error is authoritative — never second-guess it with the message text.
+    if (code === ERROR_CODES.WALLET_LOCKED) return 'locked';
+    if (code === ERROR_CODES.NOT_CONNECTED || code === ERROR_CODES.SESSION_EXPIRED) return 'teardown';
+    return 'other';
+  }
+
+  const message = err instanceof Error ? err.message : String(err);
+  return CODELESS_TEARDOWN.test(message) ? 'teardown' : 'other';
+}

--- a/browser/src/lib/walletProtocol.test.ts
+++ b/browser/src/lib/walletProtocol.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { SPHERE_CONNECT_VERSION } from '@unicitylabs/sphere-sdk/connect';
+import { minorOf, supportsGracefulLock } from './walletProtocol';
+
+describe('minorOf', () => {
+  it('reads the MINOR out of a MAJOR.MINOR string', () => {
+    expect(minorOf('2.0')).toBe(0);
+    expect(minorOf('2.1')).toBe(1);
+    expect(minorOf('2.10')).toBe(10);
+  });
+
+  it('returns null for anything that is not MAJOR.MINOR', () => {
+    expect(minorOf(null)).toBeNull();
+    expect(minorOf(undefined)).toBeNull();
+    expect(minorOf('2')).toBeNull();
+    expect(minorOf('two.one')).toBeNull();
+  });
+});
+
+describe('supportsGracefulLock', () => {
+  // The SDK this dApp is built against must itself pass the check, or the reference
+  // implementation would classify its own wallet as legacy.
+  it('accepts the protocol version this SDK ships', () => {
+    expect(supportsGracefulLock(SPHERE_CONNECT_VERSION)).toBe(true);
+  });
+
+  it('rejects a 2.0 wallet: its wallet:locked already revoked the session', () => {
+    expect(supportsGracefulLock('2.0')).toBe(false);
+  });
+
+  it('treats an unknown protocol as legacy — never assume the session survives', () => {
+    expect(supportsGracefulLock(null)).toBe(false);
+    expect(supportsGracefulLock(undefined)).toBe(false);
+    expect(supportsGracefulLock('nonsense')).toBe(false);
+  });
+});

--- a/browser/src/lib/walletProtocol.ts
+++ b/browser/src/lib/walletProtocol.ts
@@ -1,0 +1,35 @@
+/**
+ * What the wallet's Connect protocol version tells a dApp about `wallet:locked`.
+ *
+ * The event name did not change, its MEANING did:
+ *   2.0 wallet — the removed ConnectHost.notifyWalletLocked() pushed wallet:locked AND
+ *                revoked the session. There is nothing to wait for: wallet:unlocked will
+ *                never arrive.
+ *   2.1 wallet — ConnectHost.setLocked() pushes wallet:locked and PRESERVES the session.
+ *                Requests answer WALLET_LOCKED (4009) until wallet:unlocked.
+ *
+ * This is the receiver for the 2.0 -> 2.1 MINOR bump. The compatibility gate itself compares
+ * MAJOR only, so both wallets connect fine — only the lock semantics differ, and the client
+ * learns which it is talking to from ConnectClient.walletProtocol (the `v` field the wallet
+ * puts on every frame, captured at handshake time).
+ */
+
+/** The MINOR component of a `MAJOR.MINOR` protocol string, or null when it is not one. */
+export function minorOf(version: string | null | undefined): number | null {
+  if (typeof version !== 'string') return null;
+  const match = /^(\d+)\.(\d+)$/.exec(version.trim());
+  if (!match) return null;
+  return Number(match[2]);
+}
+
+/**
+ * True when the wallet preserves the session across a lock (Connect >= 2.1).
+ *
+ * An unknown or unparseable version is treated as LEGACY on purpose: assuming the session
+ * survives when it does not leaves the dApp permanently stuck on a locked screen, waiting for
+ * a wallet:unlocked that the wallet is not able to send.
+ */
+export function supportsGracefulLock(walletProtocol: string | null | undefined): boolean {
+  const minor = minorOf(walletProtocol);
+  return minor !== null && minor >= 1;
+}

--- a/browser/src/test/env.smoke.test.tsx
+++ b/browser/src/test/env.smoke.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * Guards the test environment itself.
+ *
+ * Every test this branch adds depends on three things being true: jsdom is the
+ * environment, React Testing Library can mount a component, and the shared
+ * @unicitylabs/sphere-ui components survive that mount (Task 7's WalletStatusBanner
+ * renders AlertBanner). When one of them breaks it must break HERE — not inside a
+ * hook test, where it would look like a product bug.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Button } from '@unicitylabs/sphere-ui';
+
+describe('test environment', () => {
+  it('runs in jsdom, not node', () => {
+    expect(typeof document).toBe('object');
+    expect(document.body).toBeTruthy();
+    expect(typeof window.sessionStorage.setItem).toBe('function');
+  });
+
+  it('mounts a sphere-ui component through React Testing Library', () => {
+    render(<Button>Unlock</Button>);
+    expect(screen.getByRole('button', { name: 'Unlock' })).toBeTruthy();
+  });
+});

--- a/browser/src/test/fakeConnectClient.ts
+++ b/browser/src/test/fakeConnectClient.ts
@@ -1,0 +1,133 @@
+/**
+ * Test double for ConnectClient.
+ *
+ * useWalletConnect is the unit under test, so the SDK client is replaced wholesale:
+ * connect() resolves immediately and the test drives auto-pushed wallet events with emit(),
+ * exactly as ConnectHost.pushClientEvent would.
+ *
+ * It lives in its own module because a vi.mock factory is hoisted above the test file's own
+ * declarations and therefore cannot close over them — the factory pulls this in with a
+ * dynamic import instead.
+ *
+ * Deliberately has NO resubscribeAll(): the host re-arms suspended subscriptions itself in
+ * updateSphere(), before it pushes wallet:unlocked. A client-side re-subscribe would mean a
+ * dApp that never upgrades loses its event streams forever.
+ */
+import type { PublicIdentity } from '@unicitylabs/sphere-sdk/connect';
+
+export const FAKE_IDENTITY: PublicIdentity = {
+  chainPubkey: '02aaaa000000000000000000000000000000000000000000000000000000000000',
+  directAddress: 'DIRECT://aaaa000000000000000000000000000000000000000000000000000000000000',
+  nametag: 'alice',
+};
+
+/** A DIFFERENT wallet — what "Forgot password -> restore from recovery phrase" installs. */
+export const OTHER_IDENTITY: PublicIdentity = {
+  chainPubkey: '02bbbb000000000000000000000000000000000000000000000000000000000000',
+  directAddress: 'DIRECT://bbbb000000000000000000000000000000000000000000000000000000000000',
+  nametag: 'mallory',
+};
+
+export interface FakeClientOptions {
+  transport: unknown;
+  dapp: unknown;
+  network?: unknown;
+  resumeSessionId?: string;
+  silent?: boolean;
+}
+
+export class FakeConnectClient {
+  static instances: FakeConnectClient[] = [];
+  static nextIdentity: PublicIdentity = FAKE_IDENTITY;
+  static nextSessionId = 'session-1';
+  /** Connect protocol version the wallet reports. '2.0' = legacy lock semantics. */
+  static nextWalletProtocol = '2.1';
+  /** ConnectResult.locked — a resume handshake that landed on a LOCKED but live wallet. */
+  static nextLocked = false;
+
+  static reset(): void {
+    FakeConnectClient.instances = [];
+    FakeConnectClient.nextIdentity = FAKE_IDENTITY;
+    FakeConnectClient.nextSessionId = 'session-1';
+    FakeConnectClient.nextWalletProtocol = '2.1';
+    FakeConnectClient.nextLocked = false;
+  }
+
+  /** Never index the array directly — browser/tsconfig.json has noUncheckedIndexedAccess. */
+  static get last(): FakeConnectClient {
+    const last = FakeConnectClient.instances[FakeConnectClient.instances.length - 1];
+    if (!last) throw new Error('No FakeConnectClient has been constructed');
+    return last;
+  }
+
+  readonly options: FakeClientOptions;
+  readonly queries: string[] = [];
+  /** Every event name the hook registered a handler for, in order. */
+  readonly onCalls: string[] = [];
+  readonly walletProtocol: string;
+  walletLocked: boolean;
+  session: string | null = null;
+  disconnectCalls = 0;
+  queryResult: unknown = null;
+  /** Set to make the next query()/intent() reject with this value. */
+  queryError: unknown = null;
+
+  private readonly handlers = new Map<string, Set<(data: unknown) => void>>();
+
+  constructor(options: FakeClientOptions) {
+    this.options = options;
+    this.walletProtocol = FakeConnectClient.nextWalletProtocol;
+    this.walletLocked = FakeConnectClient.nextLocked;
+    FakeConnectClient.instances.push(this);
+  }
+
+  async connect(): Promise<{
+    sessionId: string;
+    permissions: string[];
+    identity: PublicIdentity;
+    locked?: boolean;
+  }> {
+    this.session = FakeConnectClient.nextSessionId;
+    return {
+      sessionId: FakeConnectClient.nextSessionId,
+      permissions: ['identity:read', 'balance:read'],
+      identity: FakeConnectClient.nextIdentity,
+      locked: FakeConnectClient.nextLocked,
+    };
+  }
+
+  async disconnect(): Promise<void> {
+    this.disconnectCalls += 1;
+    this.session = null;
+  }
+
+  async query<T>(method: string): Promise<T> {
+    this.queries.push(method);
+    if (this.queryError) throw this.queryError;
+    return this.queryResult as T;
+  }
+
+  async intent<T>(action: string): Promise<T> {
+    this.queries.push(action);
+    if (this.queryError) throw this.queryError;
+    return this.queryResult as T;
+  }
+
+  on(event: string, handler: (data: unknown) => void): () => void {
+    this.onCalls.push(event);
+    let set = this.handlers.get(event);
+    if (!set) {
+      set = new Set();
+      this.handlers.set(event, set);
+    }
+    set.add(handler);
+    return () => {
+      this.handlers.get(event)?.delete(handler);
+    };
+  }
+
+  /** Deliver an auto-pushed wallet event to every registered handler. */
+  emit(event: string, data: unknown): void {
+    for (const handler of [...(this.handlers.get(event) ?? [])]) handler(data);
+  }
+}

--- a/browser/src/test/fakeConnectClient.ts
+++ b/browser/src/test/fakeConnectClient.ts
@@ -44,6 +44,12 @@ export class FakeConnectClient {
   static nextWalletProtocol = '2.1';
   /** ConnectResult.locked — a resume handshake that landed on a LOCKED but live wallet. */
   static nextLocked = false;
+  /**
+   * Makes the NEXT connect() reject. Models the two ways a handshake fails against a wallet
+   * that cannot serve yet: the readiness wait timing out, and the SDK's errorless empty
+   * refusal from a host built behind the lock screen.
+   */
+  static nextConnectError: Error | null = null;
 
   static reset(): void {
     FakeConnectClient.instances = [];
@@ -51,6 +57,7 @@ export class FakeConnectClient {
     FakeConnectClient.nextSessionId = 'session-1';
     FakeConnectClient.nextWalletProtocol = '2.1';
     FakeConnectClient.nextLocked = false;
+    FakeConnectClient.nextConnectError = null;
   }
 
   /** Never index the array directly — browser/tsconfig.json has noUncheckedIndexedAccess. */
@@ -87,6 +94,9 @@ export class FakeConnectClient {
     identity: PublicIdentity;
     locked?: boolean;
   }> {
+    if (FakeConnectClient.nextConnectError) {
+      throw FakeConnectClient.nextConnectError;
+    }
     this.session = FakeConnectClient.nextSessionId;
     return {
       sessionId: FakeConnectClient.nextSessionId,

--- a/browser/vitest.config.ts
+++ b/browser/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    // Required so @testing-library/react can register its automatic cleanup() on the
+    // global afterEach — without it, mounted components leak between tests.
+    globals: true,
+    environment: 'jsdom',
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    // Every vi.spyOn (window.open, …) is undone between tests.
+    restoreMocks: true,
+  },
+});

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -8,35 +8,120 @@
       "name": "sphere-connect-nodejs-example",
       "version": "0.0.0",
       "dependencies": {
-        "@unicitylabs/sphere-sdk": "0.12.0",
+        "@unicitylabs/sphere-sdk": "file:../../sphere-sdk",
         "ws": "^8.18.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/ws": "^8.18.1",
         "tsx": "^4.19.0",
-        "typescript": "~5.6.0"
+        "typescript": "~5.6.0",
+        "vitest": "^4.1.10"
       }
     },
-    "node_modules/@chainsafe/is-ip": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.1.0.tgz",
-      "integrity": "sha512-KIjt+6IfysQ4GCv66xihEitBjvhU/bixbbbFxdJ1sqCp4uJ0wuZiYBPhksZoy4lfaF0k9cwNzY5upEW/VWdw3w==",
+    "../../sphere-sdk": {
+      "name": "@unicitylabs/sphere-sdk",
+      "version": "0.12.0",
       "license": "MIT",
-      "optional": true
+      "dependencies": {
+        "@noble/ciphers": "^2.2.0",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "@unicitylabs/nostr-js-sdk": "^0.6.0",
+        "@unicitylabs/state-transition-sdk": "2.0.1",
+        "bip39": "^3.1.0",
+        "buffer": "^6.0.3",
+        "canonicalize": "^3.0.0",
+        "crypto-js": "^4.2.0"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.39.2",
+        "@libp2p/bootstrap": "^12.0.11",
+        "@libp2p/crypto": "^5.1.13",
+        "@libp2p/interface": "^3.1.0",
+        "@libp2p/peer-id": "^6.0.4",
+        "@types/crypto-js": "^4.2.2",
+        "@types/node": "^22.0.0",
+        "@types/ws": "^8.18.1",
+        "@typescript-eslint/eslint-plugin": "^8.54.0",
+        "@typescript-eslint/parser": "^8.54.0",
+        "eslint": "^9.39.2",
+        "fake-indexeddb": "^6.2.5",
+        "multiformats": "^13.4.2",
+        "testcontainers": "^11.11.0",
+        "tsup": "^8.5.1",
+        "tsx": "^4.21.0",
+        "typescript": "~5.6.0",
+        "typescript-eslint": "^8.54.0",
+        "vitest": "^2.0.0",
+        "ws": "^8.18.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "@libp2p/crypto": "^5.1.13",
+        "@libp2p/peer-id": "^6.0.4",
+        "ipns": "^10.0.0",
+        "multiformats": "^13.4.2"
+      },
+      "peerDependencies": {
+        "@libp2p/crypto": ">=5.0.0",
+        "@libp2p/peer-id": ">=6.0.0",
+        "ipns": ">=10.0.0",
+        "multiformats": ">=13.0.0",
+        "ws": ">=8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@libp2p/crypto": {
+          "optional": true
+        },
+        "@libp2p/peer-id": {
+          "optional": true
+        },
+        "ipns": {
+          "optional": true
+        },
+        "multiformats": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
     },
-    "node_modules/@dnsquery/dns-packet": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@dnsquery/dns-packet/-/dns-packet-6.1.1.tgz",
-      "integrity": "sha512-WXTuFvL3G+74SchFAtz3FgIYVOe196ycvGsMgvSH/8Goptb1qpIQtIuM4SOK9G9lhMWYpHxnXyy544ZhluFOew==",
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@leichtgewicht/ip-codec": "^2.0.4",
-        "utf8-codec": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -481,213 +566,348 @@
         "node": ">=18"
       }
     },
-    "node_modules/@leichtgewicht/ip-codec": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
-      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
       "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@libp2p/crypto": {
-      "version": "5.1.20",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.20.tgz",
-      "integrity": "sha512-sPz+CvDWPDb+O8xYsueXDdrV6Kf7PciNEYvcCjOR/VqM0iHwzC7aaM0xPiQqrUDj1nggswbY/E/vNZYJ4aCQaA==",
-      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "dependencies": {
-        "@libp2p/interface": "^3.2.4",
-        "@noble/curves": "^2.0.1",
-        "@noble/hashes": "^2.0.1",
-        "multiformats": "^14.0.0",
-        "protons-runtime": "^7.0.0",
-        "uint8arraylist": "^3.0.2",
-        "uint8arrays": "^6.1.1"
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
-    "node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/@libp2p/interface": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.4.tgz",
-      "integrity": "sha512-o/ZMbsplniVQhz0AW1CinZcfZPEfr7ttu4w7aivrFAs6xDpnJYmN3FTeEgTt93EHs+AEOcIT76V3KMFDZmIEcQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@multiformats/dns": "^1.0.6",
-        "@multiformats/multiaddr": "^13.0.3",
-        "main-event": "^1.0.1",
-        "multiformats": "^14.0.0",
-        "progress-events": "^1.1.0",
-        "uint8arraylist": "^3.0.2"
-      }
-    },
-    "node_modules/@libp2p/interface/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/@libp2p/logger": {
-      "version": "6.2.9",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.9.tgz",
-      "integrity": "sha512-hjuF81KSt9dWNPJZcdJ4SHEuygMLHrPZVTGNzCWu+2jxpJqOHWy9CJS8llLH7pgbDtlq4jJ4uuqihCR5Gjo4gA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@libp2p/interface": "^3.2.4",
-        "@multiformats/multiaddr": "^13.0.3",
-        "interface-datastore": "^10.0.1",
-        "multiformats": "^14.0.0",
-        "weald": "^1.1.0"
-      }
-    },
-    "node_modules/@libp2p/logger/node_modules/interface-datastore": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-10.0.1.tgz",
-      "integrity": "sha512-DYMj/Og5Cz1Qwkx6/x5KRvR8SYEX7rVAv3KKCm2NzTwWSfpNAC4PahjcYbHyoZBP6zPWrhQv5n5wE+vaDdgSAg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "abort-error": "^1.0.2",
-        "interface-store": "^8.0.0",
-        "uint8arrays": "^6.1.1"
-      }
-    },
-    "node_modules/@libp2p/logger/node_modules/interface-store": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-8.0.0.tgz",
-      "integrity": "sha512-e2+s3EEROzM+Wlas4hU3zveTUscvVMf1BOvdsJfpzFm19SoEXLVadpACjWOnM491HqGpvtfFnevyiaN8W+I6Eg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "abort-error": "^1.0.2"
-      }
-    },
-    "node_modules/@libp2p/logger/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/@libp2p/peer-id": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.11.tgz",
-      "integrity": "sha512-p2Sw8y12gcrmDYGTrbvGQzMhM7ypquCfQX5WdhitI0+ArTSRHHXt7ozdpUWzcq7CNaK5r2q6FIbpz9Yxywg9Hw==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@libp2p/crypto": "^5.1.20",
-        "@libp2p/interface": "^3.2.4",
-        "multiformats": "^14.0.0",
-        "uint8arrays": "^6.1.1"
-      }
-    },
-    "node_modules/@libp2p/peer-id/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/@multiformats/dns": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.13.tgz",
-      "integrity": "sha512-yr4bxtA3MbvJ+2461kYIYMsiiZj/FIqKI64hE4SdvWJUdWF9EtZLar38juf20Sf5tguXKFUruluswAO6JsjS2w==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@dnsquery/dns-packet": "^6.1.1",
-        "@libp2p/interface": "^3.1.0",
-        "hashlru": "^2.3.0",
-        "p-queue": "^9.0.0",
-        "progress-events": "^1.0.0",
-        "uint8arrays": "^5.0.2"
-      }
-    },
-    "node_modules/@multiformats/dns/node_modules/uint8arrays": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
-      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
-    },
-    "node_modules/@multiformats/multiaddr": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-13.0.3.tgz",
-      "integrity": "sha512-mEqqJ4r3a/uuFMTpRkU316wGNIDQNhuVWpm+ebKTQeYsfv9jXbPONWM6VVnj3KGUrwfsX7GZOyp4TFqEA2SPCw==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@chainsafe/is-ip": "^2.0.1",
-        "multiformats": "^14.0.0",
-        "uint8-varint": "^3.0.0",
-        "uint8arrays": "^6.1.1"
-      }
-    },
-    "node_modules/@multiformats/multiaddr/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/@noble/ciphers": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
-      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
       "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
       "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
-    "node_modules/@scure/base": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
-      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.19.11",
@@ -709,223 +929,165 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@unicitylabs/nostr-js-sdk": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/nostr-js-sdk/-/nostr-js-sdk-0.6.0.tgz",
-      "integrity": "sha512-l6WcCmFok9nxI1WkYsjIVu67svouA2QyB5Vb+GTNugWrbw7hUgJMA1Elj8qu3u0qojvSINL/L9eWTmXVWRzZUw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/ciphers": "^1.0.0",
-        "@noble/curves": "^1.6.0",
-        "@noble/hashes": "^1.5.0",
-        "@scure/base": "^1.1.9",
-        "libphonenumber-js": "^1.11.14"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.12.0.tgz",
-      "integrity": "sha512-y3t64uac9cjKLmhgbVav5nCfz5iyovJ9YofSKeTr+Zl6dsp9rshsuJXPtMJELu1Sze8f8A7qvpu997QnD5q3Tw==",
+      "resolved": "../../sphere-sdk",
+      "link": true
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@noble/ciphers": "^2.2.0",
-        "@noble/curves": "^2.0.1",
-        "@noble/hashes": "^2.0.1",
-        "@unicitylabs/nostr-js-sdk": "^0.6.0",
-        "@unicitylabs/state-transition-sdk": "2.0.1",
-        "bip39": "^3.1.0",
-        "buffer": "^6.0.3",
-        "canonicalize": "^3.0.0",
-        "crypto-js": "^4.2.0"
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
-      "engines": {
-        "node": ">=22.0.0"
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
       },
-      "optionalDependencies": {
-        "@libp2p/crypto": "^5.1.13",
-        "@libp2p/peer-id": "^6.0.4",
-        "ipns": "^10.0.0",
-        "multiformats": "^13.4.2"
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@libp2p/crypto": ">=5.0.0",
-        "@libp2p/peer-id": ">=6.0.0",
-        "ipns": ">=10.0.0",
-        "multiformats": ">=13.0.0",
-        "ws": ">=8.0.0"
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
-        "@libp2p/crypto": {
+        "msw": {
           "optional": true
         },
-        "@libp2p/peer-id": {
-          "optional": true
-        },
-        "ipns": {
-          "optional": true
-        },
-        "multiformats": {
-          "optional": true
-        },
-        "ws": {
+        "vite": {
           "optional": true
         }
       }
     },
-    "node_modules/@unicitylabs/state-transition-sdk": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/state-transition-sdk/-/state-transition-sdk-2.0.1.tgz",
-      "integrity": "sha512-O0pjxaL32VgHYjSM3Ei64UWBG2qwBzdQ9aIdlyhzTnPdI+kKu3h9saSMF1uV9XTfqKHsNGUpE/2dFUulNfmdmg==",
-      "license": "ISC",
-      "dependencies": {
-        "@noble/curves": "2.2.0",
-        "@noble/hashes": "2.2.0",
-        "uuid": "14.0.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/abort-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/abort-error/-/abort-error-1.0.2.tgz",
-      "integrity": "sha512-lVgvB2NyPLqbXXhVmXcYFTC1x5K7CiVdPgdY7LGgFQWC8506oN01sPN3i9cl9ynuwF4iJ0TS9exnR7cZ9FuX4w==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/bip39": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
-      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
-      "license": "ISC",
-      "dependencies": {
-        "@noble/hashes": "^1.2.0"
-      }
-    },
-    "node_modules/bip39/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
-        "url": "https://paulmillr.com/funding/"
+        "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/canonicalize": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-3.0.0.tgz",
-      "integrity": "sha512-yYLfHyDMIXRyRqsKBRLX023riFLpXY2YOfdtqKXZRZy9qsfOJ9U+4F9YZL7MEzL5+ziN2x2nlBvY/Voi3EBljA==",
-      "license": "Apache-2.0",
-      "bin": {
-        "canonicalize": "bin/canonicalize.js"
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
       },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/cborg": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.1.tgz",
-      "integrity": "sha512-BDbSRIp6XrQXkTc7g+DN0RB9RrDPTUfals2ecWUlt3juPLjbAvy/V72mJcXY0Ehu0Dq/3WpNCOCT68HUTbW+lw==",
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
-      "bin": {
-        "cborg": "lib/bin.js"
+      "engines": {
+        "node": ">=8"
       }
     },
-    "node_modules/crypto-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
@@ -970,12 +1132,43 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
       "license": "MIT",
-      "optional": true
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1005,200 +1198,364 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "node_modules/hashlru": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
-      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==",
-      "license": "MIT",
-      "optional": true
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
+          "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/interface-datastore": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-9.0.3.tgz",
-      "integrity": "sha512-NLZa7Mp+0qn48nSwIY/C36da4uVIKzwG2tuEIpaSJArsuB2RrdyDWwkoDUyjsJ+VrMntXz38VSk9vXTx/ZUpAw==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "interface-store": "^7.0.0",
-        "uint8arrays": "^5.1.0"
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/interface-datastore/node_modules/uint8arrays": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
-      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "multiformats": "^13.0.0"
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
-    "node_modules/interface-store": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-7.0.2.tgz",
-      "integrity": "sha512-KYOPcDH+1peaPhSeoZujR5nwkVeola1EdrnrlHTIM0HRNUs9B0aTsUQMH5kTmIjaQq1BOowoUyoCamgL8IMyww==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/ipns": {
-      "version": "10.1.6",
-      "resolved": "https://registry.npmjs.org/ipns/-/ipns-10.1.6.tgz",
-      "integrity": "sha512-mTACIdTBBXY5kbCo3t/M3ycNWbjajLrSXhTvjD0MEGyOUaI3uMv94JbJSHGaJ2xxRlpOrRk1ifToOsyPZiglnA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@libp2p/crypto": "^5.0.0",
-        "@libp2p/interface": "^3.0.2",
-        "@libp2p/logger": "^6.0.4",
-        "cborg": "^5.1.0",
-        "interface-datastore": "^9.0.2",
-        "multiformats": "^13.2.2",
-        "protons-runtime": "^6.0.1",
-        "timestamp-nano": "^1.0.1",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.1.0"
-      }
-    },
-    "node_modules/ipns/node_modules/protons-runtime": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
-      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8-varint": "^2.0.4",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.1.0"
-      }
-    },
-    "node_modules/ipns/node_modules/uint8-varint": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.5.tgz",
-      "integrity": "sha512-jeFLbL/x30wBRnWjKE1qVBXeumG46r7XmYkpis955lTQ+blccGKFrOsSMHlxePwYB1pI7L8YPHz1t4jLxEs3nA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/ipns/node_modules/uint8arraylist": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.9.tgz",
-      "integrity": "sha512-KxWjyEFzchzik3aoQlK66oaoxIReoMo5bQRm1fcjBUZvE8xv/tyR3CTKhjh6K/faV8VaF6hd5pjr45CzbwuwkA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8arrays": "^5.0.1"
-      }
-    },
-    "node_modules/ipns/node_modules/uint8arrays": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
-      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
-    },
-    "node_modules/libphonenumber-js": {
-      "version": "1.13.9",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.9.tgz",
-      "integrity": "sha512-VNS5vWMM7r0P66BYv+TQJATxExEgLxN+34hfHDVhDkUsGAE4cRg0shCNSLTXNKm7nIUscC7AfB51TjxEeF7msQ==",
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
-    "node_modules/main-event": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/main-event/-/main-event-1.0.4.tgz",
-      "integrity": "sha512-sKazUjIy2Jalv5lkQ446iOcrx8Q7TkaCuk6xfnzg5uUqMusMLDMPmRDmSNE2kjSVpSTJo4j1bQZusS+Ib7Bvrg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
-    "node_modules/ms": {
-      "version": "4.0.0-nightly.202508271359",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-4.0.0-nightly.202508271359.tgz",
-      "integrity": "sha512-WC/Eo7NzFrOV/RRrTaI0fxKVbNCzEy76j2VqNV8SxDf9D69gSE2Lh0QwYvDlhiYmheBYExAvEAxVf5NoN0cj2A==",
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/multiformats": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
-      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/p-queue": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
-      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "eventemitter3": "^5.0.4",
-        "p-timeout": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=20"
+        "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/p-timeout": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
-      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+    "node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/progress-events": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.1.0.tgz",
-      "integrity": "sha512-82DVc5tI36neVB3IjdXR11ztwGuoBc98em9ijzubeZKxI47OlV2Znq6mlPqE5xPDzO2Uw98GHiQSjj2favBCRQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/protons-runtime": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-7.0.0.tgz",
-      "integrity": "sha512-r/e72006xoVND4Uvf1aIs4OQOkJaASBU3ip4DzOWAktoKAkTiOYqKoS3TYMBm8HnnYU8+h0uEzr5gIRwk/pmTg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
       "dependencies": {
-        "uint8-varint": "^3.0.0",
-        "uint8arraylist": "^3.0.0",
-        "uint8arrays": "^6.0.0"
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -1211,28 +1568,122 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
-    "node_modules/supports-color": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
-      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
-    "node_modules/timestamp-nano": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/timestamp-nano/-/timestamp-nano-1.0.1.tgz",
-      "integrity": "sha512-4oGOVZWTu5sl89PtCDnhQBSt7/vL1zVEwAfxH1p49JhTosxzVQWYBYFRFZ8nJmo0G6f824iyP/44BFAwIoKvIA==",
-      "license": "MIT",
-      "optional": true,
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
-        "node": ">= 4.5.0"
+        "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -1268,44 +1719,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/uint8-varint": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-3.0.0.tgz",
-      "integrity": "sha512-S4DdpXBaLwKcFo7f0bWzWfHjbZ/i3QhM842qn+ZvHjxqFCfUcEB9SQNcmI69S+zMlcmIcKxsk9Iyw77S2Kxv6Q==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8arraylist": "^3.0.1",
-        "uint8arrays": "^6.1.0"
-      }
-    },
-    "node_modules/uint8arraylist": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-3.0.2.tgz",
-      "integrity": "sha512-LDVoq9BQaGJzGDUovEnoX6rpKCvnY/Jbtws4ikwnBzjRbq5qBAFpBZevUEbSmMM87aO0Sp+wOZy2ZXf5yODmXQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8arrays": "^6.0.0"
-      }
-    },
-    "node_modules/uint8arrays": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-6.1.1.tgz",
-      "integrity": "sha512-iz7JN0XCSZYA111lhFG2Ui9EhFvTNekqSRHw3lvMHq+dzwWy1OQftxFQREEh4rffU0oSoXdQHsk2TiHKVm4fsA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "multiformats": "^14.0.0"
-      }
-    },
-    "node_modules/uint8arrays/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -1313,35 +1726,189 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/utf8-codec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utf8-codec/-/utf8-codec-1.0.0.tgz",
-      "integrity": "sha512-S/QSLezp3qvG4ld5PUfXiH7mCFxLKjSVZRFkB3DOjgwHuJPFDkInAXc/anf7BAbHt/D38ozDzL+QMZ6/7gsI6w==",
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
       "license": "MIT",
-      "optional": true
-    },
-    "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
       "bin": {
-        "uuid": "dist-node/bin/uuid"
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
-    "node_modules/weald": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/weald/-/weald-1.1.3.tgz",
-      "integrity": "sha512-vMWtNbYuPb58NeG2+0sKA0Een4VMDwzf+3oHqh68buWRSOMUBlUeRb11LhV28czV+DUpJHRykifijZDuS9bInA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ms": "^4.0.0-nightly.202508271359",
-        "supports-color": "^10.0.0"
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ws": {

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "sphere-connect-nodejs-example",
       "version": "0.0.0",
       "dependencies": {
-        "@unicitylabs/sphere-sdk": "file:../../sphere-sdk",
+        "@unicitylabs/sphere-sdk": "0.13.0",
         "ws": "^8.18.0"
       },
       "devDependencies": {
@@ -19,75 +19,25 @@
         "vitest": "^4.1.10"
       }
     },
-    "../../sphere-sdk": {
-      "name": "@unicitylabs/sphere-sdk",
-      "version": "0.12.0",
+    "node_modules/@chainsafe/is-ip": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.1.0.tgz",
+      "integrity": "sha512-KIjt+6IfysQ4GCv66xihEitBjvhU/bixbbbFxdJ1sqCp4uJ0wuZiYBPhksZoy4lfaF0k9cwNzY5upEW/VWdw3w==",
       "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@dnsquery/dns-packet": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@dnsquery/dns-packet/-/dns-packet-6.1.1.tgz",
+      "integrity": "sha512-WXTuFvL3G+74SchFAtz3FgIYVOe196ycvGsMgvSH/8Goptb1qpIQtIuM4SOK9G9lhMWYpHxnXyy544ZhluFOew==",
+      "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "@noble/ciphers": "^2.2.0",
-        "@noble/curves": "^2.0.1",
-        "@noble/hashes": "^2.0.1",
-        "@unicitylabs/nostr-js-sdk": "^0.6.0",
-        "@unicitylabs/state-transition-sdk": "2.0.1",
-        "bip39": "^3.1.0",
-        "buffer": "^6.0.3",
-        "canonicalize": "^3.0.0",
-        "crypto-js": "^4.2.0"
-      },
-      "devDependencies": {
-        "@eslint/js": "^9.39.2",
-        "@libp2p/bootstrap": "^12.0.11",
-        "@libp2p/crypto": "^5.1.13",
-        "@libp2p/interface": "^3.1.0",
-        "@libp2p/peer-id": "^6.0.4",
-        "@types/crypto-js": "^4.2.2",
-        "@types/node": "^22.0.0",
-        "@types/ws": "^8.18.1",
-        "@typescript-eslint/eslint-plugin": "^8.54.0",
-        "@typescript-eslint/parser": "^8.54.0",
-        "eslint": "^9.39.2",
-        "fake-indexeddb": "^6.2.5",
-        "multiformats": "^13.4.2",
-        "testcontainers": "^11.11.0",
-        "tsup": "^8.5.1",
-        "tsx": "^4.21.0",
-        "typescript": "~5.6.0",
-        "typescript-eslint": "^8.54.0",
-        "vitest": "^2.0.0",
-        "ws": "^8.18.1"
+        "@leichtgewicht/ip-codec": "^2.0.4",
+        "utf8-codec": "^1.0.0"
       },
       "engines": {
-        "node": ">=22.0.0"
-      },
-      "optionalDependencies": {
-        "@libp2p/crypto": "^5.1.13",
-        "@libp2p/peer-id": "^6.0.4",
-        "ipns": "^10.0.0",
-        "multiformats": "^13.4.2"
-      },
-      "peerDependencies": {
-        "@libp2p/crypto": ">=5.0.0",
-        "@libp2p/peer-id": ">=6.0.0",
-        "ipns": ">=10.0.0",
-        "multiformats": ">=13.0.0",
-        "ws": ">=8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@libp2p/crypto": {
-          "optional": true
-        },
-        "@libp2p/peer-id": {
-          "optional": true
-        },
-        "ipns": {
-          "optional": true
-        },
-        "multiformats": {
-          "optional": true
-        },
-        "ws": {
-          "optional": true
-        }
+        "node": ">=6"
       }
     },
     "node_modules/@emnapi/core": {
@@ -573,6 +523,156 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/crypto": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
+      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/interface": "^3.2.5",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "multiformats": "^14.0.0",
+        "protons-runtime": "^7.0.0",
+        "uint8arraylist": "^3.0.2",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/crypto/node_modules/multiformats": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/interface": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
+      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@multiformats/dns": "^1.0.6",
+        "@multiformats/multiaddr": "^13.0.3",
+        "main-event": "^1.0.1",
+        "multiformats": "^14.0.0",
+        "progress-events": "^1.1.0",
+        "uint8arraylist": "^3.0.2"
+      }
+    },
+    "node_modules/@libp2p/interface/node_modules/multiformats": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/logger": {
+      "version": "6.2.11",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.11.tgz",
+      "integrity": "sha512-zZ4m2EKyyRY2G8GAzmG/ZJm4CIqmaJucl5X7zTmGs1SXlb4Ayj4aP1vsaP/cVWadf/RuPWjgmIJP+Y/sZoE7Rg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/interface": "^3.2.5",
+        "@multiformats/multiaddr": "^13.0.3",
+        "interface-datastore": "^10.0.1",
+        "multiformats": "^14.0.0",
+        "weald": "^1.1.0"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/interface-datastore": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-10.0.1.tgz",
+      "integrity": "sha512-DYMj/Og5Cz1Qwkx6/x5KRvR8SYEX7rVAv3KKCm2NzTwWSfpNAC4PahjcYbHyoZBP6zPWrhQv5n5wE+vaDdgSAg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "abort-error": "^1.0.2",
+        "interface-store": "^8.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/interface-store": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-8.0.0.tgz",
+      "integrity": "sha512-e2+s3EEROzM+Wlas4hU3zveTUscvVMf1BOvdsJfpzFm19SoEXLVadpACjWOnM491HqGpvtfFnevyiaN8W+I6Eg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "abort-error": "^1.0.2"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/multiformats": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/peer-id": {
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.13.tgz",
+      "integrity": "sha512-A3sP3QUjunp7Wo5aGOkRsuYtGJZbLD4KPlHKObMam1fUCx+gHKnfyKeaWMQLkjeaUNETz9R6llquWyi41QzkLg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/interface": "^3.2.5",
+        "multiformats": "^14.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/peer-id/node_modules/multiformats": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@multiformats/dns": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.15.tgz",
+      "integrity": "sha512-W0zAMABtAn+3chgFcPGvllKND7M6GblMAAFcJQTy+iMmGiyFErZYPzAh2b50Y3SFf340iFV7+ckVgZkGfUyxzA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@dnsquery/dns-packet": "^6.1.1",
+        "@libp2p/interface": "^3.1.0",
+        "hashlru": "^2.3.0",
+        "p-queue": "^9.0.0",
+        "progress-events": "^1.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@multiformats/multiaddr": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-13.0.3.tgz",
+      "integrity": "sha512-mEqqJ4r3a/uuFMTpRkU316wGNIDQNhuVWpm+ebKTQeYsfv9jXbPONWM6VVnj3KGUrwfsX7GZOyp4TFqEA2SPCw==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "multiformats": "^14.0.0",
+        "uint8-varint": "^3.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/multiformats": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -590,6 +690,45 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -866,6 +1005,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -929,9 +1077,124 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@unicitylabs/nostr-js-sdk": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/nostr-js-sdk/-/nostr-js-sdk-0.6.0.tgz",
+      "integrity": "sha512-l6WcCmFok9nxI1WkYsjIVu67svouA2QyB5Vb+GTNugWrbw7hUgJMA1Elj8qu3u0qojvSINL/L9eWTmXVWRzZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^1.0.0",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/base": "^1.1.9",
+        "libphonenumber-js": "^1.11.14"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "resolved": "../../sphere-sdk",
-      "link": true
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.13.0.tgz",
+      "integrity": "sha512-uK7/xplYUNwsQ+tKJDDVClWXYxz9x7gKP8aVoSbJAbrGshG1XsG7D260AUDfIvG+pSONRfwX42ga3lW3TT/dmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^2.2.0",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "@unicitylabs/nostr-js-sdk": "^0.6.0",
+        "@unicitylabs/state-transition-sdk": "2.0.1",
+        "bip39": "^3.1.0",
+        "buffer": "^6.0.3",
+        "canonicalize": "^3.0.0",
+        "crypto-js": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "@libp2p/crypto": "^5.1.13",
+        "@libp2p/peer-id": "^6.0.4",
+        "ipns": "^10.0.0",
+        "multiformats": "^13.4.2"
+      },
+      "peerDependencies": {
+        "@libp2p/crypto": ">=5.0.0",
+        "@libp2p/peer-id": ">=6.0.0",
+        "ipns": ">=10.0.0",
+        "multiformats": ">=13.0.0",
+        "ws": ">=8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@libp2p/crypto": {
+          "optional": true
+        },
+        "@libp2p/peer-id": {
+          "optional": true
+        },
+        "ipns": {
+          "optional": true
+        },
+        "multiformats": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@unicitylabs/state-transition-sdk": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/state-transition-sdk/-/state-transition-sdk-2.0.1.tgz",
+      "integrity": "sha512-O0pjxaL32VgHYjSM3Ei64UWBG2qwBzdQ9aIdlyhzTnPdI+kKu3h9saSMF1uV9XTfqKHsNGUpE/2dFUulNfmdmg==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "uuid": "14.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.10",
@@ -1046,6 +1309,13 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abort-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/abort-error/-/abort-error-1.0.2.tgz",
+      "integrity": "sha512-lVgvB2NyPLqbXXhVmXcYFTC1x5K7CiVdPgdY7LGgFQWC8506oN01sPN3i9cl9ynuwF4iJ0TS9exnR7cZ9FuX4w==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1054,6 +1324,93 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bip39": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
+      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0"
+      }
+    },
+    "node_modules/bip39/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/canonicalize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-3.0.0.tgz",
+      "integrity": "sha512-yYLfHyDMIXRyRqsKBRLX023riFLpXY2YOfdtqKXZRZy9qsfOJ9U+4F9YZL7MEzL5+ziN2x2nlBvY/Voi3EBljA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cborg": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.8.tgz",
+      "integrity": "sha512-enonPtLyeEF8M8GF/5NdjLHmRGslrwKR2LvkN+yFYQJw7mzt6iOoPvkVs3vcb3rUvltzL0QfvtM6FQ44o8nhSg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "bin": {
+        "cborg": "lib/bin.js"
       }
     },
     "node_modules/chai": {
@@ -1071,6 +1428,12 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
       "license": "MIT"
     },
     "node_modules/detect-libc": {
@@ -1142,6 +1505,13 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -1197,6 +1567,129 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/interface-datastore": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-9.0.3.tgz",
+      "integrity": "sha512-NLZa7Mp+0qn48nSwIY/C36da4uVIKzwG2tuEIpaSJArsuB2RrdyDWwkoDUyjsJ+VrMntXz38VSk9vXTx/ZUpAw==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "interface-store": "^7.0.0",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/interface-datastore/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/interface-store": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-7.0.2.tgz",
+      "integrity": "sha512-KYOPcDH+1peaPhSeoZujR5nwkVeola1EdrnrlHTIM0HRNUs9B0aTsUQMH5kTmIjaQq1BOowoUyoCamgL8IMyww==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/ipns": {
+      "version": "10.1.6",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-10.1.6.tgz",
+      "integrity": "sha512-mTACIdTBBXY5kbCo3t/M3ycNWbjajLrSXhTvjD0MEGyOUaI3uMv94JbJSHGaJ2xxRlpOrRk1ifToOsyPZiglnA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/crypto": "^5.0.0",
+        "@libp2p/interface": "^3.0.2",
+        "@libp2p/logger": "^6.0.4",
+        "cborg": "^5.1.0",
+        "interface-datastore": "^9.0.2",
+        "multiformats": "^13.2.2",
+        "protons-runtime": "^6.0.1",
+        "timestamp-nano": "^1.0.1",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/ipns/node_modules/protons-runtime": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8-varint": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.5.tgz",
+      "integrity": "sha512-jeFLbL/x30wBRnWjKE1qVBXeumG46r7XmYkpis955lTQ+blccGKFrOsSMHlxePwYB1pI7L8YPHz1t4jLxEs3nA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8arraylist": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.9.tgz",
+      "integrity": "sha512-KxWjyEFzchzik3aoQlK66oaoxIReoMo5bQRm1fcjBUZvE8xv/tyR3CTKhjh6K/faV8VaF6hd5pjr45CzbwuwkA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.13.9",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.9.tgz",
+      "integrity": "sha512-VNS5vWMM7r0P66BYv+TQJATxExEgLxN+34hfHDVhDkUsGAE4cRg0shCNSLTXNKm7nIUscC7AfB51TjxEeF7msQ==",
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.33.0",
@@ -1469,6 +1962,30 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/main-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/main-event/-/main-event-1.0.4.tgz",
+      "integrity": "sha512-sKazUjIy2Jalv5lkQ446iOcrx8Q7TkaCuk6xfnzg5uUqMusMLDMPmRDmSNE2kjSVpSTJo4j1bQZusS+Ib7Bvrg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/ms": {
+      "version": "4.0.0-nightly.202508271359",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-4.0.0-nightly.202508271359.tgz",
+      "integrity": "sha512-WC/Eo7NzFrOV/RRrTaI0fxKVbNCzEy76j2VqNV8SxDf9D69gSE2Lh0QwYvDlhiYmheBYExAvEAxVf5NoN0cj2A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
     "node_modules/nanoid": {
       "version": "3.3.16",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
@@ -1500,6 +2017,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.3.tgz",
+      "integrity": "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pathe": {
@@ -1556,6 +2103,25 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/progress-events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.1.0.tgz",
+      "integrity": "sha512-82DVc5tI36neVB3IjdXR11ztwGuoBc98em9ijzubeZKxI47OlV2Znq6mlPqE5xPDzO2Uw98GHiQSjj2favBCRQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/protons-runtime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-7.0.0.tgz",
+      "integrity": "sha512-r/e72006xoVND4Uvf1aIs4OQOkJaASBU3ip4DzOWAktoKAkTiOYqKoS3TYMBm8HnnYU8+h0uEzr5gIRwk/pmTg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8-varint": "^3.0.0",
+        "uint8arraylist": "^3.0.0",
+        "uint8arrays": "^6.0.0"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -1632,6 +2198,29 @@
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/timestamp-nano": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/timestamp-nano/-/timestamp-nano-1.0.1.tgz",
+      "integrity": "sha512-4oGOVZWTu5sl89PtCDnhQBSt7/vL1zVEwAfxH1p49JhTosxzVQWYBYFRFZ8nJmo0G6f824iyP/44BFAwIoKvIA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4.5.0"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -1719,12 +2308,70 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uint8-varint": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-3.0.0.tgz",
+      "integrity": "sha512-S4DdpXBaLwKcFo7f0bWzWfHjbZ/i3QhM842qn+ZvHjxqFCfUcEB9SQNcmI69S+zMlcmIcKxsk9Iyw77S2Kxv6Q==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arraylist": "^3.0.1",
+        "uint8arrays": "^6.1.0"
+      }
+    },
+    "node_modules/uint8arraylist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-3.0.2.tgz",
+      "integrity": "sha512-LDVoq9BQaGJzGDUovEnoX6rpKCvnY/Jbtws4ikwnBzjRbq5qBAFpBZevUEbSmMM87aO0Sp+wOZy2ZXf5yODmXQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arrays": "^6.0.0"
+      }
+    },
+    "node_modules/uint8arrays": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-6.1.1.tgz",
+      "integrity": "sha512-iz7JN0XCSZYA111lhFG2Ui9EhFvTNekqSRHw3lvMHq+dzwWy1OQftxFQREEh4rffU0oSoXdQHsk2TiHKVm4fsA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^14.0.0"
+      }
+    },
+    "node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/utf8-codec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utf8-codec/-/utf8-codec-1.0.0.tgz",
+      "integrity": "sha512-S/QSLezp3qvG4ld5PUfXiH7mCFxLKjSVZRFkB3DOjgwHuJPFDkInAXc/anf7BAbHt/D38ozDzL+QMZ6/7gsI6w==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/vite": {
       "version": "8.1.5",
@@ -1892,6 +2539,17 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/weald": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/weald/-/weald-1.1.3.tgz",
+      "integrity": "sha512-vMWtNbYuPb58NeG2+0sKA0Een4VMDwzf+3oHqh68buWRSOMUBlUeRb11LhV28czV+DUpJHRykifijZDuS9bInA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^4.0.0-nightly.202508271359",
+        "supports-color": "^10.0.0"
       }
     },
     "node_modules/why-is-node-running": {

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -8,7 +8,7 @@
     "client": "npx tsx src/index.ts"
   },
   "dependencies": {
-    "@unicitylabs/sphere-sdk": "0.12.0",
+    "@unicitylabs/sphere-sdk": "file:../../sphere-sdk",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -9,7 +9,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@unicitylabs/sphere-sdk": "file:../../sphere-sdk",
+    "@unicitylabs/sphere-sdk": "0.13.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "server": "npx tsx src/mock-wallet-server.ts",
-    "client": "npx tsx src/index.ts"
+    "client": "npx tsx src/index.ts",
+    "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "@unicitylabs/sphere-sdk": "file:../../sphere-sdk",
@@ -15,6 +16,7 @@
     "@types/node": "^22.0.0",
     "@types/ws": "^8.18.1",
     "tsx": "^4.19.0",
-    "typescript": "~5.6.0"
+    "typescript": "~5.6.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "server": "npx tsx src/mock-wallet-server.ts",
     "client": "npx tsx src/index.ts",
-    "test": "vitest run --passWithNoTests"
+    "test": "vitest run"
   },
   "dependencies": {
     "@unicitylabs/sphere-sdk": "file:../../sphere-sdk",

--- a/nodejs/src/index.ts
+++ b/nodejs/src/index.ts
@@ -6,8 +6,10 @@
  *   2. Run client:        npx tsx src/index.ts
  */
 
-import { ConnectClient, RPC_METHODS, INTENT_ACTIONS, SPHERE_NETWORKS } from '@unicitylabs/sphere-sdk/connect';
+import { ConnectClient, ERROR_CODES, RPC_METHODS, INTENT_ACTIONS, SPHERE_NETWORKS, WALLET_EVENTS } from '@unicitylabs/sphere-sdk/connect';
+import type { PublicIdentity } from '@unicitylabs/sphere-sdk/connect';
 import { WebSocketTransport } from '@unicitylabs/sphere-sdk/connect/nodejs';
+import { describeConnectFailure, isSameWallet } from './lockResume';
 import WebSocket from 'ws';
 import readline from 'readline';
 
@@ -39,6 +41,54 @@ async function main() {
   console.log('Session:', client.session);
   console.log('Identity:', JSON.stringify(result.identity, null, 2));
   console.log('Permissions:', result.permissions.join(', '));
+  let connectedIdentity: PublicIdentity | null = result.identity;
+  // Queries only. An intent is NEVER auto-resumed: it moves money and would fire with no fresh
+  // user gesture, at the exact moment the wallet came back.
+  let lastQuery: { method: string; params?: Record<string, unknown> } | null = null;
+
+  async function runQuery(method: string, params?: Record<string, unknown>): Promise<unknown> {
+    lastQuery = { method, params };
+    return client.query(method, params);
+  }
+
+  if (result.locked) {
+    console.log('\n[state] the wallet was LOCKED when we resumed — connected AND locked.');
+    console.log('        Requests answer 4009 until you type "unlock" in the wallet.\n');
+  }
+
+  // Auto-pushed by ConnectHost — no sphere_subscribe needed for any of these.
+  client.on(WALLET_EVENTS.LOCKED, () => {
+    console.log(`\n[EVENT] wallet:locked — session preserved; requests answer ${ERROR_CODES.WALLET_LOCKED}`);
+    showPrompt();
+  });
+  client.on(WALLET_EVENTS.UNLOCKED, (data: unknown) => {
+    const next = (data as { identity?: PublicIdentity } | undefined)?.identity ?? null;
+    if (!isSameWallet(connectedIdentity, next)) {
+      connectedIdentity = next;
+      console.log('\n[EVENT] wallet:unlocked — DIFFERENT wallet came back. Nothing resumed.');
+      console.log('        New identity:', JSON.stringify(next));
+      lastQuery = null;
+      showPrompt();
+      return;
+    }
+    // Nothing to re-subscribe: the host replayed every suspended subscription key before it
+    // pushed this event.
+    console.log('\n[EVENT] wallet:unlocked — same wallet, same session.');
+    if (lastQuery) {
+      const replay = lastQuery;
+      client
+        .query(replay.method, replay.params)
+        .then((res) => console.log(`[resume] ${replay.method}:`, JSON.stringify(res, null, 2)))
+        .catch((err) => console.error('[resume]', describeConnectFailure(err)))
+        .finally(showPrompt);
+      return;
+    }
+    showPrompt();
+  });
+  client.on(WALLET_EVENTS.DISCONNECTED, () => {
+    console.log('\n[EVENT] wallet:disconnected — the session is gone. Re-run the client to re-handshake.');
+    process.exit(0);
+  });
 
   // Subscribe to events
   client.on('transfer:incoming', (data: unknown) => {
@@ -69,32 +119,32 @@ async function main() {
       try {
         switch (cmd) {
           case 'balance': {
-            const balance = await client.query(RPC_METHODS.GET_BALANCE);
+            const balance = await runQuery(RPC_METHODS.GET_BALANCE);
             console.log('Balance:', JSON.stringify(balance, null, 2));
             break;
           }
           case 'assets': {
-            const assets = await client.query(RPC_METHODS.GET_ASSETS);
+            const assets = await runQuery(RPC_METHODS.GET_ASSETS);
             console.log('Assets:', JSON.stringify(assets, null, 2));
             break;
           }
           case 'fiat': {
-            const fiat = await client.query(RPC_METHODS.GET_FIAT_BALANCE);
+            const fiat = await runQuery(RPC_METHODS.GET_FIAT_BALANCE);
             console.log('Fiat Balance:', JSON.stringify(fiat, null, 2));
             break;
           }
           case 'tokens': {
-            const tokens = await client.query(RPC_METHODS.GET_TOKENS);
+            const tokens = await runQuery(RPC_METHODS.GET_TOKENS);
             console.log('Tokens:', JSON.stringify(tokens, null, 2));
             break;
           }
           case 'history': {
-            const history = await client.query(RPC_METHODS.GET_HISTORY);
+            const history = await runQuery(RPC_METHODS.GET_HISTORY);
             console.log('History:', JSON.stringify(history, null, 2));
             break;
           }
           case 'identity': {
-            const identity = await client.query(RPC_METHODS.GET_IDENTITY);
+            const identity = await runQuery(RPC_METHODS.GET_IDENTITY);
             console.log('Identity:', JSON.stringify(identity, null, 2));
             break;
           }
@@ -104,7 +154,7 @@ async function main() {
               console.log('Usage: resolve @nametag');
               break;
             }
-            const peer = await client.query(RPC_METHODS.RESOLVE, {
+            const peer = await runQuery(RPC_METHODS.RESOLVE, {
               identifier: identifier.startsWith('@') ? identifier : '@' + identifier,
             });
             console.log('Resolved:', JSON.stringify(peer, null, 2));
@@ -191,7 +241,7 @@ async function main() {
           }
           case 'conversations':
           case 'convos': {
-            const convos = await client.query(RPC_METHODS.GET_CONVERSATIONS);
+            const convos = await runQuery(RPC_METHODS.GET_CONVERSATIONS);
             console.log('Conversations:', JSON.stringify(convos, null, 2));
             break;
           }
@@ -204,7 +254,7 @@ async function main() {
             }
             const msgParams: Record<string, unknown> = { peerPubkey: peer };
             if (parts[2]) msgParams.limit = parseInt(parts[2]);
-            const msgs = await client.query(RPC_METHODS.GET_MESSAGES, msgParams);
+            const msgs = await runQuery(RPC_METHODS.GET_MESSAGES, msgParams);
             console.log('Messages:', JSON.stringify(msgs, null, 2));
             break;
           }
@@ -212,7 +262,7 @@ async function main() {
             const unreadPeer = parts[1] || undefined;
             const unreadParams: Record<string, unknown> = {};
             if (unreadPeer) unreadParams.peerPubkey = unreadPeer;
-            const unread = await client.query(RPC_METHODS.GET_DM_UNREAD_COUNT, unreadParams);
+            const unread = await runQuery(RPC_METHODS.GET_DM_UNREAD_COUNT, unreadParams);
             console.log('Unread:', JSON.stringify(unread, null, 2));
             break;
           }
@@ -222,7 +272,7 @@ async function main() {
               console.log('Usage: read <messageId1> [messageId2] ...');
               break;
             }
-            const readResult = await client.query(RPC_METHODS.MARK_AS_READ, { messageIds: ids });
+            const readResult = await runQuery(RPC_METHODS.MARK_AS_READ, { messageIds: ids });
             console.log('Marked as read:', JSON.stringify(readResult, null, 2));
             break;
           }
@@ -264,6 +314,9 @@ Commands:
   OTHER
     disconnect                   - Disconnect and exit
     help                         - Show this help
+    (lock the wallet with "lock" in the mock server: queries then fail with 4009,
+     the session survives, "identity" still works from the frozen snapshot, and the
+     last query auto-resumes on "unlock" — intents never do)
 `);
             break;
           }
@@ -271,7 +324,7 @@ Commands:
             console.log(`Unknown command: ${cmd}. Type "help" for available commands.`);
         }
       } catch (err) {
-        console.error('Error:', err instanceof Error ? err.message : err);
+        console.error('Error:', describeConnectFailure(err));
       }
 
       showPrompt();

--- a/nodejs/src/lockGate.test.ts
+++ b/nodejs/src/lockGate.test.ts
@@ -334,11 +334,15 @@ describe('locked gate over a real ConnectHost', () => {
     });
   });
 
-  it('refuses sphere_subscribe for an auto-pushed event name', async () => {
+  it('answers sphere_subscribe for an auto-pushed event name with SUCCESS', async () => {
     const { client } = await connectPair();
-    // Sphere.on() accepts any string and never emits for these names, so a subscribe that
-    // "succeeded" would deliver nothing forever.
-    await expect(client.query(RPC_METHODS.SUBSCRIBE, { event: WALLET_EVENTS.UNLOCKED })).rejects.toBeTruthy();
+    // The host pushes these unconditionally, so "you are subscribed" is true — it is just
+    // satisfied by a different mechanism than Sphere.on(), which accepts any string and never
+    // emits for them. This used to throw, which silently broke every dApp built before 2.1:
+    // client.on('wallet:locked', …) fires sphere_subscribe fire-and-forget, and on 2.0 that
+    // call succeeded.
+    await expect(client.query(RPC_METHODS.SUBSCRIBE, { event: WALLET_EVENTS.UNLOCKED }))
+      .resolves.toEqual({ subscribed: true, event: WALLET_EVENTS.UNLOCKED });
   });
 
   it('reports protocol 2.1 and ships no client-side retry surface in Release 1', async () => {

--- a/nodejs/src/lockGate.test.ts
+++ b/nodejs/src/lockGate.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Headless proof of the Connect 2.1 locked gate.
+ *
+ * Uses an in-process loopback transport — no ports, no timers, no flakes — so CI can assert
+ * WALLET_LOCKED (4009) against the REAL ConnectHost and ConnectClient.
+ *
+ * This file is the cross-repo canary. It pins the CODE and the structured `data`, never the
+ * refusal text: 'Wallet is locked' is a documented recommendation, not a wire contract, and a
+ * dApp that discriminates on the message is the bug this feature exists to remove.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  AUTO_PUSHED_EVENTS,
+  ConnectClient,
+  ConnectHost,
+  ERROR_CODES,
+  INTENT_ACTIONS,
+  PERMISSION_SCOPES,
+  RPC_METHODS,
+  SPHERE_CONNECT_VERSION,
+  SPHERE_NETWORKS,
+  WALLET_EVENTS,
+} from '@unicitylabs/sphere-sdk/connect';
+import type {
+  ConnectHostConfig,
+  ConnectTransport,
+  LockedRequestContext,
+  PublicIdentity,
+  SphereConnectMessage,
+} from '@unicitylabs/sphere-sdk/connect';
+import { mockSphere } from './mockSphere';
+
+const ORIGIN = 'ws://localhost:8765';
+const DAPP = { name: 'lock-gate test', description: 'headless 4009 check', url: 'cli://test' };
+
+type Handler = (m: SphereConnectMessage) => void;
+
+/**
+ * One host endpoint, N client endpoints. The host broadcasts to every live client endpoint,
+ * like a WS server with several peers; a client endpoint that is destroyed stops hearing.
+ * Delivery is always out of band (queueMicrotask), never re-entrant inside send().
+ */
+function createLoopback() {
+  const hostHandlers = new Set<Handler>();
+  const clientSets = new Set<Set<Handler>>();
+
+  const deliver = (targets: Iterable<Handler>, m: SphereConnectMessage) => {
+    const snapshot = [...targets];
+    queueMicrotask(() => {
+      for (const handler of snapshot) handler(m);
+    });
+  };
+
+  const host: ConnectTransport = {
+    send: (m) => {
+      const all: Handler[] = [];
+      for (const set of clientSets) all.push(...set);
+      deliver(all, m);
+    },
+    onMessage: (h) => {
+      hostHandlers.add(h);
+      return () => {
+        hostHandlers.delete(h);
+      };
+    },
+    destroy: () => {
+      hostHandlers.clear();
+    },
+  };
+
+  const newClient = (): ConnectTransport => {
+    const mine = new Set<Handler>();
+    clientSets.add(mine);
+    return {
+      send: (m) => deliver(hostHandlers, m),
+      onMessage: (h) => {
+        mine.add(h);
+        return () => {
+          mine.delete(h);
+        };
+      },
+      destroy: () => {
+        mine.clear();
+        clientSets.delete(mine);
+      },
+    };
+  };
+
+  return { host, newClient };
+}
+
+/** Let the loopback microtask queue drain so pushed events have arrived. */
+const settle = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+async function connectPair() {
+  const loop = createLoopback();
+  const lockedRequests: LockedRequestContext[] = [];
+
+  const hostConfig: ConnectHostConfig = {
+    sphere: mockSphere,
+    transport: loop.host,
+    origin: ORIGIN,
+    onConnectionRequest: async () => ({
+      approved: true,
+      grantedPermissions: Object.values(PERMISSION_SCOPES),
+    }),
+    onIntent: async () => ({ result: { ok: true } }),
+    // Notify-only. The host has ALREADY answered; this must never raise a credential surface.
+    onLockedRequest: (ctx) => {
+      lockedRequests.push(ctx);
+    },
+  };
+  const host = new ConnectHost(hostConfig);
+
+  const clientTransport = loop.newClient();
+  const client = new ConnectClient({
+    transport: clientTransport,
+    dapp: DAPP,
+    network: SPHERE_NETWORKS.testnet2,
+    timeout: 2000,
+  });
+
+  const seen: { event: string; data: unknown }[] = [];
+  for (const event of AUTO_PUSHED_EVENTS) {
+    client.on(event, (data) => seen.push({ event, data }));
+  }
+
+  const result = await client.connect();
+  return { loop, host, client, clientTransport, seen, lockedRequests, sessionId: result.sessionId, result };
+}
+
+describe('locked gate over a real ConnectHost', () => {
+  it('serves queries while live', async () => {
+    const { client, host, result } = await connectPair();
+    const balance = await client.query(RPC_METHODS.GET_BALANCE);
+    expect(Array.isArray(balance)).toBe(true);
+    expect(host.walletState).toBe('live');
+    expect(host.getState().session?.id).toBe(result.sessionId);
+    expect(result.locked).not.toBe(true);
+    expect(client.walletLocked).toBe(false);
+  });
+
+  it('answers WALLET_LOCKED with data.reason and keeps the session after setLocked()', async () => {
+    const { client, host, seen, sessionId } = await connectPair();
+
+    host.setLocked();
+    await settle();
+
+    expect(host.walletState).toBe('locked');
+    expect(seen.map((s) => s.event)).toEqual([WALLET_EVENTS.LOCKED]);
+    // The session survives a lock — that is the entire feature.
+    expect(host.getSession()?.id).toBe(sessionId);
+    expect(client.session).toBe(sessionId);
+    expect(client.walletLocked).toBe(true);
+
+    // CANARY: the code and the structured data are the contract. The message is NOT.
+    await expect(client.query(RPC_METHODS.GET_BALANCE)).rejects.toMatchObject({
+      code: ERROR_CODES.WALLET_LOCKED,
+      data: { reason: 'locked' },
+    });
+    // Balances, tokens and history are never served from a cache: a dApp with a stale balance
+    // is a dApp about to collect an unpayable spend.
+    for (const method of [
+      RPC_METHODS.GET_ASSETS,
+      RPC_METHODS.GET_TOKENS,
+      RPC_METHODS.GET_HISTORY,
+      RPC_METHODS.GET_FIAT_BALANCE,
+    ]) {
+      await expect(client.query(method)).rejects.toMatchObject({ code: ERROR_CODES.WALLET_LOCKED });
+    }
+  });
+
+  it('serves the locked allow-list from the snapshot', async () => {
+    const { client, host } = await connectPair();
+
+    host.setLocked();
+    await settle();
+
+    // sphere_getIdentity: exactly the bytes this origin already received in the handshake
+    // response. Never undefined-as-success, which would read as "the wallet has no identity".
+    const identity = await client.query<PublicIdentity>(RPC_METHODS.GET_IDENTITY);
+    expect(identity.chainPubkey).toBe(mockSphere.identity.chainPubkey);
+
+    // sphere_subscribe MUST succeed while locked. ConnectClient.on() is fire-and-forget and
+    // never retries, so refusing it would kill the dApp's event stream forever after one lock.
+    await expect(
+      client.query(RPC_METHODS.SUBSCRIBE, { event: 'transfer:incoming' }),
+    ).resolves.toMatchObject({ subscribed: true, event: 'transfer:incoming' });
+
+    await expect(
+      client.query(RPC_METHODS.UNSUBSCRIBE, { event: 'transfer:incoming' }),
+    ).resolves.toMatchObject({ unsubscribed: true, event: 'transfer:incoming' });
+  });
+
+  it('lets a locked dApp disconnect', async () => {
+    const { client, host, seen } = await connectPair();
+
+    host.setLocked();
+    await settle();
+
+    await expect(client.query(RPC_METHODS.DISCONNECT)).resolves.toMatchObject({ disconnected: true });
+    await settle();
+
+    expect(host.getSession()).toBeNull();
+    expect(seen.map((s) => s.event)).toContain(WALLET_EVENTS.DISCONNECTED);
+  });
+
+  it('notifies onLockedRequest for a refused query and a refused intent, and not for a served one', async () => {
+    const { client, host, lockedRequests } = await connectPair();
+
+    host.setLocked();
+    await settle();
+
+    await expect(client.query(RPC_METHODS.GET_BALANCE)).rejects.toMatchObject({
+      code: ERROR_CODES.WALLET_LOCKED,
+    });
+    await expect(
+      client.intent(INTENT_ACTIONS.SEND, { to: '@bob', amount: '1', coinId: 'aa'.repeat(32) }),
+    ).rejects.toMatchObject({ code: ERROR_CODES.WALLET_LOCKED });
+
+    expect(lockedRequests).toEqual([
+      { origin: ORIGIN, kind: 'query', name: RPC_METHODS.GET_BALANCE },
+      { origin: ORIGIN, kind: 'intent', name: INTENT_ACTIONS.SEND },
+    ]);
+
+    // An allow-listed method is SERVED, so it is not a locked request and notifies nothing.
+    await client.query(RPC_METHODS.GET_IDENTITY);
+    expect(lockedRequests).toHaveLength(2);
+  });
+
+  it('pushes wallet:locked exactly once for a repeated lock', async () => {
+    const { host, seen } = await connectPair();
+    host.setLocked();
+    host.setLocked();
+    await settle();
+    expect(seen.filter((s) => s.event === WALLET_EVENTS.LOCKED)).toHaveLength(1);
+  });
+
+  it('resumes the same session on updateSphere() and reports the identity', async () => {
+    const { client, host, seen, sessionId } = await connectPair();
+
+    host.setLocked();
+    await settle();
+    host.updateSphere(mockSphere);
+    await settle();
+
+    expect(host.walletState).toBe('live');
+    const unlocked = seen.find((s) => s.event === WALLET_EVENTS.UNLOCKED);
+    expect(unlocked).toBeTruthy();
+    expect((unlocked?.data as { identity?: PublicIdentity } | undefined)?.identity?.chainPubkey).toBe(
+      mockSphere.identity.chainPubkey,
+    );
+    expect(client.session).toBe(sessionId);
+    expect(client.walletLocked).toBe(false);
+
+    const balance = await client.query(RPC_METHODS.GET_BALANCE);
+    expect(Array.isArray(balance)).toBe(true);
+  });
+
+  // Connect 2.1 makes this SUCCEED — the most common entry into the feature. A dApp that
+  // reloads during a lock gets a live session back plus locked: true, with no consent prompt
+  // (any handshake while locked is forced silent).
+  it('answers a resume handshake while locked with locked: true', async () => {
+    const { loop, host, clientTransport, sessionId } = await connectPair();
+
+    host.setLocked();
+    await settle();
+
+    // Retire the first client so it cannot swallow the second one's handshake response.
+    clientTransport.destroy();
+
+    const resumeClient = new ConnectClient({
+      transport: loop.newClient(),
+      dapp: DAPP,
+      network: SPHERE_NETWORKS.testnet2,
+      resumeSessionId: sessionId,
+      timeout: 2000,
+    });
+
+    const resumed = await resumeClient.connect();
+    expect(resumed.sessionId).toBe(sessionId);
+    expect(resumed.locked).toBe(true);
+    expect(resumeClient.walletLocked).toBe(true);
+    expect(resumeClient.walletProtocol).toBe(SPHERE_CONNECT_VERSION);
+  });
+
+  // The lock screen's "Forgot password -> restore from recovery phrase" installs a DIFFERENT
+  // seed behind an origin-keyed approval. The host compares chainPubkey on the locked -> live
+  // edge and revokes rather than unlocking.
+  it('revokes instead of unlocking when a different seed comes back', async () => {
+    const { host, seen } = await connectPair();
+    const otherSphere = {
+      ...mockSphere,
+      identity: {
+        ...mockSphere.identity,
+        chainPubkey: '02bbbb000000000000000000000000000000000000000000000000000000000000',
+      },
+    };
+
+    host.setLocked();
+    await settle();
+    host.updateSphere(otherSphere);
+    await settle();
+
+    expect(seen.map((s) => s.event)).toContain(WALLET_EVENTS.DISCONNECTED);
+    expect(seen.map((s) => s.event)).not.toContain(WALLET_EVENTS.UNLOCKED);
+    expect(host.getSession()).toBeNull();
+  });
+
+  it('announces wallet:disconnected on revokeSession()', async () => {
+    const { host, seen } = await connectPair();
+
+    host.revokeSession();
+    await settle();
+
+    expect(seen.map((s) => s.event)).toContain(WALLET_EVENTS.DISCONNECTED);
+    expect(host.getSession()).toBeNull();
+  });
+
+  // 'unavailable' is Sphere gone for a NON-lock reason. It is a dead end: unlocking cannot
+  // cure it, so it revokes and answers the existing NOT_CONNECTED (4001) — there is
+  // deliberately no dedicated error code.
+  it('answers 4001 and revokes after setUnavailable()', async () => {
+    const { client, host, seen } = await connectPair();
+
+    host.setUnavailable();
+    await settle();
+
+    expect(host.walletState).toBe('unavailable');
+    expect(host.getSession()).toBeNull();
+    expect(seen.map((s) => s.event)).toContain(WALLET_EVENTS.DISCONNECTED);
+    await expect(client.query(RPC_METHODS.GET_BALANCE)).rejects.toMatchObject({
+      code: ERROR_CODES.NOT_CONNECTED,
+    });
+  });
+
+  it('refuses sphere_subscribe for an auto-pushed event name', async () => {
+    const { client } = await connectPair();
+    // Sphere.on() accepts any string and never emits for these names, so a subscribe that
+    // "succeeded" would deliver nothing forever.
+    await expect(client.query(RPC_METHODS.SUBSCRIBE, { event: WALLET_EVENTS.UNLOCKED })).rejects.toBeTruthy();
+  });
+
+  it('reports protocol 2.1 and ships no client-side retry surface in Release 1', async () => {
+    const { client } = await connectPair();
+    expect(SPHERE_CONNECT_VERSION).toBe('2.1');
+    expect(client.walletProtocol).toBe('2.1');
+    // Release 1 is fail-fast: no queue, no client-only 4010, and no re-subscribe API.
+    expect((ERROR_CODES as Record<string, number>).REQUEST_TIMEOUT).toBeUndefined();
+    expect((client as unknown as { resubscribeAll?: unknown }).resubscribeAll).toBeUndefined();
+  });
+});

--- a/nodejs/src/lockResume.test.ts
+++ b/nodejs/src/lockResume.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { ConnectError, ERROR_CODES } from '@unicitylabs/sphere-sdk/connect';
+import type { PublicIdentity } from '@unicitylabs/sphere-sdk/connect';
+import { describeConnectFailure, isSameWallet, isWalletLocked } from './lockResume';
+
+const alice: PublicIdentity = { chainPubkey: '02aaaa', nametag: 'alice' };
+const mallory: PublicIdentity = { chainPubkey: '02bbbb', nametag: 'mallory' };
+const locked = () => new ConnectError('Wallet is locked', ERROR_CODES.WALLET_LOCKED, { reason: 'locked' });
+
+describe('isWalletLocked', () => {
+  it('recognises 4009 and nothing else, whatever the text says', () => {
+    expect(isWalletLocked(locked())).toBe(true);
+    expect(isWalletLocked(new ConnectError('Gesperrt', ERROR_CODES.WALLET_LOCKED))).toBe(true);
+    expect(isWalletLocked(new ConnectError('Not connected', ERROR_CODES.NOT_CONNECTED))).toBe(false);
+    expect(isWalletLocked(new Error('Query timeout: sphere_getBalance'))).toBe(false);
+  });
+});
+
+describe('describeConnectFailure', () => {
+  it('tells a headless operator what a lock means and how to clear it', () => {
+    const text = describeConnectFailure(locked());
+    expect(text).toContain('4009');
+    expect(text).toContain('session is still alive');
+    expect(text).toContain('unlock');
+  });
+
+  it('keeps the code visible on other typed refusals', () => {
+    expect(describeConnectFailure(new ConnectError('Permission denied', ERROR_CODES.PERMISSION_DENIED))).toBe(
+      'Permission denied (code 4002)',
+    );
+  });
+
+  it('passes a codeless error through unchanged', () => {
+    expect(describeConnectFailure(new Error('Query timeout: sphere_getBalance'))).toBe(
+      'Query timeout: sphere_getBalance',
+    );
+  });
+});
+
+describe('isSameWallet', () => {
+  it('compares chainPubkey and treats a missing identity as different', () => {
+    expect(isSameWallet(alice, alice)).toBe(true);
+    expect(isSameWallet(alice, mallory)).toBe(false);
+    expect(isSameWallet(alice, null)).toBe(false);
+    expect(isSameWallet(alice, undefined)).toBe(false);
+    expect(isSameWallet(null, alice)).toBe(false);
+  });
+});

--- a/nodejs/src/lockResume.ts
+++ b/nodejs/src/lockResume.ts
@@ -1,0 +1,46 @@
+/**
+ * Lock helpers for the CLI dApp.
+ *
+ * Deliberately duplicated rather than shared with browser/src/lib/connectErrors.ts: each
+ * example in this repo must be copy-pasteable on its own.
+ */
+import { ERROR_CODES } from '@unicitylabs/sphere-sdk/connect';
+import type { PublicIdentity } from '@unicitylabs/sphere-sdk/connect';
+
+function connectErrorCode(err: unknown): number | undefined {
+  if (typeof err !== 'object' || err === null || !('code' in err)) return undefined;
+  const code = (err as { code: unknown }).code;
+  return typeof code === 'number' ? code : undefined;
+}
+
+/** Discriminate on the CODE. The refusal text is a recommendation, not a contract. */
+export function isWalletLocked(err: unknown): boolean {
+  return connectErrorCode(err) === ERROR_CODES.WALLET_LOCKED;
+}
+
+export function describeConnectFailure(err: unknown): string {
+  const code = connectErrorCode(err);
+  const message = err instanceof Error ? err.message : String(err);
+
+  if (code === ERROR_CODES.WALLET_LOCKED) {
+    return (
+      'Wallet is locked (4009) — the session is still alive, so nothing needs reconnecting. ' +
+      'Type "unlock" in the mock wallet server (or unlock the real wallet) and run the command again.'
+    );
+  }
+  if (code === undefined) return message;
+  return `${message} (code ${code})`;
+}
+
+/**
+ * Unlock is NOT implicitly the same wallet: the lock screen's "restore from recovery phrase"
+ * installs a different seed while the approval that authorised this session is keyed on origin
+ * alone. The host's own lock-edge guard revokes on a mismatch, but a dApp still compares so it
+ * can render honestly and resume nothing it should not.
+ */
+export function isSameWallet(
+  before: PublicIdentity | null,
+  after: PublicIdentity | null | undefined,
+): boolean {
+  return !!before && !!after && before.chainPubkey === after.chainPubkey;
+}

--- a/nodejs/src/mock-wallet-server.ts
+++ b/nodejs/src/mock-wallet-server.ts
@@ -5,181 +5,19 @@
  */
 
 import { ConnectHost, PERMISSION_SCOPES } from '@unicitylabs/sphere-sdk/connect';
-import type { DAppMetadata, PermissionScope } from '@unicitylabs/sphere-sdk/connect';
+import type { DAppMetadata, LockedRequestContext, PermissionScope } from '@unicitylabs/sphere-sdk/connect';
 import { WebSocketTransport } from '@unicitylabs/sphere-sdk/connect/nodejs';
-
-const now = Date.now();
-
-// Mock Sphere object matching the SphereInstance interface expected by ConnectHost
-const mockSphere = {
-  networkId: 4,
-  identity: {
-    chainPubkey: '02abc123def456789012345678901234567890123456789012345678901234567890',
-    directAddress: 'DIRECT://abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
-    nametag: 'alice',
-  },
-  payments: {
-    getBalance: (_coinId?: string) => [
-      {
-        coinId: 'UCT', symbol: 'UCT', name: 'Unicity Token', decimals: 8,
-        totalAmount: '500000000', tokenCount: 3,
-        confirmedAmount: '300000000', unconfirmedAmount: '200000000',
-        confirmedTokenCount: 2, unconfirmedTokenCount: 1,
-      },
-      {
-        coinId: 'USDU', symbol: 'USDU', name: 'USD Unicity', decimals: 6,
-        totalAmount: '1000000000', tokenCount: 1,
-        confirmedAmount: '1000000000', unconfirmedAmount: '0',
-        confirmedTokenCount: 1, unconfirmedTokenCount: 0,
-      },
-    ],
-    getAssets: async (_coinId?: string) => [
-      {
-        coinId: 'UCT', symbol: 'UCT', name: 'Unicity Token', decimals: 8,
-        iconUrl: null, totalAmount: '500000000', tokenCount: 3,
-        confirmedAmount: '300000000', unconfirmedAmount: '200000000',
-        confirmedTokenCount: 2, unconfirmedTokenCount: 1,
-        priceUsd: 0.051, priceEur: 0.047, change24h: 2.4,
-        fiatValueUsd: 2.55, fiatValueEur: 2.35,
-      },
-      {
-        coinId: 'USDU', symbol: 'USDU', name: 'USD Unicity', decimals: 6,
-        iconUrl: null, totalAmount: '1000000000', tokenCount: 1,
-        confirmedAmount: '1000000000', unconfirmedAmount: '0',
-        confirmedTokenCount: 1, unconfirmedTokenCount: 0,
-        priceUsd: 1.0, priceEur: 0.92, change24h: 0.01,
-        fiatValueUsd: 1000.0, fiatValueEur: 920.0,
-      },
-    ],
-    getFiatBalance: async () => 1002.55,
-    getTokens: (_filter?: unknown) => [
-      {
-        id: 'tok-abc123def456', coinId: 'UCT', symbol: 'UCT', name: 'Unicity Token',
-        decimals: 8, amount: '200000000', status: 'confirmed',
-        createdAt: now - 86400000, updatedAt: now - 3600000,
-      },
-      {
-        id: 'tok-789ghi012jkl', coinId: 'UCT', symbol: 'UCT', name: 'Unicity Token',
-        decimals: 8, amount: '100000000', status: 'confirmed',
-        createdAt: now - 43200000, updatedAt: now - 7200000,
-      },
-      {
-        id: 'tok-mno345pqr678', coinId: 'UCT', symbol: 'UCT', name: 'Unicity Token',
-        decimals: 8, amount: '200000000', status: 'submitted',
-        createdAt: now - 1800000, updatedAt: now - 600000,
-      },
-      {
-        id: 'tok-stu901vwx234', coinId: 'USDU', symbol: 'USDU', name: 'USD Unicity',
-        decimals: 6, amount: '1000000000', status: 'confirmed',
-        createdAt: now - 172800000, updatedAt: now - 86400000,
-      },
-    ],
-    getHistory: () => [
-      {
-        id: 'h1', type: 'SENT', amount: '100000000', coinId: 'UCT', symbol: 'UCT',
-        timestamp: now - 3600000, recipientNametag: 'bob', transferId: 'xfer-001',
-      },
-      {
-        id: 'h2', type: 'RECEIVED', amount: '500000000', coinId: 'UCT', symbol: 'UCT',
-        timestamp: now - 7200000, senderPubkey: '03fedcba09876543210fedcba09876543210fedcba09876543210fedcba0987654321',
-        senderNametag: 'charlie',
-      },
-      {
-        id: 'h3', type: 'MINT', amount: '1000000000', coinId: 'USDU', symbol: 'USDU',
-        timestamp: now - 86400000,
-      },
-    ],
-  },
-  resolve: async (identifier: string) => ({
-    nametag: identifier.replace('@', ''),
-    chainPubkey: '03fedcba09876543210fedcba09876543210fedcba09876543210fedcba0987654321',
-    directAddress: 'DIRECT://fedcba09876543210fedcba09876543210fedcba09876543210fedcba0987654321',
-    transportPubkey: 'aa00bb11cc22dd33ee44ff5566778899aabbccddeeff00112233445566778899',
-  }),
-  on: () => () => {}, // no-op event subscription
-  communications: {
-    getConversations: () => {
-      const convos = new Map();
-      convos.set('03fedcba09876543210fedcba09876543210fedcba09876543210fedcba0987654321', [
-        {
-          id: 'dm-1', senderPubkey: '03fedcba09876543210fedcba09876543210fedcba09876543210fedcba0987654321',
-          senderNametag: 'bob', recipientPubkey: '02abc123def456789012345678901234567890123456789012345678901234567890',
-          recipientNametag: 'alice', content: 'Hey Alice, how are you?',
-          timestamp: now - 7200000, isRead: true,
-        },
-        {
-          id: 'dm-2', senderPubkey: '02abc123def456789012345678901234567890123456789012345678901234567890',
-          senderNametag: 'alice', recipientPubkey: '03fedcba09876543210fedcba09876543210fedcba09876543210fedcba0987654321',
-          recipientNametag: 'bob', content: 'Hi Bob! I am good, thanks!',
-          timestamp: now - 3600000, isRead: true,
-        },
-        {
-          id: 'dm-3', senderPubkey: '03fedcba09876543210fedcba09876543210fedcba09876543210fedcba0987654321',
-          senderNametag: 'bob', recipientPubkey: '02abc123def456789012345678901234567890123456789012345678901234567890',
-          recipientNametag: 'alice', content: 'Want to test the new Connect protocol?',
-          timestamp: now - 1800000, isRead: false,
-        },
-      ]);
-      convos.set('04aabbcc112233445566778899001122334455667788990011223344556677889900', [
-        {
-          id: 'dm-4', senderPubkey: '04aabbcc112233445566778899001122334455667788990011223344556677889900',
-          senderNametag: 'charlie', recipientPubkey: '02abc123def456789012345678901234567890123456789012345678901234567890',
-          recipientNametag: 'alice', content: 'Sent you some UCT!',
-          timestamp: now - 86400000, isRead: true,
-        },
-      ]);
-      return convos;
-    },
-    getConversationPage: (peerPubkey: string, _options?: { limit?: number; before?: number }) => {
-      const isBob = peerPubkey.startsWith('03fed');
-      return {
-        messages: isBob ? [
-          {
-            id: 'dm-1', senderPubkey: peerPubkey, senderNametag: 'bob',
-            recipientPubkey: '02abc123def456789012345678901234567890123456789012345678901234567890',
-            recipientNametag: 'alice', content: 'Hey Alice, how are you?',
-            timestamp: now - 7200000, isRead: true,
-          },
-          {
-            id: 'dm-2', senderPubkey: '02abc123def456789012345678901234567890123456789012345678901234567890',
-            senderNametag: 'alice', recipientPubkey: peerPubkey,
-            recipientNametag: 'bob', content: 'Hi Bob! I am good, thanks!',
-            timestamp: now - 3600000, isRead: true,
-          },
-          {
-            id: 'dm-3', senderPubkey: peerPubkey, senderNametag: 'bob',
-            recipientPubkey: '02abc123def456789012345678901234567890123456789012345678901234567890',
-            recipientNametag: 'alice', content: 'Want to test the new Connect protocol?',
-            timestamp: now - 1800000, isRead: false,
-          },
-        ] : [
-          {
-            id: 'dm-4', senderPubkey: peerPubkey, senderNametag: 'charlie',
-            recipientPubkey: '02abc123def456789012345678901234567890123456789012345678901234567890',
-            recipientNametag: 'alice', content: 'Sent you some UCT!',
-            timestamp: now - 86400000, isRead: true,
-          },
-        ],
-        hasMore: false,
-        oldestTimestamp: isBob ? now - 7200000 : now - 86400000,
-      };
-    },
-    getUnreadCount: (peerPubkey?: string) => peerPubkey?.startsWith('03fed') ? 1 : peerPubkey ? 0 : 1,
-    markAsRead: async (_messageIds: string[]) => { /* no-op */ },
-    sendDM: async (recipient: string, content: string) => ({
-      id: `msg-${Date.now()}`,
-      senderPubkey: '02abc123def456789012345678901234567890123456789012345678901234567890',
-      senderNametag: 'alice',
-      recipientPubkey: '03fedcba09876543210fedcba09876543210fedcba09876543210fedcba0987654321',
-      recipientNametag: recipient.replace('@', ''),
-      content,
-      timestamp: Date.now(),
-      isRead: false,
-    }),
-  },
-};
+import readline from 'readline';
+import { mockSphere } from './mockSphere';
 
 const PORT = 8765;
+
+/**
+ * What a real wallet renders as a PASSIVE badge in its permanent chrome: "N requests waiting -
+ * Unlock". A dApp request must never raise a credential surface, so this counter is the entire
+ * permitted reaction. The password field appears only after a human clicks the badge.
+ */
+let waitingWhileLocked = 0;
 
 async function main() {
   const transport = WebSocketTransport.createServer({ port: PORT });
@@ -190,6 +28,22 @@ async function main() {
   const host = new ConnectHost({
     sphere: mockSphere,
     transport,
+    // The transport-verified origin. A WS host has no browser origin, so the server's own
+    // listen address is the honest answer — never the dApp-CLAIMED session.dapp.url.
+    // Optional by design: with no credential prompt, no security decision depends on it.
+    origin: `ws://localhost:${PORT}`,
+    // Notify-only. The host has ALREADY answered WALLET_LOCKED (4009) in the same tick and
+    // never waits for this callback. It must NOT raise a credential surface: a dApp request
+    // may trigger a consent prompt, never a password field. Volume is bounded by the host's
+    // own checkRateLimit(), so there is no coalescing, cooldown or cap here by design.
+    onLockedRequest: (ctx: LockedRequestContext) => {
+      waitingWhileLocked += 1;
+      console.log(
+        `\n[LOCKED] refused ${ctx.kind} "${ctx.name}" from ${ctx.origin ?? 'a connected app'} with 4009.`,
+      );
+      console.log(`         Badge would read: "${waitingWhileLocked} request(s) waiting — Unlock".`);
+      console.log('         Type "unlock" to re-arm this mock wallet.\n');
+    },
     onConnectionRequest: async (dapp: DAppMetadata, requestedPermissions: PermissionScope[]) => {
       console.log(`\nConnection request from: ${dapp.name} (${dapp.url})`);
       console.log(`Requested permissions: ${requestedPermissions.join(', ')}`);
@@ -244,11 +98,60 @@ async function main() {
   } as any);
 
   console.log('Waiting for dApp connections...');
-  console.log('Press Ctrl+C to stop.\n');
+  console.log('Commands: lock | unlock | logout | unavailable | status | help | quit\n');
 
-  // Keep process alive
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  rl.on('line', (line: string) => {
+    switch (line.trim().toLowerCase()) {
+      case 'lock':
+        // ORDERING CONTRACT: setLocked() FIRST, then destroy the Sphere. The host drops its
+        // Sphere reference here and freezes its snapshot; destroying first would leave
+        // in-flight requests reading a dead instance. This mock has nothing to destroy, but
+        // the order is the lesson.
+        host.setLocked();
+        console.log(`[wallet] locked — walletState=${host.walletState}; session preserved, requests answer 4009`);
+        break;
+      case 'unlock':
+        waitingWhileLocked = 0;
+        host.updateSphere(mockSphere);
+        console.log(`[wallet] unlocked — walletState=${host.walletState}; same session, subscriptions re-armed, wallet:unlocked pushed`);
+        break;
+      case 'logout':
+        host.revokeSession();
+        console.log(`[wallet] logged out — walletState=${host.walletState}; session destroyed, wallet:disconnected pushed`);
+        break;
+      case 'unavailable':
+        host.setUnavailable();
+        console.log(`[wallet] unavailable — walletState=${host.walletState}; revoked, requests answer 4001 (unlocking cannot cure it)`);
+        break;
+      case 'status':
+        console.log(
+          `[wallet] walletState=${host.walletState} session=${host.getSession()?.id ?? 'none'} waiting=${waitingWhileLocked}`,
+        );
+        break;
+      case 'help':
+        console.log('  lock        — setLocked(): session preserved, requests answer WALLET_LOCKED (4009)');
+        console.log('  unlock      — updateSphere(): same session resumes, wallet:unlocked pushed');
+        console.log('  logout      — revokeSession(): session destroyed, wallet:disconnected pushed');
+        console.log('  unavailable — setUnavailable(): Sphere gone for a non-lock reason, 4001');
+        console.log('  status      — print walletState, session id and the waiting-request count');
+        console.log('  quit        — shut down');
+        break;
+      case 'quit':
+      case 'exit':
+        rl.close();
+        host.destroy();
+        transport.destroy();
+        process.exit(0);
+        break;
+      default:
+        console.log('Unknown command. Type "help".');
+    }
+  });
+
   process.on('SIGINT', () => {
     console.log('\nShutting down...');
+    rl.close();
     host.destroy();
     transport.destroy();
     process.exit(0);

--- a/nodejs/src/mockSphere.ts
+++ b/nodejs/src/mockSphere.ts
@@ -1,0 +1,175 @@
+/**
+ * Mock Sphere instance shared by the mock wallet server and the headless lock-gate test.
+ *
+ * Lives in its own module so a test can construct a ConnectHost around it without importing
+ * mock-wallet-server.ts, which starts a WebSocket server as a side effect of being imported.
+ */
+const now = Date.now();
+
+export const mockSphere = {
+  networkId: 4,
+  identity: {
+    chainPubkey: '02abc123def456789012345678901234567890123456789012345678901234567890',
+    directAddress: 'DIRECT://abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+    nametag: 'alice',
+  },
+  payments: {
+    getBalance: (_coinId?: string) => [
+      {
+        coinId: 'UCT', symbol: 'UCT', name: 'Unicity Token', decimals: 8,
+        totalAmount: '500000000', tokenCount: 3,
+        confirmedAmount: '300000000', unconfirmedAmount: '200000000',
+        confirmedTokenCount: 2, unconfirmedTokenCount: 1,
+      },
+      {
+        coinId: 'USDU', symbol: 'USDU', name: 'USD Unicity', decimals: 6,
+        totalAmount: '1000000000', tokenCount: 1,
+        confirmedAmount: '1000000000', unconfirmedAmount: '0',
+        confirmedTokenCount: 1, unconfirmedTokenCount: 0,
+      },
+    ],
+    getAssets: async (_coinId?: string) => [
+      {
+        coinId: 'UCT', symbol: 'UCT', name: 'Unicity Token', decimals: 8,
+        iconUrl: null, totalAmount: '500000000', tokenCount: 3,
+        confirmedAmount: '300000000', unconfirmedAmount: '200000000',
+        confirmedTokenCount: 2, unconfirmedTokenCount: 1,
+        priceUsd: 0.051, priceEur: 0.047, change24h: 2.4,
+        fiatValueUsd: 2.55, fiatValueEur: 2.35,
+      },
+      {
+        coinId: 'USDU', symbol: 'USDU', name: 'USD Unicity', decimals: 6,
+        iconUrl: null, totalAmount: '1000000000', tokenCount: 1,
+        confirmedAmount: '1000000000', unconfirmedAmount: '0',
+        confirmedTokenCount: 1, unconfirmedTokenCount: 0,
+        priceUsd: 1.0, priceEur: 0.92, change24h: 0.01,
+        fiatValueUsd: 1000.0, fiatValueEur: 920.0,
+      },
+    ],
+    getFiatBalance: async () => 1002.55,
+    getTokens: (_filter?: unknown) => [
+      {
+        id: 'tok-abc123def456', coinId: 'UCT', symbol: 'UCT', name: 'Unicity Token',
+        decimals: 8, amount: '200000000', status: 'confirmed',
+        createdAt: now - 86400000, updatedAt: now - 3600000,
+      },
+      {
+        id: 'tok-789ghi012jkl', coinId: 'UCT', symbol: 'UCT', name: 'Unicity Token',
+        decimals: 8, amount: '100000000', status: 'confirmed',
+        createdAt: now - 43200000, updatedAt: now - 7200000,
+      },
+      {
+        id: 'tok-mno345pqr678', coinId: 'UCT', symbol: 'UCT', name: 'Unicity Token',
+        decimals: 8, amount: '200000000', status: 'submitted',
+        createdAt: now - 1800000, updatedAt: now - 600000,
+      },
+      {
+        id: 'tok-stu901vwx234', coinId: 'USDU', symbol: 'USDU', name: 'USD Unicity',
+        decimals: 6, amount: '1000000000', status: 'confirmed',
+        createdAt: now - 172800000, updatedAt: now - 86400000,
+      },
+    ],
+    getHistory: () => [
+      {
+        id: 'h1', type: 'SENT', amount: '100000000', coinId: 'UCT', symbol: 'UCT',
+        timestamp: now - 3600000, recipientNametag: 'bob', transferId: 'xfer-001',
+      },
+      {
+        id: 'h2', type: 'RECEIVED', amount: '500000000', coinId: 'UCT', symbol: 'UCT',
+        timestamp: now - 7200000, senderPubkey: '03fedcba09876543210fedcba09876543210fedcba09876543210fedcba0987654321',
+        senderNametag: 'charlie',
+      },
+      {
+        id: 'h3', type: 'MINT', amount: '1000000000', coinId: 'USDU', symbol: 'USDU',
+        timestamp: now - 86400000,
+      },
+    ],
+  },
+  resolve: async (identifier: string) => ({
+    nametag: identifier.replace('@', ''),
+    chainPubkey: '03fedcba09876543210fedcba09876543210fedcba09876543210fedcba0987654321',
+    directAddress: 'DIRECT://fedcba09876543210fedcba09876543210fedcba09876543210fedcba0987654321',
+    transportPubkey: 'aa00bb11cc22dd33ee44ff5566778899aabbccddeeff00112233445566778899',
+  }),
+  on: () => () => {}, // no-op event subscription
+  communications: {
+    getConversations: () => {
+      const convos = new Map();
+      convos.set('03fedcba09876543210fedcba09876543210fedcba09876543210fedcba0987654321', [
+        {
+          id: 'dm-1', senderPubkey: '03fedcba09876543210fedcba09876543210fedcba09876543210fedcba0987654321',
+          senderNametag: 'bob', recipientPubkey: '02abc123def456789012345678901234567890123456789012345678901234567890',
+          recipientNametag: 'alice', content: 'Hey Alice, how are you?',
+          timestamp: now - 7200000, isRead: true,
+        },
+        {
+          id: 'dm-2', senderPubkey: '02abc123def456789012345678901234567890123456789012345678901234567890',
+          senderNametag: 'alice', recipientPubkey: '03fedcba09876543210fedcba09876543210fedcba09876543210fedcba0987654321',
+          recipientNametag: 'bob', content: 'Hi Bob! I am good, thanks!',
+          timestamp: now - 3600000, isRead: true,
+        },
+        {
+          id: 'dm-3', senderPubkey: '03fedcba09876543210fedcba09876543210fedcba09876543210fedcba0987654321',
+          senderNametag: 'bob', recipientPubkey: '02abc123def456789012345678901234567890123456789012345678901234567890',
+          recipientNametag: 'alice', content: 'Want to test the new Connect protocol?',
+          timestamp: now - 1800000, isRead: false,
+        },
+      ]);
+      convos.set('04aabbcc112233445566778899001122334455667788990011223344556677889900', [
+        {
+          id: 'dm-4', senderPubkey: '04aabbcc112233445566778899001122334455667788990011223344556677889900',
+          senderNametag: 'charlie', recipientPubkey: '02abc123def456789012345678901234567890123456789012345678901234567890',
+          recipientNametag: 'alice', content: 'Sent you some UCT!',
+          timestamp: now - 86400000, isRead: true,
+        },
+      ]);
+      return convos;
+    },
+    getConversationPage: (peerPubkey: string, _options?: { limit?: number; before?: number }) => {
+      const isBob = peerPubkey.startsWith('03fed');
+      return {
+        messages: isBob ? [
+          {
+            id: 'dm-1', senderPubkey: peerPubkey, senderNametag: 'bob',
+            recipientPubkey: '02abc123def456789012345678901234567890123456789012345678901234567890',
+            recipientNametag: 'alice', content: 'Hey Alice, how are you?',
+            timestamp: now - 7200000, isRead: true,
+          },
+          {
+            id: 'dm-2', senderPubkey: '02abc123def456789012345678901234567890123456789012345678901234567890',
+            senderNametag: 'alice', recipientPubkey: peerPubkey,
+            recipientNametag: 'bob', content: 'Hi Bob! I am good, thanks!',
+            timestamp: now - 3600000, isRead: true,
+          },
+          {
+            id: 'dm-3', senderPubkey: peerPubkey, senderNametag: 'bob',
+            recipientPubkey: '02abc123def456789012345678901234567890123456789012345678901234567890',
+            recipientNametag: 'alice', content: 'Want to test the new Connect protocol?',
+            timestamp: now - 1800000, isRead: false,
+          },
+        ] : [
+          {
+            id: 'dm-4', senderPubkey: peerPubkey, senderNametag: 'charlie',
+            recipientPubkey: '02abc123def456789012345678901234567890123456789012345678901234567890',
+            recipientNametag: 'alice', content: 'Sent you some UCT!',
+            timestamp: now - 86400000, isRead: true,
+          },
+        ],
+        hasMore: false,
+        oldestTimestamp: isBob ? now - 7200000 : now - 86400000,
+      };
+    },
+    getUnreadCount: (peerPubkey?: string) => peerPubkey?.startsWith('03fed') ? 1 : peerPubkey ? 0 : 1,
+    markAsRead: async (_messageIds: string[]) => { /* no-op */ },
+    sendDM: async (recipient: string, content: string) => ({
+      id: `msg-${Date.now()}`,
+      senderPubkey: '02abc123def456789012345678901234567890123456789012345678901234567890',
+      senderNametag: 'alice',
+      recipientPubkey: '03fedcba09876543210fedcba09876543210fedcba09876543210fedcba0987654321',
+      recipientNametag: recipient.replace('@', ''),
+      content,
+      timestamp: Date.now(),
+      isRead: false,
+    }),
+  },
+};


### PR DESCRIPTION
Example/docs half of the graceful wallet lock. Depends on **sphere-sdk PR #695** and pairs with **sphere PR #458**.

## Why this repo matters here

This is what third-party devs copy. Before this branch it taught the exact opposite of the feature: `useWalletConnect` destroyed the transport and cleared `sessionStorage` on `wallet:locked`, and four documents said a lock means "clear your session and reconnect".

## What changes

- **A lock is a state, not a disconnect**, in every transport mode. `wallet:locked` sets a flag; `wallet:disconnected` is the only teardown. A Connect **2.0** wallet still gets the old teardown — there the same event really did revoke the session, and `client.walletProtocol` tells them apart.
- **Failures are classified by `.code` and `data.reason`**, never by message text. The old rule was `/not.connected|timeout|transport|closed|session/i` — it disconnected on any error whose *text* mentioned a session and had no notion of `4009`.
- **`wallet:unlocked` is identity-checked.** An unlock is not implicitly the same wallet: the lock screen's "restore from recovery phrase" installs another seed. Same wallet → `unlockEpoch` bumps and read panels refetch. Different wallet → `walletChanged`, and nothing resumes.
- **Reads resume, intents never do.** An intent would move money with no fresh user gesture at the moment the wallet returned.
- **Seven connect paths collapse into one `handshake()`**, so `ConnectResult.locked` is honoured everywhere — previously a dApp connecting to an already-locked wallet believed it was live. A permanent `HOST_READY` listener re-handshakes after a wallet-page reload during a lock.
- **A headless `4009` test** drives the real `ConnectHost`/`ConnectClient` pair over an in-process loopback — the cross-repo canary, and the answer to "what does a bot do when nobody can type a password": it fails fast on a typed error. The mock wallet server gains `lock` / `unlock` / `logout` / `unavailable` / `status` stdin commands.

## Test infrastructure

There was **no vitest config anywhere**, so vitest silently fell back to `vite.config.ts` and ran under `node` — no component or hook test could exist. `nodejs` and `backend-auth/frontend` had no runner at all, and the only workflow built `browser/**` without running a single test. This branch adds jsdom + React Testing Library, runners for all packages, and a CI job.

## Verification

| package | tests | typecheck |
|---|---|---|
| browser | 48 | clean |
| nodejs | 18 | clean |
| backend-auth/frontend | 8 | clean |
| backend-auth/backend | 4 | — |
| bot | 25 | — |

Documentation grep gates pass: no `Full disconnect`, no `extension/iframe only`, no `resubscribeAll`, no `SPHERE_CONNECT_VERSION = '2.0'`.

## Not done here, on purpose

Packages point at `file:../../sphere-sdk`, and the docs say so rather than naming a version. **The published pin and the SDK version number are the owner's call.**


---

## Fixes added after this PR was opened

**The reference hook was polling into a locked wallet.** `isWalletLocked` reached only the header and the banner, so `ChatPanel` kept loading conversations and messages behind the lock screen and every read collected a 4009 — the wallet's badge climbed to "18 requests blocked" from one origin during testing. This hook is what third-party devs copy, so it was teaching exactly the wrong thing. It now stops fetching while locked and resumes on `unlockEpoch`.

**A failed attempt against a locked wallet heals itself.** The wallet defers `HOST_READY` until a host can actually complete a handshake, which for a locked wallet means "when a human unlocks it". The `HOST_READY` listener is therefore always armed, never gated on `isConnected` — gating it swallowed the announcement that follows an unlock, leaving the user pressing Connect at a wallet that was already ready. A retry against an already-open popup also no longer waits for `HOST_READY`: that window has booted and announced, so waiting hung for the full 30 s.

Deliberately **not** a remembered "host is ready" bit: readiness is not monotonic — a wallet can lock again with no wire signal at all, since `setLocked()` pushes `wallet:locked` only when a session is active — so a cached bit goes stale with nothing to clear it.

**A user-triggered request that hits 4009 raises the wallet window.** The distinction that makes this safe is not "automatic vs button" but **user-initiated vs background**: `navigator.userActivation.isActive` is sampled synchronously at the call site, before any await, which is the only moment the gesture is still live. A poller has no activation and can never steal focus. `focusWallet()` deliberately does **not** reopen a closed popup — closing it is a real disconnect (the wallet revokes the session on `beforeunload`) and a fresh window cold-starts locked anyway, so promising a restore would be a lie.

**`CONNECT.md` now says which transport to pick by session lifetime.** Popup for a short bounded flow — closing it disconnects, reloading it re-locks the wallet, it cold-starts locked even when Sphere is unlocked in another tab, and it does not scale to several dApps. Iframe for a long-lived session: one wallet window, many hosts, one unlock, and the badge in the wallet's own chrome.

**The lock paragraph was under-stated.** It named only the money reads, so it read as if DMs keep working. The allow-list is four of sixteen methods; the twelve refused include `sphere_resolve` and all four DM reads. It also documents the case the old wording gets wrong, and it is the common one: a wallet that cold-starts locked holds no session, so the handshake itself is refused with an errorless empty response — a generated `catch (err.code === WALLET_LOCKED)` catches nothing, because there is no code.

`58` tests across 9 files in `browser`, plus 18 / 8 / 4 / 25 in the other packages. Typecheck clean everywhere.
