### PR TITLE
chore(deps): bump @unicitylabs/sphere-sdk to 0.13.1

### DIFF
--- a/backend-auth/backend/package-lock.json
+++ b/backend-auth/backend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "sphere-connect-backend-auth-example",
       "version": "0.0.0",
       "dependencies": {
-        "@unicitylabs/sphere-sdk": "0.13.0",
+        "@unicitylabs/sphere-sdk": "0.13.1",
         "dotenv": "^17.4.2",
         "express": "^4.21.2",
         "jsonwebtoken": "^9.0.2",
@@ -1256,9 +1256,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.13.0.tgz",
-      "integrity": "sha512-uK7/xplYUNwsQ+tKJDDVClWXYxz9x7gKP8aVoSbJAbrGshG1XsG7D260AUDfIvG+pSONRfwX42ga3lW3TT/dmw==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.13.1.tgz",
+      "integrity": "sha512-i/cnbr9Puk30b7z/JANTYN8hhp5OmVCpmo/MA2dS0SwV9wtBasQYI3sLosRXaVMCEX2n269K1y3M+BccU1KBxA==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/backend-auth/backend/package.json
+++ b/backend-auth/backend/package.json
@@ -11,7 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@unicitylabs/sphere-sdk": "0.13.0",
+    "@unicitylabs/sphere-sdk": "0.13.1",
     "dotenv": "^17.4.2",
     "express": "^4.21.2",
     "jsonwebtoken": "^9.0.2",

--- a/backend-auth/frontend/package-lock.json
+++ b/backend-auth/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "sphere-connect-backend-auth-frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@unicitylabs/sphere-sdk": "0.13.0",
+        "@unicitylabs/sphere-sdk": "0.13.1",
         "react": "^19.1.1",
         "react-dom": "^19.2.4"
       },
@@ -1524,9 +1524,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.13.0.tgz",
-      "integrity": "sha512-uK7/xplYUNwsQ+tKJDDVClWXYxz9x7gKP8aVoSbJAbrGshG1XsG7D260AUDfIvG+pSONRfwX42ga3lW3TT/dmw==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.13.1.tgz",
+      "integrity": "sha512-i/cnbr9Puk30b7z/JANTYN8hhp5OmVCpmo/MA2dS0SwV9wtBasQYI3sLosRXaVMCEX2n269K1y3M+BccU1KBxA==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/backend-auth/frontend/package.json
+++ b/backend-auth/frontend/package.json
@@ -10,7 +10,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@unicitylabs/sphere-sdk": "0.13.0",
+    "@unicitylabs/sphere-sdk": "0.13.1",
     "react": "^19.1.1",
     "react-dom": "^19.2.4"
   },

--- a/bot/package-lock.json
+++ b/bot/package-lock.json
@@ -8,7 +8,7 @@
       "name": "sphere-connect-bot-example",
       "version": "0.0.0",
       "dependencies": {
-        "@unicitylabs/sphere-sdk": "0.13.0",
+        "@unicitylabs/sphere-sdk": "0.13.1",
         "dotenv": "^17.4.2",
         "ws": "^8.21.1"
       },
@@ -1137,9 +1137,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.13.0.tgz",
-      "integrity": "sha512-uK7/xplYUNwsQ+tKJDDVClWXYxz9x7gKP8aVoSbJAbrGshG1XsG7D260AUDfIvG+pSONRfwX42ga3lW3TT/dmw==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.13.1.tgz",
+      "integrity": "sha512-i/cnbr9Puk30b7z/JANTYN8hhp5OmVCpmo/MA2dS0SwV9wtBasQYI3sLosRXaVMCEX2n269K1y3M+BccU1KBxA==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/bot/package.json
+++ b/bot/package.json
@@ -11,7 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@unicitylabs/sphere-sdk": "0.13.0",
+    "@unicitylabs/sphere-sdk": "0.13.1",
     "dotenv": "^17.4.2",
     "ws": "^8.21.1"
   },

--- a/browser/package-lock.json
+++ b/browser/package-lock.json
@@ -14,7 +14,7 @@
         "@tailwindcss/vite": "^4.1.16",
         "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-table": "^8.21.3",
-        "@unicitylabs/sphere-sdk": "0.13.0",
+        "@unicitylabs/sphere-sdk": "0.13.1",
         "@unicitylabs/sphere-ui": "^0.1.34",
         "lucide-react": "^0.400.0",
         "react": "^19.1.1",
@@ -2286,9 +2286,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.13.0.tgz",
-      "integrity": "sha512-uK7/xplYUNwsQ+tKJDDVClWXYxz9x7gKP8aVoSbJAbrGshG1XsG7D260AUDfIvG+pSONRfwX42ga3lW3TT/dmw==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.13.1.tgz",
+      "integrity": "sha512-i/cnbr9Puk30b7z/JANTYN8hhp5OmVCpmo/MA2dS0SwV9wtBasQYI3sLosRXaVMCEX2n269K1y3M+BccU1KBxA==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/browser/package.json
+++ b/browser/package.json
@@ -17,7 +17,7 @@
     "@tailwindcss/vite": "^4.1.16",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-table": "^8.21.3",
-    "@unicitylabs/sphere-sdk": "0.13.0",
+    "@unicitylabs/sphere-sdk": "0.13.1",
     "@unicitylabs/sphere-ui": "^0.1.34",
     "lucide-react": "^0.400.0",
     "react": "^19.1.1",

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "sphere-connect-nodejs-example",
       "version": "0.0.0",
       "dependencies": {
-        "@unicitylabs/sphere-sdk": "0.13.0",
+        "@unicitylabs/sphere-sdk": "0.13.1",
         "ws": "^8.18.0"
       },
       "devDependencies": {
@@ -1133,9 +1133,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.13.0.tgz",
-      "integrity": "sha512-uK7/xplYUNwsQ+tKJDDVClWXYxz9x7gKP8aVoSbJAbrGshG1XsG7D260AUDfIvG+pSONRfwX42ga3lW3TT/dmw==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.13.1.tgz",
+      "integrity": "sha512-i/cnbr9Puk30b7z/JANTYN8hhp5OmVCpmo/MA2dS0SwV9wtBasQYI3sLosRXaVMCEX2n269K1y3M+BccU1KBxA==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -9,7 +9,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@unicitylabs/sphere-sdk": "0.13.0",
+    "@unicitylabs/sphere-sdk": "0.13.1",
     "ws": "^8.18.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Follow-up to #21, which merged before 0.13.1 was published.

All five packages (browser, nodejs, bot, backend-auth ×2) move together so the examples do not drift apart on SDK versions.

0.13.1 ships sphere-sdk#705 — the compatibility gate now names the versions it compared in `error.message`, and adds `data.requiredProtocol`. `describeConnectFailure` (merged in #21) already reads `requiredSdk` / `actualSdk`; `requiredProtocol` was the one branch with nothing to read on 0.13.0.

Verified on 0.13.1: `browser` 70/70, `tsc --noEmit` clean.
